### PR TITLE
Refresh cached SearchUpdater when AbstractSearch.paths is reassigned

### DIFF
--- a/autofit/non_linear/search/abstract_search.py
+++ b/autofit/non_linear/search/abstract_search.py
@@ -936,7 +936,21 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
 
     @property
     def _updater(self):
-        if not hasattr(self, "_search_updater") or self._search_updater is None:
+        # The cached ``SearchUpdater`` must be invalidated whenever
+        # ``self.paths`` is reassigned to a new object — otherwise the
+        # updater holds a stale reference to the old paths and writes
+        # output (samples, visualizations, profiles) under the wrong
+        # directory. This happens routinely when a single search
+        # instance is reused across factor optimisations in the EP
+        # loop: ``AbstractSearch.optimise(factor_approx)`` mutates
+        # ``self.paths = SubDirectoryPaths(...)`` per factor and per EP
+        # iteration, but the updater would otherwise stay pinned to
+        # whichever paths were live the first time ``_updater`` was
+        # accessed. Identity comparison (``is not``) is the right test:
+        # the search instance receives a freshly-constructed
+        # ``SubDirectoryPaths`` each time, never an in-place mutation.
+        cached = getattr(self, "_search_updater", None)
+        if cached is None or cached._paths is not self.paths:
             from autofit.non_linear.search.updater import SearchUpdater
 
             self._search_updater = SearchUpdater(

--- a/test_autofit/non_linear/search/test_abstract_search.py
+++ b/test_autofit/non_linear/search/test_abstract_search.py
@@ -112,6 +112,33 @@ class TestSearchConfig:
         assert "nlive" in dynesty.__identifier_fields__
 
 
+class TestUpdaterPathsRefresh:
+    """
+    The cached ``SearchUpdater`` must be invalidated when ``self.paths``
+    is reassigned to a new object — otherwise output (samples, viz,
+    profiling) keeps writing under the FIRST paths the search ever saw.
+    The EP loop does this routinely:
+    ``AbstractSearch.optimise(factor_approx)`` reassigns ``self.paths``
+    to a fresh ``SubDirectoryPaths`` per factor and per EP iteration.
+    """
+
+    def test__updater_refreshes_when_paths_reassigned(self):
+        search = af.DynestyStatic(name="updater_paths_test_a")
+        first_updater = search._updater
+        first_paths = search.paths
+        # Sanity: cache hit on second access with no path change.
+        assert search._updater is first_updater
+
+        search.paths = af.DirectoryPaths(name="updater_paths_test_b")
+        second_updater = search._updater
+
+        assert second_updater is not first_updater, (
+            "Expected a fresh SearchUpdater after self.paths was reassigned"
+        )
+        assert second_updater._paths is search.paths
+        assert second_updater._paths is not first_paths
+
+
 class TestLabels:
     def test_param_names(self):
         model = af.Model(af.m.MockClassx4)


### PR DESCRIPTION
## Summary
`AbstractSearch._updater` lazy-caches a `SearchUpdater` on first access and previously never invalidated the cache. When the EP loop reuses one search instance across factors and iterations, `AbstractSearch.optimise(factor_approx)` reassigns `self.paths` to a fresh `SubDirectoryPaths` per factor and per EP iteration — but the updater stayed pinned to the very first paths it ever saw. Result: every per-factor / per-iteration sample, visualisation, and profile output silently wrote under the first iteration's directory, with each later iteration overwriting the earlier one. The user-visible symptom is that an `Analysis.Visualizer` only ever produces output under `dataset_<i>/optimization_0/image/`, never under `optimization_1/`, `optimization_2/`, etc.

The fix is one identity check in the `_updater` property: if the cached updater's `_paths` is no longer the search's current `self.paths`, recreate the updater. Identity (`is not`) is the right test — `AbstractSearch.optimise` always assigns a freshly-constructed `SubDirectoryPaths`, never an in-place mutation. Plus a unit test that simulates the EP path-mutation pattern (assign `search.paths = af.DirectoryPaths(...)` and check `_updater._paths is search.paths`).

End-to-end verified on the cancer-IC50 EP validation script: 10 datasets × 3 EP iterations now produces 30 per-iteration Hill-curve fit plots correctly distributed across `dataset_0..9 / optimization_0..2`. Before the fix the same script produced only 10 plots, all in the iter-1 directory.

## API Changes
None — internal change only. Existing callers see no behaviour difference unless they were affected by the bug. The `_updater` property remains a private cached lazily-initialised `SearchUpdater`; the only difference is that it now refreshes when the search's `paths` attribute has been reassigned to a new object.

## Test Plan
- [x] `pytest test_autofit/non_linear/search/test_abstract_search.py::TestUpdaterPathsRefresh` — new test
- [x] `pytest test_autofit/non_linear test_autofit/graphical -q` — 426 tests pass (no regressions)
- [x] End-to-end on cancer-IC50 EP fit (10 datasets × 3 EP iterations): 30 per-iteration `hill_curve_fit.png` plots distributed correctly across `dataset_<i> / optimization_<j>` (was 10 plots, all in `optimization_0`, before the fix)

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- `autofit.non_linear.search.abstract_search.AbstractSearch._updater` — the cached `SearchUpdater` is now invalidated and recreated when `self.paths` is reassigned to a different object. Previously it was created once on first access and reused forever, regardless of subsequent `self.paths` reassignments. Identity comparison (`is not`) is used as the cache-invalidation key.

### Migration
None required — the property is private and the bug fix removes a silent behaviour that no correct caller could have relied on.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)