### PR TITLE
Guard corner_cornerpy against samples < dims

### DIFF
--- a/autofit/non_linear/plot/samples_plotters.py
+++ b/autofit/non_linear/plot/samples_plotters.py
@@ -1,12 +1,26 @@
+import logging
+
 import numpy as np
 
 from autoconf import conf
 
 from autofit.non_linear.plot.plot_util import skip_in_test_mode, output_figure
 
+logger = logging.getLogger(__name__)
+
 
 @skip_in_test_mode
 def corner_cornerpy(samples, path=None, filename="corner", format="show", **kwargs):
+    data = np.asarray(samples.parameter_lists)
+    if data.ndim < 2 or data.shape[0] <= data.shape[1]:
+        logger.info(
+            "corner_cornerpy: skipping corner plot, only %s sample(s) for %s parameter(s) "
+            "(e.g. PYAUTO_TEST_MODE bypass or an early-iteration update).",
+            data.shape[0] if data.ndim >= 1 else 0,
+            data.shape[1] if data.ndim >= 2 else 0,
+        )
+        return
+
     import matplotlib.pylab as pylab
 
     config_dict = conf.instance["visualize"]["plots_settings"]["corner_cornerpy"]
@@ -17,7 +31,7 @@ def corner_cornerpy(samples, path=None, filename="corner", format="show", **kwar
     import corner
 
     corner.corner(
-        data=np.asarray(samples.parameter_lists),
+        data=data,
         weight_list=samples.weight_list,
         labels=samples.model.parameter_labels_with_superscripts_latex,
     )


### PR DESCRIPTION
## Summary
`aplt.corner_cornerpy` asserted inside the `corner` library when called with fewer samples than model dimensions. This is routine under `PYAUTO_TEST_MODE=2` (bypass leaves 1–2 samples) and can also happen during very-early updates when `corner_cornerpy` is called before the sampler has produced a full chain. Log and skip instead of asserting so callers can invoke the plot unconditionally.

## API Changes
None — internal behaviour of `corner_cornerpy` now gracefully skips when samples are insufficient. Callers see an INFO log line and a `None` return instead of an `AssertionError`.
See full details below.

## Test Plan
- [x] `pytest test_autofit/non_linear/` (239 passed)
- [x] Full autofit_workspace smoke sweep (40 pass / 0 fail / 12 skip)

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- `autofit.non_linear.plot.samples_plotters.corner_cornerpy` — now returns early with an INFO log when `samples.parameter_lists` has `ndim < 2` or fewer rows than columns (samples < dims+1). Previous behaviour raised `AssertionError` from `corner.corner_impl`.

</details>

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>