### PR TITLE
docs(install): clone workspace at tag matching library version

### DIFF
--- a/docs/installation/conda.rst
+++ b/docs/installation/conda.rst
@@ -28,13 +28,15 @@ the installation has clean dependencies):
 
     pip install autofit
 
-Next, clone the ``autofit workspace`` (the line ``--depth 1`` clones only the most recent branch on
-the ``autofit_workspace``, reducing the download size):
+Next, clone the ``autofit_workspace`` at the tag matching your installed ``PyAutoFit`` version. Each
+``PyAutoFit`` release tags a paired ``autofit_workspace`` snapshot, so cloning by tag guarantees that the
+example scripts and notebooks were generated against the library version you installed:
 
 .. code-block:: bash
 
    cd /path/on/your/computer/you/want/to/put/the/autofit_workspace
-   git clone https://github.com/Jammy2211/autofit_workspace --depth 1
+   AUTOFIT_VERSION=$(python -c "import autofit; print(autofit.__version__)")
+   git clone https://github.com/Jammy2211/autofit_workspace --branch $AUTOFIT_VERSION --depth 1
    cd autofit_workspace
 
 Run the `welcome.py` script to get started!

--- a/docs/installation/pip.rst
+++ b/docs/installation/pip.rst
@@ -17,13 +17,15 @@ the installation has clean dependencies):
 If this raises no errors **PyAutoFit** is installed! If there is an error check out
 the `troubleshooting section <https://pyautofit.readthedocs.io/en/latest/installation/troubleshooting.html>`_.
 
-Next, clone the ``autofit workspace`` (the line ``--depth 1`` clones only the most recent branch on
-the ``autofit_workspace``, reducing the download size):
+Next, clone the ``autofit_workspace`` at the tag matching your installed ``PyAutoFit`` version. Each
+``PyAutoFit`` release tags a paired ``autofit_workspace`` snapshot, so cloning by tag guarantees that the
+example scripts and notebooks were generated against the library version you installed:
 
 .. code-block:: bash
 
    cd /path/on/your/computer/you/want/to/put/the/autofit_workspace
-   git clone https://github.com/Jammy2211/autofit_workspace --depth 1
+   AUTOFIT_VERSION=$(python -c "import autofit; print(autofit.__version__)")
+   git clone https://github.com/Jammy2211/autofit_workspace --branch $AUTOFIT_VERSION --depth 1
    cd autofit_workspace
 
 Run the ``welcome.py`` script to get started!


### PR DESCRIPTION
## Summary

Each PyAuto release tags a paired workspace snapshot. The pip and conda install instructions now clone the workspace via `--branch $AUTOFIT_VERSION` (read from the installed library) so example scripts and notebooks line up with the installed library version. Companion to PyAutoLabs/autolens_workspace#71.

## API Changes

None — documentation only.

See full details below.

## Test Plan

- [ ] Render docs and confirm the new bash snippet renders correctly.
- [ ] Once a release is cut with the new pipeline (PyAutoBuild PR), follow the install docs end-to-end and confirm the cloned workspace's `version.txt` matches the installed `autofit.__version__`.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- `docs/installation/pip.rst` and `docs/installation/conda.rst`: workspace clone command now reads the installed library version and clones the matching tag, rather than a bare `--depth 1` clone of the (formerly default) `release` branch.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)