### PR TITLE
fix: af.ex.Analysis use_jax=True with bare af.Model fallback

### DIFF
--- a/autofit/example/analysis.py
+++ b/autofit/example/analysis.py
@@ -109,7 +109,7 @@ class Analysis(af.Analysis):
                 except AttributeError:
                     pass
         except TypeError:
-            model_data_1d += instance.model_data_from(xvalues=xvalues)
+            model_data_1d += instance.model_data_from(xvalues=xvalues, xp=self._xp)
 
         return model_data_1d
 


### PR DESCRIPTION
## Summary

`af.ex.Analysis.model_data_1d_from` had two paths: a `Collection` branch that correctly forwarded `xp=self._xp` to each profile's `model_data_from`, and a bare-`Model` fallback (the `except TypeError` branch, hit when `instance` is a single non-iterable model component) that called `instance.model_data_from(xvalues=xvalues)` without `xp`. With `use_jax=True` on a bare `af.Model(af.ex.Gaussian)`, this defaulted `xp` to `numpy` and triggered `TracerArrayConversionError` inside `jax.jit`. The Collection branch was already updated when `_xp` was wired in; the single-instance branch was missed. One-line fix: add `, xp=self._xp`.

Surfaced while building a JAX-jitted Nautilus example in `autofit_workspace_test` (separate PR to follow once this lands).

## API Changes

None — bug fix in example Analysis class. `af.ex.Analysis(use_jax=True)` now works with a bare `af.Model`; previously it silently degraded to numpy and crashed under JIT.

## Test Plan

- [ ] `python -m pytest test_autofit/ -x` passes
- [ ] Manual: `af.Nautilus` over `af.Model(af.ex.Gaussian)` with `Analysis(use_jax=True)` runs to completion (verified locally: log_Z ≈ -64.15; `JAX: Applying vmap and jit to likelihood function` log line confirms JIT path was exercised)

🤖 Generated with [Claude Code](https://claude.com/claude-code)