### PR TITLE
fix: exclude __exclude_identifier_fields__ attrs from model.info

### DIFF
--- a/autofit/mapper/prior_model/abstract.py
+++ b/autofit/mapper/prior_model/abstract.py
@@ -1780,6 +1780,26 @@ class AbstractPriorModel(AbstractModel):
         """
         formatter = TextFormatter(line_length=info_whitespace())
 
+        def _excluded_by_parent(path):
+            # Honor each parent's `__exclude_identifier_fields__` here so attributes
+            # that classes have already declared "not part of the model's identity"
+            # (e.g. JAX pytree tokens) do not leak into the human-readable model.info.
+            if not path:
+                return False
+            parent = self
+            for step in path[:-1]:
+                try:
+                    if isinstance(step, int):
+                        parent = parent[step]
+                    elif isinstance(parent, dict):
+                        parent = parent[step]
+                    else:
+                        parent = parent.__dict__[step]
+                except (AttributeError, KeyError, IndexError, TypeError):
+                    return False
+            excluded = getattr(type(parent), "__exclude_identifier_fields__", ())
+            return path[-1] in excluded
+
         for t in find_groups(
             [
                 t
@@ -1788,6 +1808,7 @@ class AbstractPriorModel(AbstractModel):
                     ignore_children=True,
                 )
                 if t[0][-1] not in ("id", "item_number")
+                and not _excluded_by_parent(t[0])
             ],
             limit=1,
         ):

--- a/test_autofit/mapper/test_constant.py
+++ b/test_autofit/mapper/test_constant.py
@@ -185,3 +185,22 @@ def test_is_instance():
     constant = af.Constant(1.0)
 
     assert isinstance(constant, float)
+
+
+class _ClassWithExcludedField:
+    # Mirrors the LightProfileLinear pattern: an internal attribute set in
+    # __init__ that is declared not part of the model identity. The info
+    # property must respect that contract and suppress `token`.
+    __exclude_identifier_fields__ = ("token",)
+
+    def __init__(self, value: float = 0.5):
+        self.value = value
+        self.token = 7
+
+
+def test_info_honors_exclude_identifier_fields():
+    model = af.Collection(thing=_ClassWithExcludedField())
+
+    info = model.info
+    assert "token" not in info
+    assert "value" in info


### PR DESCRIPTION
## Summary

`model.info` was including internal attributes that classes have explicitly declared as **not** part of the model's identity. The most visible example: every `LightProfileLinear` (e.g. linear Sersic) instance has a `pytree_token` int attribute used purely to give a stable `__hash__` / `__eq__` for JAX `pytree` flatten/unflatten round-trips. After SLaM chaining (e.g. `slam_start_here.py`) `model.info` files of later fits contained 40+ `pytree_token N` lines per basis profile — meaningless to a user.

`LightProfileLinear` (and `GridSearch` in PyAutoFit) already declare `__exclude_identifier_fields__`; the `Identifier` hash honors it (`autofit/mapper/identifier.py`) so internal attrs don't perturb the unique_id. `AbstractPriorModel.info` did not honor the same contract — until now.

## API Changes

`__exclude_identifier_fields__` now suppresses an attribute from **both** the unique_id hash and `AbstractPriorModel.info`. Previously it only affected the hash. No public symbols added, removed, or renamed; no signatures changed. Downstream libraries that already declare `__exclude_identifier_fields__` (PyAutoGalaxy `LightProfileLinear`) get the cleaner `model.info` automatically without a code change.

See full details below.

## Test Plan

- [x] New regression test `test_info_honors_exclude_identifier_fields` in `test_autofit/mapper/test_constant.py` — verified to fail without the fix and pass with it.
- [x] Full `pytest test_autofit/` passes.
- [x] End-to-end SLaM run (`PYAUTO_TEST_MODE=3 python autolens_workspace/scripts/guides/modeling/slam_start_here.py`) before/after:
  - All 5 fits' `model.info`: 120 `pytree_token` lines (40 + 40 + 40) → **0**.
  - All 5 fits' unique_id hashes (output dir names) unchanged byte-for-byte.
  - All 5 fits' `model.results` unchanged byte-for-byte.
  - All 5 fits' `model.json` semantically identical (pre-existing key-reordering noise from `set`-based `get_arguments` in PyAutoConf, unrelated to this PR).

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
None.

### Added
None.

### Changed Behaviour
- `AbstractPriorModel.info` (`autofit/mapper/prior_model/abstract.py`) — now suppresses any leaf whose name appears in the parent object's class-level `__exclude_identifier_fields__` tuple. Previously such fields rendered into the info text. The unique_id hash already honored this contract; the two are now consistent.

### Migration
None — change is internal. Downstream libraries that declare `__exclude_identifier_fields__` automatically benefit; those that don't are unaffected.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)