### PR TITLE
docs: note Python 3.12+ requirement on pip install page

### DIFF
--- a/docs/installation/pip.rst
+++ b/docs/installation/pip.rst
@@ -3,6 +3,11 @@
 Installation with pip
 =====================
 
+.. note::
+   **PyAutoFit** requires **Python 3.12 or later**. If you are on Python
+   3.9, 3.10, or 3.11, ``pip install autofit`` will fail with a "no matching
+   distribution" error. Upgrade Python to 3.12+ before installing.
+
 We strongly recommend that you install **PyAutoFit** in a
 `Python virtual environment <https://www.geeksforgeeks.org/python-virtual-environment/>`_, with the link attached
 describing what a virtual environment is and how to create one.
@@ -33,3 +38,20 @@ Run the ``welcome.py`` script to get started!
 .. code-block:: bash
 
    python3 welcome.py
+
+Legacy Python versions
+----------------------
+
+We dropped support for Python 3.9, 3.10, and 3.11 in release ``2026.4.5.3``
+(April 2026). Pre-``2026.4.5.3`` releases on PyPI have been yanked, so they
+will not install via the standard ``pip install autofit`` command.
+
+If you have an existing project that requires a pre-``2026.4.5.3`` version,
+you can still install it explicitly by pinning the version, e.g.:
+
+.. code-block:: bash
+
+    pip install autofit==2025.10.6.1
+
+Yanked releases remain available for explicit pins; only resolver-driven
+fallback is blocked.


### PR DESCRIPTION
## Summary
Adds a Python 3.12+ requirement note to the top of the pip install page,
plus a "Legacy Python versions" section at the bottom explaining how to
install pre-`2026.4.5.3` releases of `autofit` via explicit version pin.

Context: users on Python 3.9/3.10/3.11 currently see `pip install autofit`
silently roll back to a pre-`2026.4.5.3` release (which doesn't carry the
`requires-python>=3.12` pin). They then download the latest workspace,
which is paired with the current `PyAutoFit` version, and hit unrelated-looking
import errors.

This PR is paired with a follow-up PyPI yank of all releases of `autofit`
prior to `2026.4.5.3`. Yanked releases remain installable via explicit
`==` pin (so existing lockfiles keep working), but pip will no longer
fall back to them. Users on unsupported Python will instead get a clear
"no matching distribution" error pointing them at the version requirement.

## API Changes
None — docs-only change.

## Test Plan
- [ ] `make html` builds the modified `docs/installation/pip.rst` without
      warnings.
- [ ] Rendered page shows the top-of-page admonition and the bottom
      "Legacy Python versions" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)