### PR TITLE
feat: lazily JIT-cache fit_for_visualization when flag set

### DIFF
--- a/autofit/non_linear/analysis/analysis.py
+++ b/autofit/non_linear/analysis/analysis.py
@@ -58,22 +58,43 @@ class Analysis(ABC):
         """
         Build the fit used by the visualizer.
 
-        Currently a thin dispatch over ``self.fit_from``: when ``use_jax=True``
-        the fit is built on the eager JAX path (``self._xp is jnp``) and the
-        plotter materialises arrays to NumPy at the matplotlib boundary. The
-        ``use_jax_for_visualization`` flag is an explicit opt-in today — it
-        marks the intent to use JAX for visualization, and is the dispatch
-        point where full ``jax.jit``-wrapping will plug in once
-        :class:`autolens.imaging.fit_imaging.FitImaging` and its nested
-        autoarray types are registered as JAX pytrees (that work is tracked
-        separately — see ``admin_jammy/prompt/autolens/fit_imaging_pytree.md``).
+        Dispatch over ``self.fit_from`` with an opt-in ``jax.jit`` fast path:
+
+        * ``use_jax_for_visualization=False`` (default) — plain
+          ``self.fit_from(instance)``. Untouched by JAX.
+        * ``use_jax_for_visualization=True`` — lazily construct
+          ``jax.jit(self.fit_from)`` on the first call and cache it on the
+          instance as ``_jitted_fit_from``, then call that for every
+          subsequent visualization. The first call pays the compile cost;
+          subsequent calls reuse the cached compiled function.
+
+        Caching is per-``Analysis`` instance so each analysis gets its own
+        compiled function keyed off that instance's closed-over state
+        (``self.dataset``, ``self.settings``, etc. — these ride as pytree
+        aux data via ``register_instance_pytree(FitImaging, no_flatten=...)``
+        in PyAutoLens).
 
         ``fit_from`` is defined by Analysis subclasses (e.g. ``AnalysisImaging``),
         not the base class — this method is only callable on subclasses that
         provide it. Downstream visualizers should prefer this over calling
         ``fit_from`` directly so the JIT seam stays in one place.
+
+        For the JIT path to succeed, the ``Fit*`` return type (and every
+        nested autoarray / galaxy / lens type it carries) must be pytree-
+        registered. That wiring lives in each analysis subclass (see
+        ``AnalysisImaging._register_fit_imaging_pytrees`` in PyAutoLens).
+        Variants that have not yet been pytree-audited must leave
+        ``use_jax_for_visualization`` at its default of ``False``.
         """
-        return self.fit_from(instance=instance)
+        if not self._use_jax_for_visualization:
+            return self.fit_from(instance=instance)
+
+        if getattr(self, "_jitted_fit_from", None) is None:
+            import jax
+
+            self._jitted_fit_from = jax.jit(self.fit_from)
+
+        return self._jitted_fit_from(instance)
 
     def __getattr__(self, item: str):
         """

--- a/test_autofit/analysis/test_use_jax_for_visualization.py
+++ b/test_autofit/analysis/test_use_jax_for_visualization.py
@@ -20,6 +20,28 @@ class _FittableAnalysis(af.Analysis):
         return ("fit", instance)
 
 
+class _JitFittableAnalysis(af.Analysis):
+    """Analysis with a ``fit_from`` returning a JIT-traceable array.
+
+    ``_FittableAnalysis.fit_from`` returns a Python tuple with a string literal,
+    which is not tracer-compatible. For the JIT-enabled dispatch path we need a
+    ``fit_from`` whose output is entirely JAX-compatible.
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.fit_from_calls = 0
+
+    def log_likelihood_function(self, instance):
+        return 0.0
+
+    def fit_from(self, instance):
+        import jax.numpy as jnp
+
+        self.fit_from_calls += 1
+        return jnp.asarray(instance) * 2.0
+
+
 def test_default_flag_is_false():
     analysis = af.Analysis()
     assert analysis._use_jax is False
@@ -48,11 +70,21 @@ def test_pyauto_disable_jax_env_var_clears_both_flags(monkeypatch):
     assert analysis._use_jax_for_visualization is False
 
 
-def test_fit_for_visualization_dispatches_to_fit_from():
-    analysis = _FittableAnalysis(use_jax=True, use_jax_for_visualization=True)
-    result = analysis.fit_for_visualization(instance="sentinel")
-    assert result == ("fit", "sentinel")
-    assert analysis.fit_from_calls == 1
+def test_fit_for_visualization_dispatches_through_jit_when_flag_set():
+    import jax.numpy as jnp
+
+    analysis = _JitFittableAnalysis(use_jax=True, use_jax_for_visualization=True)
+
+    assert getattr(analysis, "_jitted_fit_from", None) is None
+
+    result_1 = analysis.fit_for_visualization(instance=1.0)
+    assert analysis._jitted_fit_from is not None
+    assert jnp.allclose(result_1, jnp.asarray(2.0))
+
+    jitted_after_first = analysis._jitted_fit_from
+    result_2 = analysis.fit_for_visualization(instance=3.0)
+    assert analysis._jitted_fit_from is jitted_after_first
+    assert jnp.allclose(result_2, jnp.asarray(6.0))
 
 
 def test_fit_for_visualization_works_without_flag():
@@ -60,6 +92,7 @@ def test_fit_for_visualization_works_without_flag():
     result = analysis.fit_for_visualization(instance="sentinel")
     assert result == ("fit", "sentinel")
     assert analysis.fit_from_calls == 1
+    assert getattr(analysis, "_jitted_fit_from", None) is None
 
 
 def test_subclass_can_override_supports_jax_visualization():


### PR DESCRIPTION
## Summary
Replace the pass-through stub in `Analysis.fit_for_visualization` with a lazy `jax.jit` cache. With `use_jax_for_visualization=True`, the first call compiles `self.fit_from` and stores it on the instance as `_jitted_fit_from`; subsequent calls reuse the compiled function. Default behaviour (flag off) is unchanged — this is a controlled opt-in ahead of the remaining `Fit*` pytree registrations.

## API Changes
`Analysis.fit_for_visualization` now lazily constructs and caches `jax.jit(self.fit_from)` on the instance when `use_jax_for_visualization=True`. Flag-off behaviour and all public signatures are unchanged. See full details below.

## Test Plan
- [x] `test_autofit/analysis/test_use_jax_for_visualization.py` updated to exercise both the JIT path (asserts `_jitted_fit_from` is created on first call and reused on second) and the no-flag path
- [x] Full `test_autofit/` suite passes (1232 tests)
- [x] End-to-end validated via `modeling_visualization_jit.py` in the linked workspace PR: 7.6× speedup compile → cached, Nautilus live-search fires the JIT path and writes `subplot_fit.png`

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- `Analysis.fit_for_visualization(instance)` — when `use_jax_for_visualization=True` on the instance, lazily constructs `jax.jit(self.fit_from)` on the first call, caches it as `self._jitted_fit_from`, and returns the compiled function's output for every subsequent call. Falls back to plain `self.fit_from(instance)` when the flag is off.

### Added (internal)
- `Analysis._jitted_fit_from` — lazy-initialized attribute; `None` until the first `fit_for_visualization` call with the flag on.

### Migration
No migration needed for flag-off callers (the default). Callers that set `use_jax_for_visualization=True` now get a JIT-compiled `fit_from` — their `Fit*` return type and all nested types must be pytree-registered or the compile will error. See `admin_jammy/prompt/autolens/fit_*_pytree_*.md` for the variant matrix.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)