### PR TITLE
Fix assertion failures escaping Fitness.call

### DIFF
--- a/autofit/non_linear/fitness.py
+++ b/autofit/non_linear/fitness.py
@@ -168,10 +168,10 @@ class Fitness:
         -------
         The figure of merit returned to the non-linear search, which is either the log likelihood or log posterior.
         """
-        # Get instance from model
-        instance = self.model.instance_from_vector(vector=parameters, xp=self._xp)
-
         if self._xp.__name__.startswith("jax"):
+
+            # Get instance from model (must be side-effect free and exception-free under JAX)
+            instance = self.model.instance_from_vector(vector=parameters, xp=self._xp)
 
             # Evaluate log likelihood (must be side-effect free and exception-free)
             log_likelihood = self.analysis.log_likelihood_function(instance=instance)
@@ -179,6 +179,7 @@ class Fitness:
         else:
 
             try:
+                instance = self.model.instance_from_vector(vector=parameters, xp=self._xp)
                 log_likelihood = self.analysis.log_likelihood_function(instance=instance)
             except exc.FitException:
                 return self.resample_figure_of_merit

--- a/test_autofit/non_linear/test_fitness_assertions.py
+++ b/test_autofit/non_linear/test_fitness_assertions.py
@@ -1,0 +1,32 @@
+import numpy as np
+
+import autofit as af
+from autofit.non_linear.fitness import Fitness
+
+
+def test_fitness_returns_resample_fom_on_assertion_failure():
+    """
+    If an added assertion rejects a sampled parameter vector, ``Fitness.call``
+    must return ``resample_figure_of_merit`` rather than letting the
+    ``FitException`` escape into the non-linear search. Regression for
+    the DynestyStatic-blocking bug where ``instance_from_vector`` was
+    called outside the ``try/except FitException`` block.
+    """
+    gaussian_0 = af.Model(af.ex.Gaussian)
+    gaussian_1 = af.Model(af.ex.Gaussian)
+    gaussian_0.add_assertion(gaussian_0.centre > gaussian_1.centre)
+    model = af.Collection(gaussian_0=gaussian_0, gaussian_1=gaussian_1)
+
+    data = np.ones(20)
+    noise_map = np.ones(20) * 0.1
+    analysis = af.ex.Analysis(data=data, noise_map=noise_map)
+
+    fitness = Fitness(model=model, analysis=analysis)
+
+    # centre_0 (index 0) = 10 < centre_1 (index 3) = 20  → assertion violated
+    violating = [10.0, 1.0, 1.0, 20.0, 1.0, 1.0]
+    assert fitness.call(violating) == fitness.resample_figure_of_merit
+
+    # centre_0 = 20 > centre_1 = 10  → assertion satisfied, real FOM returned
+    satisfying = [20.0, 1.0, 1.0, 10.0, 1.0, 1.0]
+    assert fitness.call(satisfying) != fitness.resample_figure_of_merit


### PR DESCRIPTION
## Summary
Assertions added to models (e.g. `gaussian_0.centre > gaussian_1.centre`) were broken for non-linear searches: when a sampled parameter vector violated an assertion, `check_assertions` raised `FitException`, but that exception escaped `Fitness.call` and killed the search. The workspace test for assertions had been commented out with the note "Assertions broken by JAX development and need fixing one day."

Root cause: `instance_from_vector` (which triggers `check_assertions`) was called **outside** the `try/except FitException` block in `Fitness.call`. Moving it inside restores the intended behaviour — assertion failures return `resample_figure_of_merit` so the sampler skips that point.

Fixes https://github.com/PyAutoLabs/PyAutoFit/issues/1215.

## API Changes
None — internal changes only. The fix restores the originally-intended behaviour of `Fitness.call` under assertion failures.
See full details below.

## Test Plan
- [x] New regression test `test_fitness_returns_resample_fom_on_assertion_failure` covers violating/satisfying vectors
- [x] Existing `test_assertion.py` suite passes (11 tests)
- [x] Full `test_autofit` suite passes (1217 tests)
- [x] Live `DynestyStatic` search with assertion constraint runs end-to-end, all collected samples satisfy the constraint

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
None.

### Added
None (new test only, not public API).

### Changed Behaviour
- `autofit.non_linear.fitness.Fitness.call` — `FitException` raised during `instance_from_vector` (i.e. assertion violation on prior values) is now caught and converts to `resample_figure_of_merit`, matching the behaviour already documented for `FitException` raised from `log_likelihood_function`. Previously such exceptions escaped and aborted the search.

### Migration
None required.

</details>

Follow-up: JAX branch of `Fitness.call` has no exception handling (JAX tracing prevents conditional exceptions); tracked in issue #1216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)