### PR TITLE
Drop Binder URLs, pin Colab URLs to workspace tag 2026.4.13.6

### DIFF
--- a/.github/workflows/url_check.yml
+++ b/.github/workflows/url_check.yml
@@ -1,0 +1,23 @@
+name: URL Check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  url_check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          path: repo
+      - name: Checkout PyAutoBuild
+        uses: actions/checkout@v4
+        with:
+          repository: PyAutoLabs/PyAutoBuild
+          ref: main
+          path: PyAutoBuild
+      - name: Run url_check.sh
+        run: bash PyAutoBuild/autobuild/url_check.sh repo

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 PyAutoFit: Classy Probabilistic Programming
 ===========================================
 
-.. |binder| image:: https://mybinder.org/badge_logo.svg
-   :target: https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/HEAD
+.. |colab| image:: https://colab.research.google.com/assets/colab-badge.svg
+   :target: https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/start_here.ipynb
 
 .. |RTD| image:: https://readthedocs.org/projects/pyautofit/badge/?version=latest
     :target: https://pyautofit.readthedocs.io/en/latest/?badge=latest
@@ -29,11 +29,11 @@ PyAutoFit: Classy Probabilistic Programming
     :target: https://pypi.org/project/autofit/
     :alt: PyPI Version
 
-|binder| |Tests| |Build| |RTD| |JOSS|
+|colab| |Tests| |Build| |RTD| |JOSS|
 
 `Installation Guide <https://pyautofit.readthedocs.io/en/latest/installation/overview.html>`_ |
 `readthedocs <https://pyautofit.readthedocs.io/en/latest/index.html>`_ |
-`Introduction on Binder <https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/release?filepath=notebooks/overview/overview_1_the_basics.ipynb>`_ |
+`Introduction on Colab <https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/notebooks/overview/overview_1_the_basics.ipynb>`_ |
 `HowToFit <https://pyautofit.readthedocs.io/en/latest/howtofit/howtofit.html>`_
 
 **PyAutoFit** is a Python based probabilistic programming language for model fitting and Bayesian inference
@@ -55,7 +55,7 @@ The following links are useful for new starters:
 
 - `The PyAutoFit readthedocs <https://pyautofit.readthedocs.io/en/latest>`_, which includes an `installation guide <https://pyautofit.readthedocs.io/en/latest/installation/overview.html>`_ and an overview of **PyAutoFit**'s core features.
 
-- `The introduction Jupyter Notebook on Binder <https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/release?filepath=notebooks/overview/overview_1_the_basics.ipynb>`_, where you can try **PyAutoFit** in a web browser (without installation).
+- `The introduction Jupyter Notebook on Colab <https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/notebooks/overview/overview_1_the_basics.ipynb>`_, where you can try **PyAutoFit** in a web browser (without installation).
 
 - `The autofit_workspace GitHub repository <https://github.com/Jammy2211/autofit_workspace>`_, which includes example scripts and the `HowToFit Jupyter notebook lectures <https://github.com/Jammy2211/autofit_workspace/tree/main/notebooks/howtofit>`_ which give new users a step-by-step introduction to **PyAutoFit**.
 

--- a/docs/howtofit/chapter_1_introduction.rst
+++ b/docs/howtofit/chapter_1_introduction.rst
@@ -6,22 +6,22 @@ Chapter 1: Introduction
 In chapter 1, we introduce you to the **PyAutoFit** and describe how to set up your own model, fit it to data via
 a non-linear search and inspect and interpret the results.
 
-You can start the tutorials right now by going to `our binder <https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/HEAD>`_
+You can start the tutorials right now by going to `our colab <https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/start_here.ipynb>`_
 and navigating to the folder ``notebooks/howtofit/chapter_1_introduction``. They are also on the `autofit_workspace <https://github.com/Jammy2211/autofit_workspace>`_.
 
 The chapter contains the following tutorials:
 
-`Tutorial 1: Models <https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/release?filepath=notebooks/howtofit/chapter_1_introduction/tutorial_1_models.ipynb>`_
+`Tutorial 1: Models <https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/notebooks/howtofit/chapter_1_introduction/tutorial_1_models.ipynb>`_
 - Composing a model in **PyAutoFit**.
 
-`Tutorial 2: Fitting Data <https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/release?filepath=notebooks/howtofit/chapter_1_introduction/tutorial_2_fitting_data.ipynb>`_
+`Tutorial 2: Fitting Data <https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/notebooks/howtofit/chapter_1_introduction/tutorial_2_fitting_data.ipynb>`_
 - Fitting a model with an input set of parameters to data.
 
-`Tutorial 3: Non Linear Search <https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/release?filepath=notebooks/howtofit/chapter_1_introduction/tutorial_3_non_linear_search.ipynb>`_
+`Tutorial 3: Non Linear Search <https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/notebooks/howtofit/chapter_1_introduction/tutorial_3_non_linear_search.ipynb>`_
 - The Concepts of a non-linear search, parameter space and priors.
 
-`Tutorial 4: Complex Models <https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/release?filepath=notebooks/howtofit/chapter_1_introduction/tutorial_4_complex_models.ipynb>`_
+`Tutorial 4: Complex Models <https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/notebooks/howtofit/chapter_1_introduction/tutorial_4_complex_models.ipynb>`_
 - Composing and fitting complex models.
 
-`Tutorial 5: Results and Samples <https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/release?filepath=notebooks/howtofit/chapter_1_introduction/tutorial_5_results_and_samples.ipynb>`_
+`Tutorial 5: Results and Samples <https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/notebooks/howtofit/chapter_1_introduction/tutorial_5_results_and_samples.ipynb>`_
 - The results of a model-fit output by **PyAutoFit**.

--- a/docs/howtofit/chapter_3_graphical_models.rst
+++ b/docs/howtofit/chapter_3_graphical_models.rst
@@ -7,23 +7,23 @@ In this chapter, we take you through how to compose and fit graphical models in 
 simultaneously fit many datasets with a model that has 'local' parameters specific to each individual dataset
 and 'global'parameters that fit for global trends across the whole dataset.
 
-You can start the tutorials right now by going to `our binder <https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/HEAD>`_
+You can start the tutorials right now by going to `our colab <https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/start_here.ipynb>`_
 and navigating to the folder ``notebooks/howtofit/chapter_graphical_models``. They are also on the `autofit_workspace <https://github.com/Jammy2211/autofit_workspace>`_.
 
 The chapter contains the following tutorials:
 
-`Tutorial 1: Individual Models <https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/release?filepath=notebooks/howtofit/chapter_graphical_models/tutorial_1_individual_models.ipynb>`_
+`Tutorial 1: Individual Models <https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/notebooks/howtofit/chapter_graphical_models/tutorial_1_individual_models.ipynb>`_
 - An example of inferring global parameters from a dataset by fitting the model to each dataset one-by-one.
 
-`Tutorial 2: Graphical Model <https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/release?filepath=notebooks/howtofit/chapter_graphical_models/tutorial_2_graphical_model.ipynb>`_
+`Tutorial 2: Graphical Model <https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/notebooks/howtofit/chapter_graphical_models/tutorial_2_graphical_model.ipynb>`_
 - Fitting the dataset with a graphical model that fits all datasets simultaneously to infer the global parameters.
 
-`Tutorial 3: Graphical Benefits <https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/release?filepath=notebooks/howtofit/chapter_graphical_models/tutorial_3_graphical_benefits.ipynb>`_
+`Tutorial 3: Graphical Benefits <https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/notebooks/howtofit/chapter_graphical_models/tutorial_3_graphical_benefits.ipynb>`_
 - Illustrating the benefits of graphical modeling over simpler approaches using a more complex model.
 
-`Tutorial 4: Hierarchical Models <https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/release?filepath=notebooks/howtofit/chapter_graphical_models/tutorial_4_hierarchical_models.ipynb>`_
+`Tutorial 4: Hierarchical Models <https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/notebooks/howtofit/chapter_graphical_models/tutorial_4_hierarchical_models.ipynb>`_
 - Fitting hierarchical models using the graphical modeling framework.
 
-`Tutorial 5: Expectation Propagation <https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/release?filepath=notebooks/howtofit/chapter_graphical_models/tutorial_5_expectation_propagation.ipynb>`_
+`Tutorial 5: Expectation Propagation <https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/notebooks/howtofit/chapter_graphical_models/tutorial_5_expectation_propagation.ipynb>`_
 - Scaling graphical models up to fit extremely large datasets using Expectation Propagation (EP).
 

--- a/docs/howtofit/howtofit.rst
+++ b/docs/howtofit/howtofit.rst
@@ -5,7 +5,7 @@ HowToFit Lectures
 
 To learn how to use **PyAutoFit**, the best starting point is the **HowToFit** lecture series, which are found on
 the `autofit_workspace <https://github.com/Jammy2211/autofit_workspace>`_ and at
-our `binder <https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/HEAD>`_.
+our `colab <https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/start_here.ipynb>`_.
 
 The lectures are provided as *Jupyter notebooks* and currently consist of 3 chapters:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,7 +20,7 @@ The following links are useful for new starters:
 
 - `The PyAutoFit readthedocs <https://pyautofit.readthedocs.io/en/latest>`_, which includes an `installation guide <https://pyautofit.readthedocs.io/en/latest/installation/overview.html>`_ and an overview of **PyAutoFit**'s core features.
 
-- `The introduction Jupyter Notebook on Binder <https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/release?filepath=notebooks/overview/overview_1_the_basics.ipynb>`_, where you can try **PyAutoFit** in a web browser (without installation).
+- `The introduction Jupyter Notebook on Colab <https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/notebooks/overview/overview_1_the_basics.ipynb>`_, where you can try **PyAutoFit** in a web browser (without installation).
 
 - `The autofit_workspace GitHub repository <https://github.com/Jammy2211/autofit_workspace>`_, which includes example scripts and the `HowToFit Jupyter notebook lectures <https://github.com/Jammy2211/autofit_workspace/tree/main/notebooks/howtofit>`_ which give new users a step-by-step introduction to **PyAutoFit**.
 

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -38,7 +38,7 @@ Advanced features include database tools for analysing large suites of modeling 
 knowledge of a problem via non-linear search chaining. Accompanying `PyAutoFit` is the [autofit workspace](https://github.com/Jammy2211/autofit_workspace), 
 which includes example scripts and the `HowToFit` lecture series which introduces non-experts to model-fitting and 
 provides a guide on how to begin a project using `PyAutoFit`. Readers can try `PyAutoFit` right now by 
-going to [the introduction Jupyter notebook on Binder](https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/HEAD)
+going to [the introduction Jupyter notebook on Colab](https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/start_here.ipynb)
 or checkout our [readthedocs](https://pyautofit.readthedocs.io/en/latest/) for a complete overview
 of **PyAutoFit**'s features.
 
@@ -132,7 +132,7 @@ contains example scripts for composing a model, performing a fit, using the `Agg
 statistical inference methods. Also included are the `HowToFit` tutorials, a series of Jupyter notebooks aimed at 
 non-experts, introducing them to model-fitting and Bayesian inference. They teach users how to write model-components 
 and `Analysis` classes in `PyAutoFit`, use these to fit a dataset and interpret the model-fitting results. The lectures 
-are available on our [Binder](https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/HEAD) and may therefore be 
+are available on our [Colab](https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/start_here.ipynb) and may therefore be 
 taken without a local `PyAutoFit` installation.
 
 # Software Citations


### PR DESCRIPTION
## Summary

Drop all `mybinder.org` URLs in favour of Google Colab. Pin every Colab URL to the
date-based workspace tag (currently `2026.4.13.6`) so links stay aligned with the
PyPI-released library that users will have installed. Rewrite the GitHub owner
from `Jammy2211` to `PyAutoLabs`.

## What changed

- **URL rewrites** across `*.rst`, `*.md`, `*.ipynb`, `*.py`:
  - `mybinder.org/v2/gh/Jammy2211/<ws>/release?filepath=<path>` → `colab.research.google.com/github/PyAutoLabs/<ws>/blob/2026.4.13.6/<path>`
  - `mybinder.org/v2/gh/Jammy2211/<ws>/HEAD` → `colab.research.google.com/github/PyAutoLabs/<ws>/blob/2026.4.13.6/start_here.ipynb`
  - `colab…/Jammy2211/<ws>/blob/release/<path>` → `colab…/PyAutoLabs/<ws>/blob/2026.4.13.6/<path>`
- **Badge swap**: Binder badge images replaced with the official Colab badge
  (`colab-badge.svg`); RST `|binder|` substitution renamed to `|colab|`.
- **Prose cleanup**: every "Binder" link caption / sentence rewritten to "Colab"
  (case-preserving) so link text matches link target.

## Release-pipeline integration

The release workflow in PyAutoBuild (#49, merged) now invokes
`bump_colab_urls.sh <new-tag>` against this repo on every release, so the pinned
tag advances automatically. No manual maintenance is required after this PR.

## Regression guard

Adds `.github/workflows/url_check.yml` which runs PyAutoBuild's
`autobuild/url_check.sh` on every push and pull request. Re-introducing any
`mybinder.org` URL, `Jammy2211/` Colab owner, or `/blob/release/` Colab ref will
fail CI.

## Test Plan
- [ ] `url_check.yml` workflow passes on this PR
- [ ] Spot-check a Colab URL by clicking through to confirm the notebook loads at the pinned tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)
