### PR TITLE
fix(jax): trace TuplePrior paired priors as pytree children

### DIFF
--- a/autofit/jax/pytrees.py
+++ b/autofit/jax/pytrees.py
@@ -74,6 +74,7 @@ def register_model(model) -> bool:
         return False
 
     from autofit.mapper.prior.abstract import Prior
+    from autofit.mapper.prior.tuple_prior import TuplePrior
     from autofit.mapper.prior_model.prior_model import Model
     from autofit.mapper.prior_model.collection import Collection
     from autofit.mapper.prior_model.abstract import AbstractPriorModel
@@ -83,7 +84,7 @@ def register_model(model) -> bool:
             cls = node.cls
             classifier = _CLASS_FIELD_CLASSIFIERS.setdefault(cls, {})
             for name, value in node.items():
-                is_dynamic = isinstance(value, (Prior, AbstractPriorModel))
+                is_dynamic = isinstance(value, (Prior, AbstractPriorModel, TuplePrior))
                 # setdefault: earliest classification wins. Different models
                 # sharing the same cls (e.g. lens vs source Galaxy) may
                 # declare different attribute sets; we accumulate them all.
@@ -123,9 +124,10 @@ def _build_instance_pytree_funcs(cls):
     Each attribute is classified as:
 
     * **Dynamic** (prior-derived): the corresponding ``Model`` attribute was
-      a ``Prior`` or ``AbstractPriorModel``. Resolved to concrete numbers
-      (or nested instances) per sampled point, so it becomes a JAX child leaf
-      and gets traced under ``jax.jit``.
+      a ``Prior``, ``AbstractPriorModel``, or ``TuplePrior``. Resolved to
+      concrete numbers (or nested instances, or a Python tuple of scalars in
+      the ``TuplePrior`` case) per sampled point, so it becomes a JAX child
+      leaf (or tuple of leaves) and gets traced under ``jax.jit``.
     * **Constant**: everything else — a fixed ``redshift=0.5``, or a concrete
       non-prior kwarg like ``Galaxy(pixelization=<Pixelization>)``. Goes into
       ``aux_data`` so it stays as the original Python object inside a trace.

--- a/test_autofit/jax/test_enable_pytrees.py
+++ b/test_autofit/jax/test_enable_pytrees.py
@@ -125,6 +125,50 @@ def test_register_model_keeps_kwarg_constants_static():
     assert float(result) == pytest.approx(2.0 * instance.scale)
 
 
+def test_register_model_traces_tuple_prior_attributes():
+    """``TuplePrior``-backed attributes must be routed into JAX children so
+    gradients flow through paired priors like ``centre=(x, y)`` and
+    ``ell_comps=(e1, e2)``.
+
+    Mirrors real-world MGE / Isothermal / ExternalShear usage where the
+    paired priors are the majority of the free parameters. Prior to the
+    fix, ``TuplePrior`` failed the ``(Prior, AbstractPriorModel)``
+    isinstance check in ``register_model``, so the resolved tuple was
+    frozen in ``aux_data`` and ``jax.value_and_grad`` returned gradients
+    only for the non-tuple attributes.
+    """
+    class Twin:
+        def __init__(self, centre, amplitude):
+            self.centre = centre
+            self.amplitude = amplitude
+
+    model = af.Model(
+        Twin,
+        centre=af.TuplePrior(
+            centre_0=af.GaussianPrior(mean=0.5, sigma=1.0),
+            centre_1=af.GaussianPrior(mean=-0.5, sigma=1.0),
+        ),
+        amplitude=af.GaussianPrior(mean=1.0, sigma=1.0),
+    )
+    register_model(model)
+    instance = model.instance_from_prior_medians()
+    params_tree = jax.tree_util.tree_map(jnp.asarray, instance)
+
+    leaves = jax.tree_util.tree_leaves(params_tree)
+    assert len(leaves) == 3  # centre[0], centre[1], amplitude
+
+    def loss(inst):
+        cx, cy = inst.centre
+        return cx * cx + cy * cy + inst.amplitude
+
+    _, grad = jax.value_and_grad(loss)(params_tree)
+    flat_grad = jnp.concatenate(
+        [jnp.asarray(l).ravel() for l in jax.tree_util.tree_leaves(grad)]
+    )
+    assert jnp.all(jnp.isfinite(flat_grad))
+    assert flat_grad.size == 3
+
+
 def test_enable_pytrees_idempotent():
     assert enable_pytrees() is True
     assert enable_pytrees() is True


### PR DESCRIPTION
## Summary

`autofit.jax.register_model` was silently freezing `TuplePrior`-backed attributes (the paired priors behind `centre=(x, y)`, `ell_comps=(e1, e2)`, etc.) into JAX `aux_data` instead of `children`. As a result, gradients through `jax.value_and_grad` could not flow into the majority of parameters in real-world models (MGE lens: 15 free params → only 3 JAX leaves).

Extends the dynamic-vs-constant classifier in `register_model` to recognise `TuplePrior` as dynamic. The resolved value is already a Python tuple of scalars, which JAX's built-in tuple pytree handling recurses into — no new pytree registration for `TuplePrior` itself is needed.

## API Changes

None — internal fix to the JAX pytree routing inside `register_model`. Public API surface unchanged; the fix only makes gradients flow through priors that were already meant to be dynamic.

See full details below.

## Test Plan

- [x] `pytest test_autofit/jax/` — new `test_register_model_traces_tuple_prior_attributes` covers a `TuplePrior`-backed attribute through `jax.value_and_grad`; all 8 tests pass.
- [x] `pytest test_autofit/jax/ test_autofit/mapper/` — 505 tests pass.
- [x] Ran `autolens_workspace_developer/jax_profiling/imaging/mge_gradients.py` against the worktree: JAX leaves went from 3 → 167 for the MGE lens model, Steps 1–5 gradients finite (previously NaN). Steps 6–8 still fail but due to a separate pre-existing NNLS-backward-pass numerics issue unrelated to this PR.
- [x] `mge.py` (forward-only JIT) unchanged — still completes end-to-end with the same timings.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
- None.

### Added
- None.

### Renamed
- None.

### Changed Signature
- None.

### Changed Behaviour
- `autofit.jax.register_model(model)` — attributes that resolve to a `TuplePrior` are now classified as **dynamic** rather than **constant**. This changes the JAX pytree layout for models that use `TuplePrior` (e.g. anything with `centre`/`ell_comps` priors): the scalar components of the tuple now appear as child leaves under `jax.tree_util.tree_flatten`, and receive gradients under `jax.value_and_grad`. Code that previously iterated `tree_leaves(instance)` and expected tuple-valued attributes to be absent will now see them — this is the intended fix. Forward-only JIT pipelines (`mge.py`, `pixelization.py`) are unaffected since traced tuple components are valid children.

### Migration
- None required. Existing consumers that never took gradients see no change. Consumers that did take gradients now correctly see finite gradients on paired-prior parameters; previously-NaN gradients in that code path should re-inspect downstream numerics (e.g. NNLS backward passes) separately.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)