### PR TITLE
Fix AnalysisFactor.visualize_combined dispatch in FactorGraph

### DIFF
--- a/autofit/graphical/declarative/factor/analysis.py
+++ b/autofit/graphical/declarative/factor/analysis.py
@@ -171,6 +171,61 @@ class AnalysisFactor(AbstractModelFactor):
         """
         self.analysis.visualize_before_fit(paths=paths, model=model)
 
+    def visualize_combined(
+        self,
+        analyses,
+        paths: AbstractPaths,
+        instance: ModelInstance,
+        during_analysis: bool,
+        quick_update: bool = False,
+    ):
+        """
+        Forward a combined-analysis visualisation request to the wrapped analysis's
+        ``Visualizer.visualize_combined``.
+
+        ``FactorGraphModel.visualize_combined`` calls this method on
+        ``model_factors[0]`` and passes the full list of factors as ``analyses``. The
+        ``Analysis.__getattr__`` auto-forwarder skips any visualizer method whose
+        signature contains ``analyses`` (it cannot tell whether the call originated
+        from a single-analysis path or from a combined-analysis path), so without
+        this explicit method the dispatch silently no-ops and combined plots like
+        ``fit_combined.png`` are never written.
+
+        We unwrap each ``AnalysisFactor`` (or ``HierarchicalFactor``) to the
+        underlying ``Analysis`` before calling the visualizer — the static method
+        expects raw analyses with a ``.dataset`` attribute, not factor wrappers.
+        """
+        inner_analyses = [
+            getattr(factor, "analysis", factor) for factor in analyses
+        ]
+        self.analysis.Visualizer.visualize_combined(
+            analyses=inner_analyses,
+            paths=paths,
+            instance=instance,
+            during_analysis=during_analysis,
+            quick_update=quick_update,
+        )
+
+    def visualize_before_fit_combined(
+        self,
+        analyses,
+        paths: AbstractPaths,
+        model: Model,
+    ):
+        """
+        Forward a combined before-fit visualisation request to the wrapped analysis's
+        ``Visualizer.visualize_before_fit_combined``. See ``visualize_combined`` for
+        why this explicit forwarder is required.
+        """
+        inner_analyses = [
+            getattr(factor, "analysis", factor) for factor in analyses
+        ]
+        self.analysis.Visualizer.visualize_before_fit_combined(
+            analyses=inner_analyses,
+            paths=paths,
+            model=model,
+        )
+
     def save_attributes(self, paths: AbstractPaths):
         """
         Save the attributes of the analysis object to a file.


### PR DESCRIPTION
## Summary

Fixes a silent dispatch bug in `af.FactorGraphModel`'s combined-visualization path. `FactorGraphModel.visualize_combined` calls `model_factors[0].visualize_combined(model_factors, ...)`, but `AnalysisFactor` did not define `visualize_combined` itself — so the lookup fell through to `Analysis.__getattr__`'s auto-forwarder, which explicitly skips visualizer methods whose signature contains `analyses` (`"Skipping {item} as this is not a combined analysis"`). The result: **no combined plots were ever produced during multi-dataset fits** — for imaging or interferometer.

This fix adds `visualize_combined` and `visualize_before_fit_combined` directly to `AnalysisFactor`, forwarding to `self.analysis.Visualizer.<method>(analyses=...)` with the wrapper-unwrapped `Analysis` instances. The skip-guard in `Analysis.__getattr__` is unchanged (it still protects single-analysis callers), but the FactorGraph dispatch path now bypasses it cleanly.

## API Changes

<details>
<summary>API Changes</summary>

### Added
- `AnalysisFactor.visualize_combined(analyses, paths, instance, during_analysis, quick_update=False)` — forwards combined-visualization to the wrapped analysis's Visualizer.
- `AnalysisFactor.visualize_before_fit_combined(analyses, paths, model)` — forwards combined before-fit visualization.

### Changed Behaviour
- `af.FactorGraphModel.visualize_combined(...)` now actually invokes the wrapped Visualizer's `visualize_combined` static method. Previously it silently no-op'd.

### Migration
None. Purely additive — no existing API changes.

</details>

## Linked Issues
- PyAutoLabs/autolens_workspace#120

## Test Plan
- [x] Existing graphical/declarative test suite passes (184/184).
- [x] `autolens_workspace_test/scripts/multi/visualization_imaging.py` confirms `fit_combined.png` is now produced via the dispatch chain (was silently MISSING before this fix).
- [x] `autolens_workspace_test/scripts/multi/visualization_interferometer.py` confirms the same for interferometer datacubes (paired with the PyAutoLens visualizer addition shipping on the same branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)