### PR TITLE
fix: stop passing dataset=None to fit_cls when sensitivity Job is complete

### DIFF
--- a/autofit/non_linear/grid/sensitivity/job.py
+++ b/autofit/non_linear/grid/sensitivity/job.py
@@ -156,13 +156,10 @@ class Job(AbstractJob):
         An object comprising the results of the two fits
         """
 
-        if self.is_complete:
-            dataset = None
-        else:
-            dataset = self.simulate_cls(
-                instance=self.simulate_instance,
-                simulate_path=self.paths.image_path.with_name("simulate"),
-            )
+        dataset = self.simulate_cls(
+            instance=self.simulate_instance,
+            simulate_path=self.paths.image_path.with_name("simulate"),
+        )
 
         result = self.base_fit_cls(
             model=self.model,


### PR DESCRIPTION
## Summary
Fixes `AttributeError: 'NoneType' object has no attribute 'data'` on re-runs of sensitivity mapping. `Job.perform()` was producing `dataset = None` as a "skip simulation if job is complete" optimization (commit 41095a0, Oct 2024), then handing that `None` straight to `base_fit_cls` / `perturb_fit_cls`. Consumer `Analysis` classes that unpack `dataset.data` / `dataset.noise_map` in `__init__` — including the user-facing `autofit_workspace/scripts/features/sensitivity_mapping.py` tutorial — crashed.

The fix is a 7-line change: always call `simulate_cls`. Re-runs still skip the expensive non-linear search via `Search.fit`'s load-from-zip path (`paths.restore()` unzips, `paths.is_complete` returns True, `result_via_completed_fit` loads samples from disk). Only the typically-cheap simulator call is no longer optimized away.

The library's own `test_perform_twice` test in `test_autofit/non_linear/grid/test_sensitivity/test_functionality.py` masked the contract issue because the test conftest's `Analysis.__init__` simply stores `dataset` without unpacking — real workspace code unpacks it eagerly.

## API Changes
None — internal change only. `Job.perform()` is library-internal; no public symbols added, removed, renamed, or signature-changed. The behavioural change is "re-runs of sensitivity mapping no longer crash" — strictly a fix.

## Test Plan
- [x] `pytest test_autofit/non_linear/grid/test_sensitivity/` passes 25/25 (incl. `test_perform_twice`).
- [x] `autofit_workspace_test/scripts/database/scrape/sensitivity.py` reproduced the `AttributeError` on re-run pre-fix; passes on a clean two-run cycle post-fix (first run completes, second run hits `is_complete=True` for both cells via zip presence, `Search.fit.restore()` unzips, load path returns).

### Known limitation (out of scope)
If a previous run was killed mid-fit (leaving e.g. `[perturb].zip` present but `[base].zip` missing), the re-run will hit a different failure on that cell: `Search.fit` finds no zip to restore for the missing side, `paths.is_complete` is False, the resume logic kicks in, and `Fitness.check_log_likelihood` raises `SearchException` because the new (non-deterministic) simulator output's FoM doesn't match the persisted partial-fit FoM. That's a separate bug from this one — flagged for follow-up. This PR fixes only the `is_complete=True` path that produced `None`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)