### PR TITLE
Feature/jax messages

### DIFF
--- a/autofit/aggregator/summary/aggregate_csv/column.py
+++ b/autofit/aggregator/summary/aggregate_csv/column.py
@@ -64,20 +64,34 @@ class Column(AbstractColumn):
         result = {}
 
         if ValueType.Median in self.value_types:
-            result[""] = row.median_pdf_sample_kwargs[self.path]
+            try:
+                result[""] = row.median_pdf_sample_kwargs[self.path]
+            except KeyError:
+                result[""] = None
 
         if ValueType.MaxLogLikelihood in self.value_types:
-            result["max_lh"] = row.max_likelihood_kwargs[self.path]
+            try:
+                result["max_lh"] = row.max_likelihood_kwargs[self.path]
+            except KeyError:
+                result["max_lh"] = None
 
         if ValueType.ValuesAt1Sigma in self.value_types:
-            lower, upper = row.values_at_sigma_1_kwargs[self.path]
-            result["lower_1_sigma"] = lower
-            result["upper_1_sigma"] = upper
+            try:
+                lower, upper = row.values_at_sigma_1_kwargs[self.path]
+                result["lower_1_sigma"] = lower
+                result["upper_1_sigma"] = upper
+            except KeyError:
+                result["lower_1_sigma"] = None
+                result["upper_1_sigma"] = None
 
         if ValueType.ValuesAt3Sigma in self.value_types:
-            lower, upper = row.values_at_sigma_3_kwargs[self.path]
-            result["lower_3_sigma"] = lower
-            result["upper_3_sigma"] = upper
+            try:
+                lower, upper = row.values_at_sigma_3_kwargs[self.path]
+                result["lower_3_sigma"] = lower
+                result["upper_3_sigma"] = upper
+            except KeyError:
+                result["lower_3_sigma"] = None
+                result["upper_3_sigma"] = None
 
         return result
 

--- a/autofit/graphical/declarative/abstract.py
+++ b/autofit/graphical/declarative/abstract.py
@@ -20,7 +20,7 @@ class AbstractDeclarativeFactor(Analysis, ABC):
     _plates: Tuple[Plate, ...] = ()
 
     def __init__(self, include_prior_factors=False, use_jax : bool = False):
-        self.include_prior_factors = include_prior_factors
+        self._include_prior_factors = include_prior_factors
 
         super().__init__(use_jax=use_jax)
 
@@ -63,7 +63,7 @@ class AbstractDeclarativeFactor(Analysis, ABC):
             for prior in factor.prior_model.priors:
                 counter[prior] += 1
         return [
-            (prior, count + 1 if self.include_prior_factors else count)
+            (prior, count + 1 if self._include_prior_factors else count)
             for prior, count in counter.items()
         ]
 
@@ -96,7 +96,7 @@ class AbstractDeclarativeFactor(Analysis, ABC):
         The complete graph made by combining all factors and priors
         """
         factors = [model for model in self.model_factors]
-        if self.include_prior_factors:
+        if self._include_prior_factors:
             factors += self.prior_factors
         # noinspection PyTypeChecker
         return DeclarativeFactorGraph(factors)

--- a/autofit/graphical/declarative/collection.py
+++ b/autofit/graphical/declarative/collection.py
@@ -42,7 +42,7 @@ class FactorGraphModel(AbstractDeclarativeFactor):
     def tree_flatten(self):
         return (
             (self._model_factors,),
-            (self._name, self.include_prior_factors),
+            (self._name, self._include_prior_factors),
         )
 
     @classmethod

--- a/autofit/graphical/declarative/factor/abstract.py
+++ b/autofit/graphical/declarative/factor/abstract.py
@@ -42,7 +42,7 @@ class AbstractModelFactor(FactorKW, AbstractDeclarativeFactor, ABC):
             factor, **prior_variable_dict,
             name=name or namer(self.__class__.__name__),
         )
-        self.include_prior_factors = include_prior_factors
+        self._include_prior_factors = include_prior_factors
 
     @property
     def info(self) -> str:

--- a/autofit/graphical/declarative/factor/hierarchical.py
+++ b/autofit/graphical/declarative/factor/hierarchical.py
@@ -72,7 +72,7 @@ class HierarchicalFactor(Model):
         self._name = name or namer(self.__class__.__name__)
         self._factors = list()
         self.optimiser = optimiser
-        self.use_jax = use_jax
+        self._use_jax = use_jax
 
     @property
     def name(self):
@@ -147,7 +147,7 @@ class Factor:
 
 class _HierarchicalFactor(AbstractModelFactor):
     def __init__(
-        self, distribution_model: HierarchicalFactor, drawn_prior: Prior, use_jax : bool = False
+        self, distribution_model: HierarchicalFactor, drawn_prior: Prior,
     ):
         """
         A factor that links a variable to a parameterised distribution.
@@ -162,7 +162,7 @@ class _HierarchicalFactor(AbstractModelFactor):
         """
         self.distribution_model = distribution_model
         self.drawn_prior = drawn_prior
-        self.use_jax = distribution_model.use_jax
+        self._use_jax = distribution_model._use_jax
 
         prior_variable_dict = {prior.name: prior for prior in distribution_model.priors}
 

--- a/autofit/graphical/declarative/factor/hierarchical.py
+++ b/autofit/graphical/declarative/factor/hierarchical.py
@@ -8,6 +8,7 @@ from autofit.mapper.variable import Plate
 from autofit.messages import NormalMessage
 from autofit.non_linear.paths.abstract import AbstractPaths
 from autofit.tools.namer import namer
+
 from .abstract import AbstractModelFactor
 
 
@@ -19,6 +20,7 @@ class HierarchicalFactor(Model):
         distribution: Type[Prior],
         optimiser=None,
         name: Optional[str] = None,
+        use_jax : bool = False,
         **kwargs,
     ):
         """
@@ -70,6 +72,7 @@ class HierarchicalFactor(Model):
         self._name = name or namer(self.__class__.__name__)
         self._factors = list()
         self.optimiser = optimiser
+        self.use_jax = use_jax
 
     @property
     def name(self):
@@ -159,7 +162,7 @@ class _HierarchicalFactor(AbstractModelFactor):
         """
         self.distribution_model = distribution_model
         self.drawn_prior = drawn_prior
-        self.use_jax = use_jax
+        self.use_jax = distribution_model.use_jax
 
         prior_variable_dict = {prior.name: prior for prior in distribution_model.priors}
 
@@ -188,7 +191,7 @@ class _HierarchicalFactor(AbstractModelFactor):
         return self.drawn_prior
 
     def log_likelihood_function(self, instance):
-        return instance.distribution_model.message(instance.drawn_prior)
+        return instance.distribution_model.message(instance.drawn_prior, xp=self._xp)
 
     @property
     def priors(self) -> Set[Prior]:

--- a/autofit/mapper/prior/arithmetic/assertion.py
+++ b/autofit/mapper/prior/arithmetic/assertion.py
@@ -1,4 +1,5 @@
 from abc import ABC
+import numpy as np
 from typing import Optional, Dict
 
 from autofit.mapper.prior.arithmetic.compound import CompoundPrior, Compound

--- a/autofit/mapper/prior/arithmetic/assertion.py
+++ b/autofit/mapper/prior/arithmetic/assertion.py
@@ -24,7 +24,7 @@ class ComparisonAssertion(CompoundPrior, Compound, ABC):
 
 
 class GreaterThanLessThanAssertion(ComparisonAssertion):
-    def _instance_for_arguments(self, arguments, ignore_assertions=False):
+    def _instance_for_arguments(self, arguments, ignore_assertions=False, xp=np):
         """
         Assert that the value in the dictionary associated with the lower
         prior is lower than the value associated with the greater prior.
@@ -55,6 +55,7 @@ class GreaterThanLessThanEqualAssertion(ComparisonAssertion):
         self,
         arguments,
         ignore_assertions=False,
+        xp=np,
     ):
         """
         Assert that the value in the dictionary associated with the lower
@@ -90,6 +91,7 @@ class CompoundAssertion(AbstractPriorModel, Compound):
         self,
         arguments,
         ignore_assertions=False,
+        xp=np,
     ):
         return self.assertion_1.instance_for_arguments(
             arguments,

--- a/autofit/mapper/prior/arithmetic/compound.py
+++ b/autofit/mapper/prior/arithmetic/compound.py
@@ -212,6 +212,7 @@ class SumPrior(CompoundPrior):
         self,
         arguments,
         ignore_assertions=False,
+        xp=np,
     ):
         return self.left_for_arguments(
             arguments,
@@ -237,6 +238,7 @@ class MultiplePrior(CompoundPrior):
         self,
         arguments,
         ignore_assertions=False,
+        xp=np,
     ):
         return self.left_for_arguments(
             arguments,
@@ -256,6 +258,7 @@ class DivisionPrior(CompoundPrior):
         self,
         arguments,
         ignore_assertions=False,
+        xp=np,
     ):
         return self.left_for_arguments(
             arguments,
@@ -275,6 +278,7 @@ class FloorDivPrior(CompoundPrior):
         self,
         arguments,
         ignore_assertions=False,
+        xp=np,
     ):
         return self.left_for_arguments(
             arguments,
@@ -294,6 +298,7 @@ class ModPrior(CompoundPrior):
         self,
         arguments,
         ignore_assertions=False,
+        xp=np,
     ):
         return self.left_for_arguments(
             arguments,
@@ -313,6 +318,7 @@ class PowerPrior(CompoundPrior):
         self,
         arguments,
         ignore_assertions=False,
+        xp=np,
     ):
         return self.left_for_arguments(
             arguments,
@@ -396,6 +402,7 @@ class NegativePrior(ModifiedPrior):
         self,
         arguments,
         ignore_assertions=False,
+        xp=np,
     ):
         return -self.prior.instance_for_arguments(
             arguments,
@@ -412,6 +419,7 @@ class AbsolutePrior(ModifiedPrior):
         self,
         arguments,
         ignore_assertions=False,
+        xp=np,
     ):
         return abs(
             self.prior.instance_for_arguments(
@@ -430,6 +438,7 @@ class Log(ModifiedPrior):
         self,
         arguments,
         ignore_assertions=False,
+        xp=np,
     ):
         return np.log(
             self.prior.instance_for_arguments(
@@ -448,6 +457,7 @@ class Log10(ModifiedPrior):
         self,
         arguments,
         ignore_assertions=False,
+        xp=np,
     ):
         return np.log10(
             self.prior.instance_for_arguments(

--- a/autofit/mapper/prior/gaussian.py
+++ b/autofit/mapper/prior/gaussian.py
@@ -1,3 +1,4 @@
+import numpy as np
 from typing import Optional
 
 from autofit.messages.normal import NormalMessage
@@ -13,6 +14,7 @@ class GaussianPrior(Prior):
         mean: float,
         sigma: float,
         id_: Optional[int] = None,
+        _xp=np
     ):
         """
         A Gaussian prior defined by a normal distribution.
@@ -50,6 +52,7 @@ class GaussianPrior(Prior):
             message=NormalMessage(
                 mean=mean,
                 sigma=sigma,
+                xp=_xp
             ),
             id_=id_,
         )

--- a/autofit/mapper/prior/gaussian.py
+++ b/autofit/mapper/prior/gaussian.py
@@ -14,7 +14,6 @@ class GaussianPrior(Prior):
         mean: float,
         sigma: float,
         id_: Optional[int] = None,
-        _xp=np
     ):
         """
         A Gaussian prior defined by a normal distribution.
@@ -48,11 +47,11 @@ class GaussianPrior(Prior):
         >>> prior = GaussianPrior(mean=1.0, sigma=2.0)
         >>> physical_value = prior.value_for(unit=0.5)  # Returns ~1.0 (mean)
         """
+
         super().__init__(
             message=NormalMessage(
                 mean=mean,
                 sigma=sigma,
-                xp=_xp
             ),
             id_=id_,
         )

--- a/autofit/mapper/prior/log_gaussian.py
+++ b/autofit/mapper/prior/log_gaussian.py
@@ -133,7 +133,7 @@ class LogGaussianPrior(Prior):
     def parameter_string(self) -> str:
         return f"mean = {self.mean}, sigma = {self.sigma}"
 
-    def log_prior_from_value(self, value):
+    def log_prior_from_value(self, value, xp=np):
         if value <= 0:
             return float("-inf")
 

--- a/autofit/mapper/prior/log_uniform.py
+++ b/autofit/mapper/prior/log_uniform.py
@@ -110,7 +110,7 @@ class LogUniformPrior(Prior):
 
     __identifier_fields__ = ("lower_limit", "upper_limit")
 
-    def log_prior_from_value(self, value) -> float:
+    def log_prior_from_value(self, value, xp=np) -> float:
         """
         Returns the log prior of a physical value, so the log likelihood of a model evaluation can be converted to a
         posterior as log_prior + log_likelihood.

--- a/autofit/mapper/prior/uniform.py
+++ b/autofit/mapper/prior/uniform.py
@@ -1,3 +1,4 @@
+import numpy as np
 from typing import Optional, Tuple
 
 from autofit.messages.normal import UniformNormalMessage
@@ -128,7 +129,7 @@ class UniformPrior(Prior):
             round(super().value_for(unit), 14)
         )
 
-    def log_prior_from_value(self, value):
+    def log_prior_from_value(self, value, xp=np):
         """
         Returns the log prior of a physical value, so the log likelihood of a model evaluation can be converted to a
         posterior as log_prior + log_likelihood.

--- a/autofit/mapper/prior_model/abstract.py
+++ b/autofit/mapper/prior_model/abstract.py
@@ -1095,7 +1095,7 @@ class AbstractPriorModel(AbstractModel):
         return list(
             map(
                 lambda prior_tuple, value: prior_tuple.prior.log_prior_from_value(
-                    value=value, xp=np
+                    value=value, xp=xp
                 ),
                 self.prior_tuples_ordered_by_id,
                 vector,

--- a/autofit/mapper/prior_model/abstract.py
+++ b/autofit/mapper/prior_model/abstract.py
@@ -1078,6 +1078,7 @@ class AbstractPriorModel(AbstractModel):
     def log_prior_list_from_vector(
         self,
         vector: [float],
+        xp=np,
     ):
         """
         Compute the log priors of every parameter in a vector, using the Prior of every parameter.
@@ -1094,7 +1095,7 @@ class AbstractPriorModel(AbstractModel):
         return list(
             map(
                 lambda prior_tuple, value: prior_tuple.prior.log_prior_from_value(
-                    value=value
+                    value=value, xp=np
                 ),
                 self.prior_tuples_ordered_by_id,
                 vector,

--- a/autofit/mapper/prior_model/abstract.py
+++ b/autofit/mapper/prior_model/abstract.py
@@ -745,7 +745,7 @@ class AbstractPriorModel(AbstractModel):
         """
         return self.vector_from_unit_vector([0.5] * len(self.unique_prior_tuples))
 
-    def instance_from_vector(self, vector, ignore_assertions: bool = False):
+    def instance_from_vector(self, vector, ignore_assertions: bool = False, xp=np):
         """
         Returns a ModelInstance, which has an attribute and class instance corresponding
         to every `Model` attributed to this instance.
@@ -778,6 +778,7 @@ class AbstractPriorModel(AbstractModel):
         return self.instance_for_arguments(
             arguments,
             ignore_assertions=ignore_assertions,
+            xp=xp
         )
 
     def has(self, cls: Union[Type, Tuple[Type, ...]]) -> bool:
@@ -1309,6 +1310,7 @@ class AbstractPriorModel(AbstractModel):
         self,
         arguments: Dict[Prior, float],
         ignore_assertions: bool = False,
+        xp=np,
     ):
         raise NotImplementedError()
 
@@ -1316,6 +1318,7 @@ class AbstractPriorModel(AbstractModel):
         self,
         arguments: Dict[Prior, float],
         ignore_assertions: bool = False,
+        xp=np,
     ):
         """
         Returns an instance of the model for a set of arguments
@@ -1339,6 +1342,7 @@ class AbstractPriorModel(AbstractModel):
         return self._instance_for_arguments(
             arguments,
             ignore_assertions=ignore_assertions,
+            xpx=p
         )
 
     def path_for_name(self, name: str) -> Tuple[str, ...]:

--- a/autofit/mapper/prior_model/abstract.py
+++ b/autofit/mapper/prior_model/abstract.py
@@ -1342,7 +1342,7 @@ class AbstractPriorModel(AbstractModel):
         return self._instance_for_arguments(
             arguments,
             ignore_assertions=ignore_assertions,
-            xpx=p
+            xp=xp
         )
 
     def path_for_name(self, name: str) -> Tuple[str, ...]:

--- a/autofit/mapper/prior_model/array.py
+++ b/autofit/mapper/prior_model/array.py
@@ -57,6 +57,7 @@ class Array(AbstractPriorModel):
         self,
         arguments: Dict[Prior, float],
         ignore_assertions: bool = False,
+        xp=np,
     ) -> np.ndarray:
         """
         Create an array where the prior at each index is replaced with the

--- a/autofit/mapper/prior_model/collection.py
+++ b/autofit/mapper/prior_model/collection.py
@@ -208,6 +208,7 @@ class Collection(AbstractPriorModel):
         self,
         arguments,
         ignore_assertions=False,
+        xp=np,
     ):
         """
         Parameters

--- a/autofit/mapper/prior_model/collection.py
+++ b/autofit/mapper/prior_model/collection.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from collections.abc import Iterable
 
 from autofit.mapper.model import ModelInstance, assert_not_frozen
@@ -229,6 +231,7 @@ class Collection(AbstractPriorModel):
                 value = value.instance_for_arguments(
                     arguments,
                     ignore_assertions=ignore_assertions,
+                    xp=xp
                 )
             elif isinstance(value, Prior):
                 value = arguments[value]

--- a/autofit/mapper/prior_model/prior_model.py
+++ b/autofit/mapper/prior_model/prior_model.py
@@ -459,6 +459,7 @@ class Model(AbstractPriorModel):
         self,
         arguments: {ModelObject: object},
         ignore_assertions=False,
+        xp=np,
     ):
         """
         Returns an instance of the associated class for a set of arguments

--- a/autofit/mapper/prior_model/prior_model.py
+++ b/autofit/mapper/prior_model/prior_model.py
@@ -2,6 +2,7 @@ import collections.abc
 import copy
 import inspect
 import logging
+import numpy as np
 import typing
 from typing import *
 
@@ -420,36 +421,6 @@ class Model(AbstractPriorModel):
 
         self.__getattribute__(item)
 
-    # def __getattr__(self, item):
-    #
-    #     try:
-    #         if (
-    #             "_" in item
-    #             and item not in ("_is_frozen", "tuple_prior_tuples")
-    #             and not item.startswith("_")
-    #         ):
-    #             return getattr(
-    #                 [v for k, v in self.tuple_prior_tuples if item.split("_")[0] == k][
-    #                     0
-    #                 ],
-    #                 item,
-    #             )
-    #
-    #     except IndexError:
-    #         pass
-    #
-    #     try:
-    #         return getattr(
-    #             self.instance_for_arguments(
-    #                 {prior: prior for prior in self.priors},
-    #             ),
-    #             item,
-    #         )
-    #     except (AttributeError, TypeError):
-    #         pass
-    #
-    #     self.__getattribute__(item)
-
     @property
     def is_deferred_arguments(self):
         return len(self.direct_deferred_tuples) > 0
@@ -491,6 +462,7 @@ class Model(AbstractPriorModel):
             ] = prior_model.instance_for_arguments(
                 arguments,
                 ignore_assertions=ignore_assertions,
+                xp=xp
             )
 
         prior_arguments = dict()
@@ -533,6 +505,7 @@ class Model(AbstractPriorModel):
                     value = value.instance_for_arguments(
                         arguments,
                         ignore_assertions=ignore_assertions,
+                        xp=xp
                     )
                 elif isinstance(value, Constant):
                     value = value.value

--- a/autofit/messages/abstract.py
+++ b/autofit/messages/abstract.py
@@ -62,7 +62,7 @@ class AbstractMessage(MessageInterface, ABC):
             self._broadcast = _xp.broadcast_arrays(*parameters)
 
         if self.shape:
-            self.parameters = tuple(xp.aarray(p) for p in parameters)
+            self.parameters = tuple(xp.asarray(p) for p in parameters)
         else:
             self.parameters = tuple(parameters)
 

--- a/autofit/messages/abstract.py
+++ b/autofit/messages/abstract.py
@@ -45,17 +45,24 @@ class AbstractMessage(MessageInterface, ABC):
         lower_limit=-math.inf,
         upper_limit=math.inf,
         id_=None,
+        _xp=np
     ):
+
+        xp=_xp
 
         self.lower_limit = float(lower_limit)
         self.upper_limit = float(upper_limit)
 
         self.id = next(self.ids) if id_ is None else id_
         self.log_norm = log_norm
-        self._broadcast = np.broadcast(*parameters)
+
+        if xp is np:
+            self._broadcast = np.broadcast(*parameters)
+        else:
+            self._broadcast = _xp.broadcast_arrays(*parameters)
 
         if self.shape:
-            self.parameters = tuple(np.asanyarray(p) for p in parameters)
+            self.parameters = tuple(xp.aarray(p) for p in parameters)
         else:
             self.parameters = tuple(parameters)
 

--- a/autofit/messages/abstract.py
+++ b/autofit/messages/abstract.py
@@ -366,8 +366,8 @@ class AbstractMessage(MessageInterface, ABC):
             )
         return mean, variance
 
-    def __call__(self, x):
-        return np.sum(self.logpdf(x))
+    def __call__(self, x, xp=np):
+        return xp.sum(self.logpdf(x, xp=xp))
 
     def factor_jacobian(
         self, x: np.ndarray, _variables: Optional[Tuple[str]] = ("x",)

--- a/autofit/messages/abstract.py
+++ b/autofit/messages/abstract.py
@@ -56,6 +56,7 @@ class AbstractMessage(MessageInterface, ABC):
         self.id = next(self.ids) if id_ is None else id_
         self.log_norm = log_norm
 
+
         if xp is np:
             self._broadcast = np.broadcast(*parameters)
         else:
@@ -222,7 +223,7 @@ class AbstractMessage(MessageInterface, ABC):
             )
 
     def __pow__(self, other: Real) -> "AbstractMessage":
-        natural = self.natural_parameters
+        natural = self.natural_parameters()
         new_params = other * natural
         log_norm = other * self.log_norm
         new = self.from_natural_parameters(
@@ -313,12 +314,12 @@ class AbstractMessage(MessageInterface, ABC):
         ]
 
         # Calculate log product of message normalisation
-        log_norm = self.log_base_measure - self.log_partition
-        log_norm += sum(dist.log_base_measure - dist.log_partition for dist in dists)
+        log_norm = self.log_base_measure - self.log_partition()
+        log_norm += sum(dist.log_base_measure - dist.log_partition() for dist in dists)
 
         # Calculate log normalisation of product of messages
         prod_dist = self.sum_natural_parameters(*dists)
-        log_norm -= prod_dist.log_base_measure - prod_dist.log_partition
+        log_norm -= prod_dist.log_base_measure - prod_dist.log_partition()
 
         return log_norm
 

--- a/autofit/messages/beta.py
+++ b/autofit/messages/beta.py
@@ -201,7 +201,8 @@ class BetaMessage(AbstractMessage):
     @staticmethod
     def calc_natural_parameters(
             alpha: Union[float, np.ndarray],
-            beta: Union[float, np.ndarray]
+            beta: Union[float, np.ndarray],
+            xp=np
     ) -> np.ndarray:
         """
         Calculate the natural parameters of a Beta distribution from alpha and beta.
@@ -217,7 +218,7 @@ class BetaMessage(AbstractMessage):
         -------
         Natural parameters [alpha - 1, beta - 1].
         """
-        return np.array([alpha - 1, beta - 1])
+        return xp.array([alpha - 1, beta - 1])
 
     @staticmethod
     def invert_natural_parameters(

--- a/autofit/messages/beta.py
+++ b/autofit/messages/beta.py
@@ -171,8 +171,7 @@ class BetaMessage(AbstractMessage):
         """
         raise NotImplemented()
 
-    @cached_property
-    def log_partition(self) -> np.ndarray:
+    def log_partition(self, xp=np) -> np.ndarray:
         """
         Compute the log partition function (log normalization constant) of the Beta distribution.
 

--- a/autofit/messages/beta.py
+++ b/autofit/messages/beta.py
@@ -184,8 +184,7 @@ class BetaMessage(AbstractMessage):
 
         return betaln(*self.parameters)
 
-    @cached_property
-    def natural_parameters(self) -> np.ndarray:
+    def natural_parameters(self, xp=np) -> np.ndarray:
         """
         Compute the natural parameters of the Beta distribution.
 
@@ -196,7 +195,8 @@ class BetaMessage(AbstractMessage):
         """
         return self.calc_natural_parameters(
             self.alpha,
-            self.beta
+            self.beta,
+            xp=xp
         )
 
     @staticmethod
@@ -258,7 +258,7 @@ class BetaMessage(AbstractMessage):
         return cls.calc_natural_parameters(a, b)
 
     @classmethod
-    def to_canonical_form(cls, x: np.ndarray) -> np.ndarray:
+    def to_canonical_form(cls, x: np.ndarray, xp=np) -> np.ndarray:
         """
         Convert a value x in (0,1) to the canonical sufficient statistics for Beta.
 
@@ -271,7 +271,7 @@ class BetaMessage(AbstractMessage):
         -------
         Canonical sufficient statistics [log(x), log(1 - x)].
         """
-        return np.array([np.log(x), np.log1p(-x)])
+        return xp.array([xp.log(x), xp.log1p(-x)])
 
     @cached_property
     def mean(self) -> Union[np.ndarray, float]:

--- a/autofit/messages/composed_transform.py
+++ b/autofit/messages/composed_transform.py
@@ -158,7 +158,7 @@ class TransformedMessage(MessageInterface):
         return self.base_message.kl(dist.base_message)
 
     def natural_parameters(self, xp=np) -> np.ndarray:
-        return self.base_message.natural_parameters
+        return self.base_message.natural_parameters(xp=xp)
 
     @inverse_transform
     def sample(self, n_samples: Optional[int] = None):
@@ -229,7 +229,7 @@ class TransformedMessage(MessageInterface):
         return self.base_message.cdf(x)
 
     def log_partition(self, xp=np) -> np.ndarray:
-        return self.base_message.log_partition
+        return self.base_message.log_partition(xp=xp)
 
     def invert_sufficient_statistics(self, sufficient_statistics):
         return self.base_message.invert_sufficient_statistics(sufficient_statistics)

--- a/autofit/messages/composed_transform.py
+++ b/autofit/messages/composed_transform.py
@@ -34,7 +34,7 @@ def transform(func):
     """
 
     @functools.wraps(func)
-    def wrapper(self, x, xp):
+    def wrapper(self, x, xp=np):
         x = self._transform(x)
         return func(self, x, xp)
 
@@ -225,8 +225,8 @@ class TransformedMessage(MessageInterface):
         return self.base_message.invert_natural_parameters(natural_parameters)
 
     @transform
-    def cdf(self, x):
-        return self.base_message.cdf(x)
+    def cdf(self, x, xp=np):
+        return self.base_message.cdf(x, xp=xp)
 
     def log_partition(self, xp=np) -> np.ndarray:
         return self.base_message.log_partition(xp=xp)

--- a/autofit/messages/composed_transform.py
+++ b/autofit/messages/composed_transform.py
@@ -34,9 +34,9 @@ def transform(func):
     """
 
     @functools.wraps(func)
-    def wrapper(self, x):
+    def wrapper(self, x, xp):
         x = self._transform(x)
-        return func(self, x)
+        return func(self, x, xp)
 
     return wrapper
 
@@ -239,8 +239,8 @@ class TransformedMessage(MessageInterface):
         return self.base_message.value_for(unit)
 
     @transform
-    def calc_log_base_measure(self, x) -> np.ndarray:
-        return self.base_message.calc_log_base_measure(x)
+    def calc_log_base_measure(self, x, xp=np) -> np.ndarray:
+        return self.base_message.calc_log_base_measure(x, xp=xp)
 
     @transform
     def to_canonical_form(self, x, xp=np) -> np.ndarray:

--- a/autofit/messages/composed_transform.py
+++ b/autofit/messages/composed_transform.py
@@ -228,8 +228,7 @@ class TransformedMessage(MessageInterface):
     def cdf(self, x):
         return self.base_message.cdf(x)
 
-    @property
-    def log_partition(self) -> np.ndarray:
+    def log_partition(self, xp=np) -> np.ndarray:
         return self.base_message.log_partition
 
     def invert_sufficient_statistics(self, sufficient_statistics):

--- a/autofit/messages/composed_transform.py
+++ b/autofit/messages/composed_transform.py
@@ -157,8 +157,7 @@ class TransformedMessage(MessageInterface):
     def kl(self, dist):
         return self.base_message.kl(dist.base_message)
 
-    @property
-    def natural_parameters(self):
+    def natural_parameters(self, xp=np) -> np.ndarray:
         return self.base_message.natural_parameters
 
     @inverse_transform
@@ -245,8 +244,8 @@ class TransformedMessage(MessageInterface):
         return self.base_message.calc_log_base_measure(x)
 
     @transform
-    def to_canonical_form(self, x) -> np.ndarray:
-        return self.base_message.to_canonical_form(x)
+    def to_canonical_form(self, x, xp=np) -> np.ndarray:
+        return self.base_message.to_canonical_form(x, xp=xp)
 
     @property
     @inverse_transform

--- a/autofit/messages/fixed.py
+++ b/autofit/messages/fixed.py
@@ -25,8 +25,7 @@ class FixedMessage(AbstractMessage):
     def value_for(self, unit: float) -> float:
         raise NotImplemented()
 
-    @cached_property
-    def natural_parameters(self) -> Tuple[np.ndarray, ...]:
+    def natural_parameters(self, xp=np) -> Tuple[np.ndarray, ...]:
         return self.parameters
 
     @staticmethod
@@ -35,7 +34,7 @@ class FixedMessage(AbstractMessage):
         return natural_parameters,
 
     @staticmethod
-    def to_canonical_form(x: np.ndarray) -> np.ndarray:
+    def to_canonical_form(x: np.ndarray, xp=np) -> np.ndarray:
         return x
 
     @cached_property

--- a/autofit/messages/fixed.py
+++ b/autofit/messages/fixed.py
@@ -37,8 +37,7 @@ class FixedMessage(AbstractMessage):
     def to_canonical_form(x: np.ndarray, xp=np) -> np.ndarray:
         return x
 
-    @cached_property
-    def log_partition(self) -> np.ndarray:
+    def log_partition(self, xp=np) -> np.ndarray:
         return 0.
 
     @classmethod

--- a/autofit/messages/gamma.py
+++ b/autofit/messages/gamma.py
@@ -36,9 +36,8 @@ class GammaMessage(AbstractMessage):
     def value_for(self, unit: float) -> float:
         raise NotImplemented()
 
-    @cached_property
-    def natural_parameters(self):
-        return self.calc_natural_parameters(self.alpha, self.beta)
+    def natural_parameters(self, xp=np) -> np.ndarray:
+        return self.calc_natural_parameters(self.alpha, self.beta, xp=xp)
 
     @staticmethod
     def calc_natural_parameters(alpha, beta):
@@ -50,8 +49,8 @@ class GammaMessage(AbstractMessage):
         return eta1 + 1, -eta2
 
     @staticmethod
-    def to_canonical_form(x):
-        return np.array([np.log(x), x])
+    def to_canonical_form(x, xp=np):
+        return xp.array([np.log(x), x])
 
     @classmethod
     def invert_sufficient_statistics(cls, suff_stats):

--- a/autofit/messages/gamma.py
+++ b/autofit/messages/gamma.py
@@ -6,11 +6,11 @@ from autofit.messages.utils import invpsilog
 
 
 class GammaMessage(AbstractMessage):
-    @property
-    def log_partition(self):
+
+    def log_partition(self, xp=np):
         from scipy import special
 
-        alpha, beta = GammaMessage.invert_natural_parameters(self.natural_parameters)
+        alpha, beta = GammaMessage.invert_natural_parameters(self.natural_parameters(xp=xp))
         return special.gammaln(alpha) - alpha * np.log(beta)
 
     log_base_measure = 0.0

--- a/autofit/messages/gamma.py
+++ b/autofit/messages/gamma.py
@@ -40,8 +40,8 @@ class GammaMessage(AbstractMessage):
         return self.calc_natural_parameters(self.alpha, self.beta, xp=xp)
 
     @staticmethod
-    def calc_natural_parameters(alpha, beta):
-        return np.array([alpha - 1, -beta])
+    def calc_natural_parameters(alpha, beta, xp=np):
+        return xp.array([alpha - 1, -beta])
 
     @staticmethod
     def invert_natural_parameters(natural_parameters):
@@ -97,13 +97,13 @@ class GammaMessage(AbstractMessage):
 
     def logpdf_gradient(self, x):
         logl = self.logpdf(x)
-        eta1 = self.natural_parameters[0]
+        eta1 = self.natural_parameters()[0]
         gradl = eta1 / x - self.beta
         return logl, gradl
 
     def logpdf_gradient_hessian(self, x):
         logl = self.logpdf(x)
-        eta1 = self.natural_parameters[0]
+        eta1 = self.natural_parameters()[0]
         gradl = eta1 / x
         hessl = -gradl / x
         gradl -= self.beta

--- a/autofit/messages/interface.py
+++ b/autofit/messages/interface.py
@@ -83,19 +83,8 @@ class MessageInterface(ABC):
 
     @classmethod
     def natural_logpdf(cls, eta, t, log_base, log_partition, xp=np):
-
-        try:
-            eta = eta()
-        except TypeError:
-            pass
-
-        try:
-            log_partition_in = log_partition(xp=xp)
-        except TypeError:
-            log_partition_in = log_partition
-
         eta_t = xp.multiply(eta, t).sum(0)
-        return xp.nan_to_num(log_base + eta_t - log_partition_in, nan=-xp.inf)
+        return xp.nan_to_num(log_base + eta_t - log_partition, nan=-xp.inf)
 
     def numerical_logpdf_gradient(
         self, x: np.ndarray, eps: float = 1e-6

--- a/autofit/messages/interface.py
+++ b/autofit/messages/interface.py
@@ -48,7 +48,7 @@ class MessageInterface(ABC):
         eta = self._broadcast_natural_parameters(x, xp=xp)
         t = self.to_canonical_form(x, xp=xp)
         log_base = self.calc_log_base_measure(x)
-        return self.natural_logpdf(eta, t, log_base, self.log_partition)
+        return self.natural_logpdf(eta, t, log_base, self.log_partition(xp=xp), xp=xp)
 
     def _broadcast_natural_parameters(self, x, xp=np):
         shape = xp.shape(x)
@@ -75,15 +75,14 @@ class MessageInterface(ABC):
     def calc_log_base_measure(cls, x):
         return cls.log_base_measure
 
-    @cached_property
     @abstractmethod
-    def log_partition(self) -> np.ndarray:
+    def log_partition(self, xp=np) -> np.ndarray:
         pass
 
     @classmethod
-    def natural_logpdf(cls, eta, t, log_base, log_partition):
-        eta_t = np.multiply(eta, t).sum(0)
-        return np.nan_to_num(log_base + eta_t - log_partition, nan=-np.inf)
+    def natural_logpdf(cls, eta, t, log_base, log_partition, xp=np):
+        eta_t = xp.multiply(eta, t).sum(0)
+        return xp.nan_to_num(log_base + eta_t - log_partition, nan=-xp.inf)
 
     def numerical_logpdf_gradient(
         self, x: np.ndarray, eps: float = 1e-6

--- a/autofit/messages/interface.py
+++ b/autofit/messages/interface.py
@@ -44,32 +44,31 @@ class MessageInterface(ABC):
     def pdf(self, x: np.ndarray) -> np.ndarray:
         return np.exp(self.logpdf(x))
 
-    def logpdf(self, x: Union[np.ndarray, float]) -> np.ndarray:
-        eta = self._broadcast_natural_parameters(x)
-        t = self.to_canonical_form(x)
+    def logpdf(self, x: Union[np.ndarray, float], xp=np) -> np.ndarray:
+        eta = self._broadcast_natural_parameters(x, xp=xp)
+        t = self.to_canonical_form(x, xp=xp)
         log_base = self.calc_log_base_measure(x)
         return self.natural_logpdf(eta, t, log_base, self.log_partition)
 
-    def _broadcast_natural_parameters(self, x):
-        shape = np.shape(x)
+    def _broadcast_natural_parameters(self, x, xp=np):
+        shape = xp.shape(x)
         if shape == self.shape:
-            return self.natural_parameters
+            return self.natural_parameters(xp=xp)
         elif shape[1:] == self.shape:
-            return self.natural_parameters[:, None, ...]
+            return self.natural_parameters(xp=xp)[:, None, ...]
         else:
             raise ValueError(
                 f"shape of passed value {shape} does not "
                 f"match message shape {self.shape}"
             )
 
-    @cached_property
     @abstractmethod
-    def natural_parameters(self):
+    def natural_parameters(self, xp=np) -> np.ndarray:
         pass
 
     @staticmethod
     @abstractmethod
-    def to_canonical_form(x: Union[np.ndarray, float]) -> np.ndarray:
+    def to_canonical_form(x: Union[np.ndarray, float], xp=np) -> np.ndarray:
         pass
 
     @classmethod

--- a/autofit/messages/interface.py
+++ b/autofit/messages/interface.py
@@ -23,6 +23,11 @@ class MessageInterface(ABC):
 
     @property
     def shape(self) -> Tuple[int, ...]:
+
+        # JAX behaviour
+        if isinstance(self.broadcast, list):
+            return ()
+
         return self.broadcast.shape
 
     @property

--- a/autofit/messages/normal.py
+++ b/autofit/messages/normal.py
@@ -93,7 +93,8 @@ class NormalMessage(AbstractMessage):
         id_
             An optional unique identifier used to track the message in larger probabilistic graphs or models.
         """
-        if isinstance(mean, (np.ndarray, float, int)):
+
+        if isinstance(mean, (np.ndarray, float, int, list)):
             xp = np
         else:
             import jax.numpy as jnp
@@ -470,7 +471,7 @@ class NormalMessage(AbstractMessage):
         A natural form Gaussian with zeroed parameters but same configuration.
         """
         return NaturalNormal.from_natural_parameters(
-            self.natural_parameters * 0.0, **self._init_kwargs
+            self.natural_parameters() * 0.0, **self._init_kwargs
         )
 
     def zeros_like(self) -> "AbstractMessage":
@@ -556,7 +557,7 @@ class NaturalNormal(NormalMessage):
         return np.nan_to_num(-self.parameters[0] / self.parameters[1] / 2)
 
     @staticmethod
-    def calc_natural_parameters(eta1: float, eta2: float) -> np.ndarray:
+    def calc_natural_parameters(eta1: float, eta2: float, xp=np) -> np.ndarray:
         """
         Return the natural parameters in array form (identity function for this class).
 
@@ -567,7 +568,7 @@ class NaturalNormal(NormalMessage):
         eta2
             The second natural parameter.
         """
-        return np.array([eta1, eta2])
+        return xp.array([eta1, eta2])
 
     def natural_parameters(self, xp=np) -> np.ndarray:
         """

--- a/autofit/messages/normal.py
+++ b/autofit/messages/normal.py
@@ -148,8 +148,7 @@ class NormalMessage(AbstractMessage):
 
         return norm.ppf(x, loc=self.mean, scale=self.sigma)
 
-    @cached_property
-    def natural_parameters(self) -> np.ndarray:
+    def natural_parameters(self, xp=np) -> np.ndarray:
         """
         The natural (canonical) parameters of the Gaussian distribution in exponential-family form.
 
@@ -162,10 +161,10 @@ class NormalMessage(AbstractMessage):
         -------
         A NumPy array containing the two natural parameters [η₁, η₂].
         """
-        return self.calc_natural_parameters(self.mean, self.sigma)
+        return self.calc_natural_parameters(self.mean, self.sigma, xp=xp)
 
     @staticmethod
-    def calc_natural_parameters(mu : Union[float, np.ndarray], sigma : Union[float, np.ndarray]) -> np.ndarray:
+    def calc_natural_parameters(mu : Union[float, np.ndarray], sigma : Union[float, np.ndarray], xp=np) -> np.ndarray:
         """
         Convert standard parameters of a Gaussian distribution (mean and standard deviation)
         into natural parameters used in its exponential family representation.
@@ -184,7 +183,7 @@ class NormalMessage(AbstractMessage):
             η₂ = -1 / (2σ²)
         """
         precision = 1 / sigma**2
-        return np.array([mu * precision, -precision / 2])
+        return xp.array([mu * precision, -precision / 2])
 
     @staticmethod
     def invert_natural_parameters(natural_parameters : np.ndarray) -> Tuple[float, float]:
@@ -207,7 +206,7 @@ class NormalMessage(AbstractMessage):
         return mu, sigma
 
     @staticmethod
-    def to_canonical_form(x : Union[float, np.ndarray]) -> np.ndarray:
+    def to_canonical_form(x : Union[float, np.ndarray], xp=np) -> np.ndarray:
         """
         Convert a scalar input `x` to its sufficient statistics for the Gaussian exponential family.
 
@@ -223,7 +222,7 @@ class NormalMessage(AbstractMessage):
         -------
         The sufficient statistics [x, x²].
         """
-        return np.array([x, x**2])
+        return xp.array([x, x**2])
 
     @classmethod
     def invert_sufficient_statistics(cls, suff_stats: Tuple[float, float]) -> np.ndarray:
@@ -570,12 +569,11 @@ class NaturalNormal(NormalMessage):
         """
         return np.array([eta1, eta2])
 
-    @cached_property
-    def natural_parameters(self) -> np.ndarray:
+    def natural_parameters(self, xp=np) -> np.ndarray:
         """
         Return the natural parameters of this distribution.
         """
-        return self.calc_natural_parameters(*self.parameters)
+        return self.calc_natural_parameters(*self.parameters, xp=xp)
 
     @classmethod
     def invert_sufficient_statistics(cls, suff_stats: Tuple[float, float]) -> np.ndarray:

--- a/autofit/messages/normal.py
+++ b/autofit/messages/normal.py
@@ -401,7 +401,7 @@ class NormalMessage(AbstractMessage):
 
         return self.mean + (self.sigma * np.sqrt(2) * inv)
 
-    def log_prior_from_value(self, value: float) -> float:
+    def log_prior_from_value(self, value: float, xp=np) -> float:
         """
         Compute the log prior probability of a given physical value under this Gaussian prior.
 

--- a/autofit/messages/normal.py
+++ b/autofit/messages/normal.py
@@ -24,6 +24,7 @@ def is_nan(value):
     return is_nan_
 
 def assert_sigma_non_negative(sigma, xp=np):
+
     sigma_arr = xp.asarray(sigma)
     is_negative = xp.any(sigma_arr < 0)
 
@@ -65,7 +66,6 @@ class NormalMessage(AbstractMessage):
         sigma : Union[float, np.ndarray],
         log_norm : Optional[float] = 0.0,
         id_ : Optional[Hashable] = None,
-        xp=np
     ):
         """
         A Gaussian (Normal) message representing a probability distribution over a continuous variable.
@@ -87,6 +87,20 @@ class NormalMessage(AbstractMessage):
         id_
             An optional unique identifier used to track the message in larger probabilistic graphs or models.
         """
+        if isinstance(mean, (np.ndarray, float, int)):
+            xp = np
+        else:
+            import jax.numpy as jnp
+            xp = jnp
+
+
+        print(type(mean))
+        print(type(mean))
+        print(xp)
+        print(xp)
+        print(xp)
+        print(xp)
+
         assert_sigma_non_negative(sigma, xp=xp)
 
         super().__init__(

--- a/autofit/messages/normal.py
+++ b/autofit/messages/normal.py
@@ -111,7 +111,7 @@ class NormalMessage(AbstractMessage):
         )
         self.mean, self.sigma = self.parameters
 
-    def cdf(self, x : Union[float, np.ndarray]) -> Union[float, np.ndarray]:
+    def cdf(self, x : Union[float, np.ndarray], xp=np) -> Union[float, np.ndarray]:
         """
         Compute the cumulative distribution function (CDF) of the Gaussian distribution
         at a given value or array of values `x`.

--- a/autofit/messages/normal.py
+++ b/autofit/messages/normal.py
@@ -45,8 +45,8 @@ def assert_sigma_non_negative(sigma, xp=np):
             raise ValueError("Sigma cannot be negative")
 
 class NormalMessage(AbstractMessage):
-    @cached_property
-    def log_partition(self):
+
+    def log_partition(self, xp=np):
         """
         Compute the log-partition function (also called log-normalizer or cumulant function)
         for the normal distribution in its natural (canonical) parameterization.
@@ -59,8 +59,8 @@ class NormalMessage(AbstractMessage):
            A(η) = η₁² / (-4η₂) - 0.5 * log(-2η₂)
         This ensures normalization of the exponential-family distribution.
         """
-        eta1, eta2 = self.natural_parameters
-        return -(eta1**2) / 4 / eta2 - np.log(-2 * eta2) / 2
+        eta1, eta2 = self.natural_parameters(xp=xp)
+        return -(eta1**2) / 4 / eta2 - xp.log(-2 * eta2) / 2
 
     log_base_measure = -0.5 * np.log(2 * np.pi)
     _support = ((-np.inf, np.inf),)

--- a/autofit/messages/truncated_normal.py
+++ b/autofit/messages/truncated_normal.py
@@ -161,7 +161,7 @@ class TruncatedNormalMessage(AbstractMessage):
         return self.calc_natural_parameters(self.mean, self.sigma, xp=xp)
 
     @staticmethod
-    def calc_natural_parameters(mu : Union[float, np.ndarray], sigma : Union[float, np.ndarray]) -> np.ndarray:
+    def calc_natural_parameters(mu : Union[float, np.ndarray], sigma : Union[float, np.ndarray], xp=np) -> np.ndarray:
         """
         Convert standard parameters of a Gaussian distribution (mean and standard deviation)
         into natural parameters used in its exponential family representation.
@@ -189,7 +189,7 @@ class TruncatedNormalMessage(AbstractMessage):
             η₂ = -1 / (2σ²)
         """
         precision = 1 / sigma**2
-        return np.array([mu * precision, -precision / 2])
+        return xp.array([mu * precision, -precision / 2])
 
     @staticmethod
     def invert_natural_parameters(natural_parameters : np.ndarray) -> Tuple[float, float]:
@@ -493,7 +493,7 @@ class TruncatedNormalMessage(AbstractMessage):
         A natural form Gaussian with zeroed parameters but same configuration.
         """
         return TruncatedNaturalNormal.from_natural_parameters(
-            self.natural_parameters * 0.0, **self._init_kwargs
+            self.natural_parameters() * 0.0, **self._init_kwargs
         )
 
     def zeros_like(self) -> "AbstractMessage":
@@ -617,10 +617,11 @@ class TruncatedNaturalNormal(TruncatedNormalMessage):
 
     @staticmethod
     def calc_natural_parameters(
-            eta1: float,
-            eta2: float,
-            lower_limit: float = -np.inf,
-            upper_limit: float = np.inf
+        eta1: float,
+        eta2: float,
+        lower_limit: float = -np.inf,
+        upper_limit: float = np.inf,
+        xp=np
     ) -> np.ndarray:
         """
         Return the natural parameters in array form (identity function for this class).
@@ -635,7 +636,7 @@ class TruncatedNaturalNormal(TruncatedNormalMessage):
         eta2
             The second natural parameter.
         """
-        return np.array([eta1, eta2])
+        return xp.array([eta1, eta2])
 
     def natural_parameters(self, xp=np) -> np.ndarray:
         """

--- a/autofit/messages/truncated_normal.py
+++ b/autofit/messages/truncated_normal.py
@@ -96,7 +96,7 @@ class TruncatedNormalMessage(AbstractMessage):
 
         self.mean, self.sigma, self.lower_limit, self.upper_limit = self.parameters
 
-    def cdf(self, x: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
+    def cdf(self, x: Union[float, np.ndarray], xp=np) -> Union[float, np.ndarray]:
         """
         Compute the cumulative distribution function (CDF) of the truncated Gaussian distribution
         at a given value or array of values `x`.

--- a/autofit/messages/truncated_normal.py
+++ b/autofit/messages/truncated_normal.py
@@ -141,8 +141,7 @@ class TruncatedNormalMessage(AbstractMessage):
         b = (self.upper_limit - self.mean) / self.sigma
         return truncnorm.ppf(x, a=a, b=b, loc=self.mean, scale=self.sigma)
 
-    @cached_property
-    def natural_parameters(self) -> np.ndarray:
+    def natural_parameters(self, xp=np) -> np.ndarray:
         """
         The pseudo-natural (canonical) parameters of a truncated Gaussian distribution.
 
@@ -159,7 +158,7 @@ class TruncatedNormalMessage(AbstractMessage):
         -------
         A NumPy array containing the pseudo-natural parameters [η₁, η₂].
         """
-        return self.calc_natural_parameters(self.mean, self.sigma)
+        return self.calc_natural_parameters(self.mean, self.sigma, xp=xp)
 
     @staticmethod
     def calc_natural_parameters(mu : Union[float, np.ndarray], sigma : Union[float, np.ndarray]) -> np.ndarray:
@@ -217,7 +216,7 @@ class TruncatedNormalMessage(AbstractMessage):
         return mu, sigma
 
     @staticmethod
-    def to_canonical_form(x : Union[float, np.ndarray]) -> np.ndarray:
+    def to_canonical_form(x : Union[float, np.ndarray], xp=np) -> np.ndarray:
         """
         Convert a scalar input `x` to its sufficient statistics for the Gaussian exponential family.
 
@@ -234,7 +233,7 @@ class TruncatedNormalMessage(AbstractMessage):
         -------
         The sufficient statistics [x, x²].
         """
-        return np.array([x, x**2])
+        return xp.array([x, x**2])
 
     @classmethod
     def invert_sufficient_statistics(cls, suff_stats: Tuple[float, float]) -> np.ndarray:
@@ -638,12 +637,11 @@ class TruncatedNaturalNormal(TruncatedNormalMessage):
         """
         return np.array([eta1, eta2])
 
-    @cached_property
-    def natural_parameters(self) -> np.ndarray:
+    def natural_parameters(self, xp=np) -> np.ndarray:
         """
         Return the natural parameters of this distribution.
         """
-        return self.calc_natural_parameters(*self.parameters, self.lower_limit, self.upper_limit)
+        return self.calc_natural_parameters(*self.parameters, self.lower_limit, self.upper_limit, xp=xp)
 
     @classmethod
     def invert_sufficient_statistics(

--- a/autofit/messages/truncated_normal.py
+++ b/autofit/messages/truncated_normal.py
@@ -422,7 +422,7 @@ class TruncatedNormalMessage(AbstractMessage):
         x_standard = norm.ppf(truncated_cdf)
         return self.mean + self.sigma * x_standard
 
-    def log_prior_from_value(self, value: float) -> float:
+    def log_prior_from_value(self, value: float, xp=np) -> float:
         """
         Compute the log prior probability of a given physical value under this truncated Gaussian prior.
 
@@ -446,11 +446,11 @@ class TruncatedNormalMessage(AbstractMessage):
         Z = norm.cdf(b) - norm.cdf(a)
 
         z = (value -self.mean) / self.sigma
-        log_pdf = -0.5 * z ** 2 - np.log(self.sigma) - 0.5 * np.log(2 * np.pi)
-        log_trunc_pdf = log_pdf - np.log(Z)
+        log_pdf = -0.5 * z ** 2 - xp.log(self.sigma) - 0.5 * xp.log(2 * xp.pi)
+        log_trunc_pdf = log_pdf - xp.log(Z)
 
         in_bounds = (self.lower_limit <= value) & (value <= self.upper_limit)
-        return np.where(in_bounds, log_trunc_pdf, -np.inf)
+        return xp.where(in_bounds, log_trunc_pdf, -xp.inf)
 
     def __str__(self):
         """

--- a/autofit/messages/truncated_normal.py
+++ b/autofit/messages/truncated_normal.py
@@ -25,8 +25,8 @@ def is_nan(value):
 
 
 class TruncatedNormalMessage(AbstractMessage):
-    @cached_property
-    def log_partition(self) -> float:
+
+    def log_partition(self, xp=np) -> float:
         """
         Compute the log-partition function (normalizer) of the truncated Gaussian.
 
@@ -46,7 +46,7 @@ class TruncatedNormalMessage(AbstractMessage):
         a = (self.lower_limit - self.mean) / self.sigma
         b = (self.upper_limit - self.mean) / self.sigma
         Z = norm.cdf(b) - norm.cdf(a)
-        return np.log(Z) if Z > 0 else -np.inf
+        return xp.log(Z) if Z > 0 else -xp.inf
 
     log_base_measure = -0.5 * np.log(2 * np.pi)
 

--- a/autofit/non_linear/analysis/analysis.py
+++ b/autofit/non_linear/analysis/analysis.py
@@ -109,7 +109,7 @@ class Analysis(ABC):
 
             compute_latent_for_model = functools.partial(self.compute_latent_variables, model=samples.model)
 
-            if self.use_jax:
+            if self._use_jax:
                 import jax
                 start = time.time()
                 logger.info("JAX: Applying vmap and jit to likelihood function for latent variables -- may take a few seconds.")
@@ -130,7 +130,7 @@ class Analysis(ABC):
                 # batched JAX call on this chunk
                 latent_values_batch = batched_compute_latent(batch)
 
-                if self.use_jax:
+                if self._use_jax:
                     import jax.numpy as jnp
                     latent_values_batch = jnp.stack(latent_values_batch, axis=-1)  # (batch, n_latents)
                     mask = jnp.all(jnp.isfinite(latent_values_batch), axis=0)

--- a/autofit/non_linear/analysis/analysis.py
+++ b/autofit/non_linear/analysis/analysis.py
@@ -36,7 +36,7 @@ class Analysis(ABC):
         self, use_jax : bool = False, **kwargs
     ):
 
-        self.use_jax = use_jax
+        self._use_jax = use_jax
         self.kwargs = kwargs
 
     def __getattr__(self, item: str):
@@ -63,7 +63,7 @@ class Analysis(ABC):
 
     @property
     def _xp(self):
-        if self.use_jax:
+        if self._use_jax:
             import jax.numpy as jnp
             return jnp
         return np

--- a/autofit/non_linear/fitness.py
+++ b/autofit/non_linear/fitness.py
@@ -157,7 +157,7 @@ class Fitness:
         The figure of merit returned to the non-linear search, which is either the log likelihood or log posterior.
         """
         # Get instance from model
-        instance = self.model.instance_from_vector(vector=parameters)
+        instance = self.model.instance_from_vector(vector=parameters, xp=self._xp)
 
         if self._xp.__name__.startswith("jax"):
 
@@ -227,7 +227,7 @@ class Fitness:
         if self.fom_is_log_likelihood:
             log_likelihood = figure_of_merit
         else:
-            log_prior_list = self._xp.array(self.model.log_prior_list_from_vector(vector=parameters))
+            log_prior_list = self._xp.array(self.model.log_prior_list_from_vector(vector=parameters, xp=self._xp))
             log_likelihood = figure_of_merit - self._xp.sum(log_prior_list)
 
         self.manage_quick_update(parameters=parameters, log_likelihood=log_likelihood)
@@ -237,8 +237,8 @@ class Fitness:
 
         if self.store_history:
 
-            self.parameters_history_list.append(parameters)
-            self.log_likelihood_history_list.append(log_likelihood)
+            self.parameters_history_list.append(np.array(parameters))
+            self.log_likelihood_history_list.append(np.array(log_likelihood))
 
         return figure_of_merit
 

--- a/autofit/non_linear/fitness.py
+++ b/autofit/non_linear/fitness.py
@@ -134,7 +134,7 @@ class Fitness:
 
     @property
     def _xp(self):
-        if self.analysis.use_jax:
+        if self.analysis._use_jax:
             import jax.numpy as jnp
             return jnp
         return np

--- a/autofit/non_linear/fitness.py
+++ b/autofit/non_linear/fitness.py
@@ -179,7 +179,7 @@ class Fitness:
             figure_of_merit = log_likelihood
         else:
             # Ensure prior list is compatible with JAX (must return a JAX array, not list)
-            log_prior_array = self._xp.array(self.model.log_prior_list_from_vector(vector=parameters))
+            log_prior_array = self._xp.array(self.model.log_prior_list_from_vector(vector=parameters, xp=self._xp))
             figure_of_merit = log_likelihood + self._xp.sum(log_prior_array)
 
         # Convert to chi-squared scale if requested

--- a/autofit/non_linear/fitness.py
+++ b/autofit/non_linear/fitness.py
@@ -317,7 +317,7 @@ class Fitness:
 
             logger.info("Performing quick update of maximum log likelihood fit image and model.results")
 
-            instance = self.model.instance_from_vector(vector=self.quick_update_max_lh_parameters)
+            instance = self.model.instance_from_vector(vector=self.quick_update_max_lh_parameters, xp=self._xp)
 
             try:
                 self.analysis.perform_quick_update(self.paths, instance)

--- a/autofit/non_linear/search/mle/bfgs/search.py
+++ b/autofit/non_linear/search/mle/bfgs/search.py
@@ -145,7 +145,7 @@ class AbstractBFGS(AbstractMLE):
                 config_dict_options["maxiter"] = iterations
 
                 search_internal = optimize.minimize(
-                    fun=fitness.call_wrap,
+                    fun=fitness._jit,
                     x0=x0,
                     method=self.method,
                     options=config_dict_options,

--- a/autofit/non_linear/search/mle/bfgs/search.py
+++ b/autofit/non_linear/search/mle/bfgs/search.py
@@ -227,6 +227,9 @@ class AbstractBFGS(AbstractMLE):
 
         weight_list = len(log_likelihood_list) * [1.0]
 
+        print(log_likelihood_list)
+        print(parameter_lists)
+
         sample_list = Sample.from_lists(
             model=model,
             parameter_lists=parameter_lists,

--- a/autofit/non_linear/search/mle/bfgs/search.py
+++ b/autofit/non_linear/search/mle/bfgs/search.py
@@ -92,7 +92,6 @@ class AbstractBFGS(AbstractMLE):
             fom_is_log_likelihood=False,
             resample_figure_of_merit=-np.inf,
             convert_to_chi_squared=True,
-            use_jax_vmap=True,
             store_history=self.should_plot_start_point
         )
 
@@ -146,7 +145,7 @@ class AbstractBFGS(AbstractMLE):
                 config_dict_options["maxiter"] = iterations
 
                 search_internal = optimize.minimize(
-                    fun=fitness.call_wrap,
+                    fun=fitness._jit,
                     x0=x0,
                     method=self.method,
                     options=config_dict_options,
@@ -209,7 +208,6 @@ class AbstractBFGS(AbstractMLE):
         x0 = search_internal.x
         total_iterations = search_internal.nit
 
-
         if self.should_plot_start_point:
 
             parameter_lists = search_internal.parameters_history_list
@@ -227,8 +225,9 @@ class AbstractBFGS(AbstractMLE):
 
         weight_list = len(log_likelihood_list) * [1.0]
 
-        print(log_likelihood_list)
         print(parameter_lists)
+        print(log_likelihood_list)
+        print(log_prior_list)
 
         sample_list = Sample.from_lists(
             model=model,

--- a/autofit/non_linear/search/mle/bfgs/search.py
+++ b/autofit/non_linear/search/mle/bfgs/search.py
@@ -92,6 +92,7 @@ class AbstractBFGS(AbstractMLE):
             fom_is_log_likelihood=False,
             resample_figure_of_merit=-np.inf,
             convert_to_chi_squared=True,
+            use_jax_vmap=True,
             store_history=self.should_plot_start_point
         )
 
@@ -145,7 +146,7 @@ class AbstractBFGS(AbstractMLE):
                 config_dict_options["maxiter"] = iterations
 
                 search_internal = optimize.minimize(
-                    fun=fitness._jit,
+                    fun=fitness.call_wrap,
                     x0=x0,
                     method=self.method,
                     options=config_dict_options,

--- a/autofit/non_linear/search/mle/bfgs/search.py
+++ b/autofit/non_linear/search/mle/bfgs/search.py
@@ -225,10 +225,6 @@ class AbstractBFGS(AbstractMLE):
 
         weight_list = len(log_likelihood_list) * [1.0]
 
-        print(parameter_lists)
-        print(log_likelihood_list)
-        print(log_prior_list)
-
         sample_list = Sample.from_lists(
             model=model,
             parameter_lists=parameter_lists,

--- a/autofit/non_linear/search/nest/dynesty/search/abstract.py
+++ b/autofit/non_linear/search/nest/dynesty/search/abstract.py
@@ -146,7 +146,7 @@ class AbstractDynesty(AbstractNest, ABC):
                         "parallel"
                     ].get("force_x1_cpu")
                     or self.kwargs.get("force_x1_cpu")
-                    or analysis.use_jax
+                    or analysis._use_jax
                 ):
                     raise RuntimeError
 

--- a/autofit/non_linear/search/nest/nautilus/search.py
+++ b/autofit/non_linear/search/nest/nautilus/search.py
@@ -127,7 +127,7 @@ class Nautilus(abstract_nest.AbstractNest):
         if (
             self.config_dict.get("force_x1_cpu")
             or self.kwargs.get("force_x1_cpu")
-            or analysis.use_jax
+            or analysis._use_jax
         ):
 
             fitness = Fitness(

--- a/test_autofit/graphical/global/test_hierarchical.py
+++ b/test_autofit/graphical/global/test_hierarchical.py
@@ -55,8 +55,7 @@ model                                                                           
 2 - 3
     one                                                                         UniformPrior [0], lower_limit = 0.0, upper_limit = 1.0
 factor
-    include_prior_factors                                                       True
-    use_jax                                                                     False"""
+    include_prior_factors                                                       True"""
     )
 
 

--- a/test_autofit/graphical/global/test_hierarchical.py
+++ b/test_autofit/graphical/global/test_hierarchical.py
@@ -53,9 +53,7 @@ model                                                                           
 1
     drawn_prior                                                                 UniformPrior [1], lower_limit = 0.0, upper_limit = 1.0
 2 - 3
-    one                                                                         UniformPrior [0], lower_limit = 0.0, upper_limit = 1.0
-factor
-    include_prior_factors                                                       True"""
+    one                                                                         UniformPrior [0], lower_limit = 0.0, upper_limit = 1.0"""
     )
 
 

--- a/test_autofit/graphical/hierarchical/test_optimise.py
+++ b/test_autofit/graphical/hierarchical/test_optimise.py
@@ -11,13 +11,6 @@ def make_factor(hierarchical_factor):
 def test_optimise(factor):
     search = af.DynestyStatic(maxcall=100, dynamic_delta=False, delta=0.1,)
 
-    print(type(factor.analysis))
-    print(type(factor.analysis))
-    print(type(factor.analysis))
-    print(type(factor.analysis))
-    print(type(factor.analysis))
-
-
     _, status = search.optimise(
         factor.mean_field_approximation().factor_approximation(factor)
     )


### PR DESCRIPTION
Makes it so that the messages package supports JAX via the `xp` interface implemented elsewhere in PyAuto repos.

This PR went OK, considering how far through the depths of the graphical source code the changes went. Integration tests on all this functionality seem to perform correctly but now work with JAX.

Its worth noting an environment variable implementation would not work, because for a given EP or graphical run this code is cycled through using both numpy and JAX (only uses JAX inside a non linear search during modeling).

There are a few nasty hacks which I need to better understand JAX in order to clean up.