### PR TITLE
Support fixed Array elements through the EP fitting pipeline

### DIFF
--- a/autofit/graphical/declarative/factor/analysis.py
+++ b/autofit/graphical/declarative/factor/analysis.py
@@ -118,7 +118,17 @@ class AnalysisFactor(AbstractModelFactor):
             return getattr(self.prior_model, item)
 
     def name_for_variable(self, variable):
-        path = ".".join(self.prior_model.path_for_prior(variable))
+        path_iter = self.prior_model.path_for_prior(variable)
+        if path_iter is None:
+            # Variable is no longer in the factor's prior model — typically
+            # because it was replaced by a fixed scalar after the factor was
+            # registered in the graph (the constant-element pattern of
+            # ``Array.__setitem__``). The factor still appears in the graph's
+            # variable→factor map, but it does not reference this variable
+            # anymore, so info-only callers (graph.info, results text) get
+            # ``None`` and are expected to skip it.
+            return None
+        path = ".".join(path_iter)
         return f"{self.name}.{path}"
 
     def visualize(
@@ -236,3 +246,22 @@ class EPAnalysisFactor(AnalysisFactor):
         cavity Gaussian summary.
         """
         self.analysis._cavity_mean_field = cavity_dist
+
+    def set_model_approx(self, model_approx):
+        """
+        Store the full ``EPMeanField`` on the wrapped ``Analysis``.
+
+        Called by :func:`factor_step` before ``set_cavity_dist`` on
+        each EP iteration. ``set_cavity_dist`` only exposes the cavity
+        ``MeanField`` over this factor's *own* variables; some
+        hierarchical use cases additionally need to inspect the
+        per-factor messages of *sibling* factors (e.g. a "global"
+        Analysis that reads each upstream local fit's posterior on a
+        variable that the global model itself does not formally vary).
+
+        The default implementation just attaches ``model_approx`` to
+        the Analysis as ``_mean_field``. Subclasses (e.g. workspace
+        factors that freeze a subset of priors at sibling-fit means
+        between iterations) can override to add more behaviour.
+        """
+        self.analysis._mean_field = model_approx

--- a/autofit/graphical/declarative/graph.py
+++ b/autofit/graphical/declarative/graph.py
@@ -91,11 +91,13 @@ class DeclarativeGraphFormatter(ABC):
                     factor.distribution_model.name
                 )
             else:
-                names.add(
-                    factor.name_for_variable(
-                        variable
-                    )
-                )
+                name = factor.name_for_variable(variable)
+                if name is None:
+                    # Factor no longer references this variable (typically
+                    # because the variable was fixed to a scalar after graph
+                    # construction). Skip it for info purposes.
+                    continue
+                names.add(name)
 
         return ", ".join(sorted(names))
 

--- a/autofit/graphical/expectation_propagation/optimiser.py
+++ b/autofit/graphical/expectation_propagation/optimiser.py
@@ -104,10 +104,21 @@ class DynamicUpdater(SimplerUpdater):
         )
 
 
-def factor_step(factor_approx, optimiser):
+def factor_step(factor_approx, optimiser, model_approx=None):
     factor = factor_approx.factor
     factor_logger = logging.getLogger(factor.name)
     factor_logger.debug("Optimising...")
+    # Mean-field opt-in: factors that implement ``set_model_approx``
+    # (e.g. ``EPAnalysisFactor``) get the *full* ``EPMeanField`` first.
+    # This is needed by hierarchical factors that have to inspect
+    # sibling factors' messages on variables the current factor's
+    # cavity no longer contains — e.g. variables that were dropped from
+    # this factor's prior model via the constant-element pattern of
+    # ``Array.__setitem__``. Default factors lack the method, so the
+    # call is a no-op for them. ``model_approx`` is None when called
+    # from a context that does not propagate it (older call sites).
+    if hasattr(factor, "set_model_approx") and model_approx is not None:
+        factor.set_model_approx(model_approx)
     # Cavity-message opt-in: factors that implement ``set_cavity_dist``
     # (e.g. ``EPAnalysisFactor``) receive the current cavity distribution
     # before optimisation so their Analysis can read per-variable cavity
@@ -277,8 +288,8 @@ class EPOptimiser:
         except exc.HistoryException as e:
             factor_logger.exception(e)
 
-    def factor_step(self, factor_approx, optimiser):
-        return factor_step(factor_approx, optimiser)
+    def factor_step(self, factor_approx, optimiser, model_approx=None):
+        return factor_step(factor_approx, optimiser, model_approx=model_approx)
 
     def run(
         self,
@@ -323,7 +334,9 @@ class EPOptimiser:
             _should_output = should_output()
             for factor, optimiser in self.factor_optimisers.items():
                 factor_approx = model_approx.factor_approximation(factor)
-                new_model_dist, status = self.factor_step(factor_approx, optimiser)
+                new_model_dist, status = self.factor_step(
+                    factor_approx, optimiser, model_approx=model_approx,
+                )
                 model_approx, status = self.updater.update_model_approx(
                     new_model_dist, factor_approx, model_approx, status
                 )

--- a/autofit/mapper/prior_model/array.py
+++ b/autofit/mapper/prior_model/array.py
@@ -223,6 +223,15 @@ class Array(AbstractPriorModel):
         """
         new_array = Array(self.shape)
         for index in self.indices:
-            new_array[index] = self[index].gaussian_prior_model_for_arguments(arguments)
+            element = self[index]
+            try:
+                new_array[index] = element.gaussian_prior_model_for_arguments(arguments)
+            except AttributeError:
+                # Element is a fixed scalar (float / int / np.ndarray) — the
+                # documented constant-element pattern of ``Array.__setitem__``.
+                # Mirrors the try/except already used in
+                # ``_instance_for_arguments`` so fixed elements pass through
+                # unchanged when the model is rebuilt from posterior samples.
+                new_array[index] = element
 
         return new_array

--- a/test_autofit/mapper/test_array.py
+++ b/test_autofit/mapper/test_array.py
@@ -143,6 +143,32 @@ def test_1d_array_modify_prior(array_1d):
     assert (array_1d.instance_from_prior_medians() == np.array([1.0, 0.0])).all()
 
 
+def test_gaussian_prior_model_for_arguments_with_fixed_element(array):
+    """
+    ``Array.gaussian_prior_model_for_arguments`` is invoked by
+    ``AbstractSearch.optimise`` to build a posterior ``GaussianPrior``
+    model from search arguments. Fixed scalar elements (set via
+    ``arr[i, j] = float``) must pass through unchanged — they have no
+    prior to update from posterior samples. Mirrors the try/except
+    already in ``_instance_for_arguments``.
+    """
+    array[0, 0] = 1.5
+    array[1, 1] = 2.5
+
+    arguments = {
+        prior: af.GaussianPrior(mean=10.0, sigma=0.1)
+        for prior in array.priors
+    }
+    new_array = array.gaussian_prior_model_for_arguments(arguments)
+
+    assert new_array.prior_count == 2
+    instance = new_array.instance_from_prior_medians()
+    assert instance[0, 0] == 1.5
+    assert instance[1, 1] == 2.5
+    assert instance[0, 1] == 10.0
+    assert instance[1, 0] == 10.0
+
+
 def test_tree_flatten(array):
     children, aux = array.tree_flatten()
     assert len(children) == 4


### PR DESCRIPTION
## Summary
PyAutoFit's composition API documents the constant-element pattern for `af.Array` (`arr[i, j] = scalar` to fix that element at a literal value). `Array._instance_for_arguments` already supports this pattern — but `Array.gaussian_prior_model_for_arguments`, called by `AbstractSearch.optimise` to rebuild a posterior prior model from search arguments, was crashing with `AttributeError: 'float' object has no attribute 'gaussian_prior_model_for_arguments'`. The same `try/except` pattern that `_instance_for_arguments` uses is now applied here, so fixed scalar elements pass through unchanged.

On top of that, this PR generalises the EP factor-step machinery so a hierarchical / population-level factor can freeze a subset of its priors at sibling factors' posterior means between EP iterations — the documented use case being a "global" Analysis whose likelihood compares predictions to per-dataset posterior summaries (the "EP message comparison" form). Three small additive changes make this safe:

- `EPAnalysisFactor.set_model_approx(model_approx)` — a new opt-in hook delivering the *full* `EPMeanField` to the factor before each step. (The existing `set_cavity_dist` only exposes the cavity over the factor's own variables, which is insufficient once a variable has been frozen and dropped from the factor's variable list — that variable's posterior message is no longer in the cavity, but it *is* still in `model_approx.factor_mean_field` for sibling factors. `EPOptimiser.run` now propagates `model_approx` through `factor_step`.)
- `AnalysisFactor.name_for_variable` returns `None` (instead of crashing) when a variable has been removed from the factor's prior model.
- `DeclarativeFactorGraph._related_factor_names` skips `None` returns from `name_for_variable` so info-only callers (graph.info, results text) don't trip on the variables that have left a factor.

Plus a unit test reproducing the original crash.

## API Changes
Purely additive. New opt-in `EPAnalysisFactor.set_model_approx(model_approx)` hook called from `factor_step` if the factor implements it; default factors are unaffected. `factor_step` and `EPOptimiser.factor_step` now accept an additional keyword-only `model_approx=None` argument so the optimiser loop can pass the full mean field through. Two info-formatter callsites learn to skip variables that have been removed from a factor's prior model. No symbols renamed, removed, or behaviour-changed for existing factors. See full details below.

## Test Plan
- [x] `pytest test_autofit/mapper/test_array.py` — new test reproduces and verifies the original crash fix
- [x] `pytest test_autofit/graphical -q` — 184 graphical tests pass (no regressions)
- [x] `pytest test_autofit/mapper test_autofit/graphical -q` — 676 combined tests pass
- [x] End-to-end exercised on the cancer-IC50 EP validation script: 10-dataset EP fit drops the global factor's `prior_count` from 93 → 63 (`coef_matrix` + `coef_mean` only) by freezing each `hill_coef[i, j]` at its local Hill factor's posterior mean; recovered `coef_mean` matches simulator truth within 0.2σ on every channel.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- `autofit.graphical.declarative.factor.analysis.EPAnalysisFactor.set_model_approx(model_approx)` — opt-in hook called by `factor_step` before each EP step, receiving the full `EPMeanField`. The default implementation attaches the mean field to the wrapped Analysis as `_mean_field`. Subclasses can override to e.g. freeze a subset of the factor's priors at sibling factors' posterior means before optimisation.

### Changed Signature
- `autofit.graphical.expectation_propagation.optimiser.factor_step(factor_approx, optimiser, model_approx=None)` — added trailing keyword argument `model_approx`. Defaults to `None`; when supplied the function calls `factor.set_model_approx(model_approx)` if the factor implements it. Backwards compatible — existing callers (e.g. `ParallelEPOptimiser`'s pool path) pass two positional args and behave as before.
- `autofit.graphical.expectation_propagation.optimiser.EPOptimiser.factor_step(factor_approx, optimiser, model_approx=None)` — same signature change on the instance method, which now forwards `model_approx` to the module-level function.

### Changed Behaviour
- `autofit.mapper.prior_model.array.Array.gaussian_prior_model_for_arguments` — now mirrors `_instance_for_arguments`: scalar elements (set via `arr[i, j] = float`) pass through unchanged instead of raising `AttributeError`. Fixes a crash on `AbstractSearch.optimise → mapper_from_prior_arguments` when any element has been pinned via the constant-element pattern.
- `autofit.graphical.declarative.factor.analysis.AnalysisFactor.name_for_variable(variable)` — now returns `None` when `prior_model.path_for_prior(variable)` returns `None` (i.e. the variable has been removed from the factor's prior model after registration). Previously raised `TypeError: can only join an iterable`.
- `autofit.graphical.declarative.graph.DeclarativeFactorGraph._related_factor_names(...)` — skips factors whose `name_for_variable` returns `None`, so `graph.info` and `make_results_text` no longer trip on variables that have left a factor.

### Migration
None required — purely additive. Existing factor implementations and existing `Array` usage see no behaviour change unless they were already crashing on the pinned-scalar case.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)