### PR TITLE
Close nautilus internal pools to silence shutdown AttributeError

### DIFF
--- a/autofit/non_linear/search/nest/nautilus/search.py
+++ b/autofit/non_linear/search/nest/nautilus/search.py
@@ -345,6 +345,19 @@ class Nautilus(abstract_nest.AbstractNest):
             fitness=fitness
         )
 
+        # Nautilus creates its own multiprocessing.Pool internally when pool=N.
+        # Close them here so their finalizers don't fire at interpreter shutdown
+        # (after pickle has been torn down, causing AttributeError on Pool.__del__).
+        for pool_attr in ("pool_l", "pool_s"):
+            pool = getattr(search_internal, pool_attr, None)
+            if pool is not None:
+                try:
+                    pool.close()
+                    pool.join()
+                except Exception:
+                    pass
+                setattr(search_internal, pool_attr, None)
+
         return search_internal
 
     def call_search(self, search_internal, model, analysis, fitness):


### PR DESCRIPTION
## Summary
Nautilus's `fit_multiprocessing` passes `pool=N` to `nautilus.Sampler(...)`, which then creates two `multiprocessing.Pool` objects (`pool_l`, `pool_s`) internally. PyAutoFit never closed them, so their finalizers fired at Python interpreter shutdown — after `pickle` had already been torn down — producing:

```
Exception ignored in: <function Pool.__del__ at 0x...>
  File ".../multiprocessing/pool.py", line 271, in __del__
  File ".../multiprocessing/queues.py", line 393, in put
AttributeError: 'NoneType' object has no attribute 'dumps'
```

The fit itself is correct, but the stderr noise makes smoke-test output look like a failure and trips log-scraping heuristics. This PR closes + joins the two pools after `call_search` returns.

## API Changes
None — internal cleanup only.
See full details below.

## Test Plan
- [x] `pytest test_autofit/non_linear/` — 239 passed
- [x] `python scripts/searches/nest/Nautilus.py` in autofit_workspace under smoke-test env vars — completes with exit 0 and no `Exception ignored` / `Pool.__del__` / `AttributeError` in the log
- [x] Full autofit_workspace smoke suite (7 scripts) re-run — all clean

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
- None

### Added
- None

### Changed Behaviour
- `autofit.non_linear.search.nest.nautilus.Nautilus.fit_multiprocessing` — now closes and joins `search_internal.pool_l` and `search_internal.pool_s` before returning, and nulls those attributes. Observable effect: the teardown `AttributeError` at interpreter shutdown is gone. No change to the returned `search_internal` semantics (the pools were never reused after this point).

### Migration
- None required.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)