### PR TITLE
feat: JAX-native priors — xp dispatch on value_for / log_prior_from_value / vector_from_unit_vector

### DIFF
--- a/autofit/mapper/prior/abstract.py
+++ b/autofit/mapper/prior/abstract.py
@@ -4,6 +4,8 @@ from abc import ABC, abstractmethod
 from copy import copy
 from typing import Union, Tuple, Optional, Dict
 
+import numpy as np
+
 from autoconf import conf
 
 from autofit.mapper.prior.arithmetic import ArithmeticMixin
@@ -137,7 +139,7 @@ class Prior(Variable, ABC, ArithmeticMixin):
             )
         )
 
-    def value_for(self, unit: float) -> float:
+    def value_for(self, unit, xp=np):
         """
         Return a physical value for a value between 0 and 1 with the transformation
         described by this prior.
@@ -146,6 +148,11 @@ class Prior(Variable, ABC, ArithmeticMixin):
         ----------
         unit
             A unit value between 0 and 1.
+        xp
+            Array-module to dispatch on (``numpy`` or ``jax.numpy``). Default ``numpy``.
+            Concrete subclasses override this method to provide a JAX-traceable
+            closed-form when ``xp`` is ``jax.numpy``; the base path delegates to
+            the message stack which is scipy-backed and NumPy-only.
 
         Returns
         -------

--- a/autofit/mapper/prior/gaussian.py
+++ b/autofit/mapper/prior/gaussian.py
@@ -113,3 +113,21 @@ class GaussianPrior(Prior):
         Return a human-readable string summarizing the GaussianPrior parameters.
         """
         return f"mean = {self.mean}, sigma = {self.sigma}"
+
+    def value_for(self, unit, xp=np):
+        """
+        Map a unit value in [0, 1] to a physical value drawn from this Gaussian prior.
+
+        Parameters
+        ----------
+        unit
+            A unit value between 0 and 1.
+        xp
+            Array-module to dispatch on (``numpy`` or ``jax.numpy``). Default ``numpy``.
+            The NumPy path delegates to the message stack (``erfinv`` via scipy); the
+            JAX path uses the same closed-form via ``jax.scipy.special.erfinv``.
+        """
+        if xp is np:
+            return self.message.value_for(unit)
+        from jax.scipy.special import erfinv
+        return self.mean + self.sigma * xp.sqrt(2.0) * erfinv(2.0 * unit - 1.0)

--- a/autofit/mapper/prior/log_gaussian.py
+++ b/autofit/mapper/prior/log_gaussian.py
@@ -113,7 +113,7 @@ class LogGaussianPrior(Prior):
             id_=self.instance().id,
         )
 
-    def value_for(self, unit: float) -> float:
+    def value_for(self, unit, xp=np):
         """
         Return a physical value for a value between 0 and 1 with the transformation
         described by this prior.
@@ -122,21 +122,33 @@ class LogGaussianPrior(Prior):
         ----------
         unit
             A unit value between 0 and 1.
+        xp
+            Array-module to dispatch on (``numpy`` or ``jax.numpy``). Default ``numpy``.
+            The NumPy path delegates to the message stack; the JAX path uses the
+            closed-form ``exp(mean + sigma * sqrt(2) * erfinv(2*unit - 1))``.
 
         Returns
         -------
         A physical value, mapped from the unit value accoridng to the prior.
         """
-        return super().value_for(unit)
+        if xp is np:
+            return super().value_for(unit)
+        from jax.scipy.special import erfinv
+        log_value = self.mean + self.sigma * xp.sqrt(2.0) * erfinv(2.0 * unit - 1.0)
+        return xp.exp(log_value)
 
     @property
     def parameter_string(self) -> str:
         return f"mean = {self.mean}, sigma = {self.sigma}"
 
     def log_prior_from_value(self, value, xp=np):
-        if value <= 0:
-            return float("-inf")
+        if xp is np:
+            if value <= 0:
+                return float("-inf")
+            return self.message.base_message.log_prior_from_value(
+                np.log(value)
+            ) - np.log(value)
 
-        return self.message.base_message.log_prior_from_value(np.log(value)) - np.log(
-            value
-        )
+        log_value = xp.log(value)
+        base_log_prior = (log_value - self.mean) ** 2 / (2 * self.sigma ** 2)
+        return xp.where(value > 0, base_log_prior - log_value, xp.inf)

--- a/autofit/mapper/prior/log_uniform.py
+++ b/autofit/mapper/prior/log_uniform.py
@@ -121,10 +121,12 @@ class LogUniformPrior(Prior):
         ----------
         value : float
             The physical value of this prior's corresponding parameter in a `NonLinearSearch` sample.
+        xp
+            Array-module to dispatch on (``numpy`` or ``jax.numpy``). Default ``numpy``.
         """
         return 1.0 / value
 
-    def value_for(self, unit: float) -> float:
+    def value_for(self, unit, xp=np):
         """
         Returns a physical value from an input unit value according to the limits of the log10 uniform prior.
 
@@ -132,6 +134,10 @@ class LogUniformPrior(Prior):
         ----------
         unit
             A unit value between 0 and 1.
+        xp
+            Array-module to dispatch on (``numpy`` or ``jax.numpy``). Default ``numpy``.
+            The NumPy path delegates to the message stack (scipy-backed); the JAX
+            path uses the closed-form ``lower * (upper / lower) ** unit``.
 
         Returns
         -------
@@ -145,7 +151,9 @@ class LogUniformPrior(Prior):
 
         physical_value = prior.value_for(unit=0.2)
         """
-        return super().value_for(unit)
+        if xp is np:
+            return super().value_for(unit)
+        return self.lower_limit * (self.upper_limit / self.lower_limit) ** unit
 
     def dict(self) -> dict:
         """

--- a/autofit/mapper/prior/truncated_gaussian.py
+++ b/autofit/mapper/prior/truncated_gaussian.py
@@ -1,5 +1,7 @@
 from typing import Optional, Tuple
 
+import numpy as np
+
 from autofit.messages.truncated_normal import TruncatedNormalMessage
 from .abstract import Prior
 
@@ -130,3 +132,32 @@ class TruncatedGaussianPrior(Prior):
                 f"lower_limit = {self.lower_limit}, "
                 f"upper_limit = {self.upper_limit}"
                 )
+
+    def value_for(self, unit, xp=np):
+        """
+        Map a unit value in [0, 1] to a physical value drawn from this truncated Gaussian prior.
+
+        Parameters
+        ----------
+        unit
+            A unit value between 0 and 1.
+        xp
+            Array-module to dispatch on (``numpy`` or ``jax.numpy``). Default ``numpy``.
+            Both paths share the standard truncated-normal inverse-CDF construction
+            via ``norm.cdf`` / ``norm.ppf`` from the matching ``scipy.stats`` /
+            ``jax.scipy.stats`` namespace.
+        """
+        if xp is np:
+            from scipy.stats import norm
+        else:
+            from jax.scipy.stats import norm
+
+        a = (self.lower_limit - self.mean) / self.sigma
+        b = (self.upper_limit - self.mean) / self.sigma
+
+        lower_cdf = norm.cdf(a)
+        upper_cdf = norm.cdf(b)
+        truncated_cdf = lower_cdf + unit * (upper_cdf - lower_cdf)
+
+        x_standard = norm.ppf(truncated_cdf)
+        return self.mean + self.sigma * x_standard

--- a/autofit/mapper/prior/uniform.py
+++ b/autofit/mapper/prior/uniform.py
@@ -132,7 +132,7 @@ class UniformPrior(Prior):
         """A human-readable string summarizing the prior's lower and upper limits."""
         return f"lower_limit = {self.lower_limit}, upper_limit = {self.upper_limit}"
 
-    def value_for(self, unit: float) -> float:
+    def value_for(self, unit, xp=np):
         """
         Returns a physical value from an input unit value according to the limits of the uniform prior.
 
@@ -140,6 +140,11 @@ class UniformPrior(Prior):
         ----------
         unit
             A unit value between 0 and 1.
+        xp
+            Array-module to dispatch on (``numpy`` or ``jax.numpy``). Default ``numpy``.
+            The NumPy path preserves the historical ``float(round(..., 14))`` snap
+            (used as a hash key in ``model.priors``); the JAX path uses the
+            closed-form ``lower + (upper - lower) * unit`` so the trace stays symbolic.
 
         Returns
         -------
@@ -153,9 +158,11 @@ class UniformPrior(Prior):
 
         physical_value = prior.value_for(unit=0.2)
         """
-        return float(
-            round(super().value_for(unit), 14)
-        )
+        if xp is np:
+            return float(
+                round(super().value_for(unit), 14)
+            )
+        return self.lower_limit + (self.upper_limit - self.lower_limit) * unit
 
     def log_prior_from_value(self, value, xp=np):
         """
@@ -166,7 +173,10 @@ class UniformPrior(Prior):
 
         For a UniformPrior this is always zero, provided the value is between the lower and upper limit.
         """
-        return 0.0
+        if xp is np:
+            return 0.0
+        in_bounds = (value >= self.lower_limit) & (value <= self.upper_limit)
+        return xp.where(in_bounds, xp.zeros_like(value), -xp.inf)
 
     @property
     def limits(self) -> Tuple[float, float]:

--- a/autofit/mapper/prior_model/abstract.py
+++ b/autofit/mapper/prior_model/abstract.py
@@ -645,26 +645,41 @@ class AbstractPriorModel(AbstractModel):
         """Unique priors sorted by their id, defining the canonical parameter ordering."""
         return [prior for _, prior in self.prior_tuples_ordered_by_id]
 
-    def vector_from_unit_vector(self, unit_vector):
+    def vector_from_unit_vector(self, unit_vector, xp=np):
         """
         Parameters
         ----------
         unit_vector: [float]
             A unit hypercube vector
+        xp
+            Array-module to dispatch on (``numpy`` or ``jax.numpy``). Default ``numpy``.
+            When ``xp is numpy`` the return type stays a plain ``list`` to preserve
+            the existing contract used by Nautilus / Dynesty / Emcee / Zeus. When
+            ``xp is jax.numpy`` an ``xp.stack`` 1-D array is returned so the call
+            is JIT-traceable end-to-end.
 
         Returns
         -------
         values: [float]
             A vector with values output by priors
         """
-        return list(
-            map(
-                lambda prior_tuple, unit: prior_tuple.prior.value_for(
-                    unit,
-                ),
-                self.prior_tuples_ordered_by_id,
-                unit_vector,
+        if xp is np:
+            return list(
+                map(
+                    lambda prior_tuple, unit: prior_tuple.prior.value_for(
+                        unit,
+                    ),
+                    self.prior_tuples_ordered_by_id,
+                    unit_vector,
+                )
             )
+        return xp.stack(
+            [
+                prior_tuple.prior.value_for(unit, xp=xp)
+                for prior_tuple, unit in zip(
+                    self.prior_tuples_ordered_by_id, unit_vector
+                )
+            ]
         )
 
     def random_unit_vector_within_limits(

--- a/autofit/messages/normal.py
+++ b/autofit/messages/normal.py
@@ -399,7 +399,7 @@ class NormalMessage(AbstractMessage):
 
     __default_fields__ = ("log_norm", "id_")
 
-    def value_for(self, unit: float) -> float:
+    def value_for(self, unit, xp=np):
         """
         Map a unit value in [0, 1] to a physical value drawn from this Gaussian prior.
 
@@ -407,6 +407,8 @@ class NormalMessage(AbstractMessage):
         ----------
         unit
             A unit value between 0 and 1 representing a uniform draw.
+        xp
+            Array-module to dispatch on (``numpy`` or ``jax.numpy``). Default ``numpy``.
 
         Returns
         -------
@@ -417,15 +419,13 @@ class NormalMessage(AbstractMessage):
         >>> prior = af.GaussianPrior(mean=1.0, sigma=2.0)
         >>> physical_value = prior.value_for(unit=0.5)
         """
-        if isinstance(unit, (np.ndarray, np.float64, float, int, list)):
-            from scipy.special import erfinv as scipy_erfinv
-            inv = scipy_erfinv(1 - 2.0 * (1.0 - unit))
+        if xp is np:
+            from scipy.special import erfinv
         else:
-            import jax.numpy as jnp
-            from jax._src.scipy.special import erfinv
-            inv = erfinv(1 - 2.0 * (1.0 - unit))
+            from jax.scipy.special import erfinv
 
-        return self.mean + (self.sigma * np.sqrt(2) * inv)
+        inv = erfinv(2.0 * unit - 1.0)
+        return self.mean + self.sigma * xp.sqrt(2.0) * inv
 
     def log_prior_from_value(self, value: float, xp=np) -> float:
         """

--- a/autofit/messages/truncated_normal.py
+++ b/autofit/messages/truncated_normal.py
@@ -440,7 +440,7 @@ class TruncatedNormalMessage(AbstractMessage):
 
     __default_fields__ = ("log_norm", "id_")
 
-    def value_for(self, unit: float) -> float:
+    def value_for(self, unit, xp=np):
         """
         Map a unit value in [0, 1] to a physical value drawn from this truncated Gaussian prior.
 
@@ -451,6 +451,8 @@ class TruncatedNormalMessage(AbstractMessage):
         ----------
         unit
             A unit value between 0 and 1 representing a uniform draw.
+        xp
+            Array-module to dispatch on (``numpy`` or ``jax.numpy``). Default ``numpy``.
 
         Returns
         -------
@@ -461,18 +463,18 @@ class TruncatedNormalMessage(AbstractMessage):
         >>> prior = af.TruncatedNormalMessage(mean=1.0, sigma=2.0, lower_limit=0.0, upper_limit=2.0)
         >>> physical_value = prior.value_for(unit=0.5)
         """
-        from scipy.stats import norm
+        if xp is np:
+            from scipy.stats import norm
+        else:
+            from jax.scipy.stats import norm
 
-        # Standardized truncation bounds
         a = (self.lower_limit - self.mean) / self.sigma
         b = (self.upper_limit - self.mean) / self.sigma
 
-        # Interpolate unit into [Phi(a), Phi(b)]
         lower_cdf = norm.cdf(a)
         upper_cdf = norm.cdf(b)
         truncated_cdf = lower_cdf + unit * (upper_cdf - lower_cdf)
 
-        # Map back to x using inverse CDF, then rescale
         x_standard = norm.ppf(truncated_cdf)
         return self.mean + self.sigma * x_standard
 


### PR DESCRIPTION
## Summary
Adds a `xp=np` kwarg to every concrete `Prior.value_for`, every `Prior.log_prior_from_value`, the underlying `NormalMessage` / `TruncatedNormalMessage` `value_for`, and `Model.vector_from_unit_vector`, so cube → physical mapping and prior log-density can run inside a `jax.jit` boundary without a `jax.pure_callback` host roundtrip. NumPy paths remain unchanged via `xp=np` defaults — all existing callers (Nautilus, Dynesty, Emcee, Zeus, EP) keep working untouched. Closes #1262 (Phase 0 of the `nss_first_class_sampler` roadmap).

## API Changes
Added an `xp=np` keyword to `Prior.value_for`, `Prior.log_prior_from_value`, `Model.vector_from_unit_vector`, `NormalMessage.value_for`, and `TruncatedNormalMessage.value_for`. Default `xp=np` preserves every existing NumPy caller. Each of the five concrete `Prior` subclasses (`UniformPrior`, `LogUniformPrior`, `GaussianPrior`, `TruncatedGaussianPrior`, `LogGaussianPrior`) now overrides `value_for` with a closed-form JAX path that runs symbolically under `jax.jit`. `NormalMessage.value_for` replaces the legacy `isinstance(unit, np.ndarray)` runtime sniff with explicit `xp` dispatch.
See full details below.

## Test Plan
- [x] `pytest test_autofit` — 1242 passed, 1 skipped on this branch
- [x] `autofit_workspace_test/scripts/jax_assertions/priors_xp_dispatch.py` — 24 new assertions pass (added in matching workspace_test PR)
- [x] `autofit_workspace_test/scripts/jax_assertions/fitness_dispatch.py` — still passes
- [x] `autofit_workspace_test/scripts/jax_assertions/nested.py` — still passes
- [x] `autofit_workspace_test/scripts/jax_assertions/enable_pytrees.py` — still passes
- [x] `autofit_workspace_test/scripts/jax_assertions/pytrees.py` — still passes
- [x] `autofit_workspace_test/scripts/graphical/ep.py` — full EP loop runs to completion
- [x] `autofit_workspace/scripts/searches/{mcmc,mle,nest,start_point}.py` — all pass

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- `Prior.value_for(unit, xp=np)` — new `xp` kwarg on the base method (`autofit/mapper/prior/abstract.py`)
- `UniformPrior.value_for(unit, xp=np)` — new `xp` kwarg
- `LogUniformPrior.value_for(unit, xp=np)` — new `xp` kwarg
- `GaussianPrior.value_for(unit, xp=np)` — new override (previously inherited from base)
- `TruncatedGaussianPrior.value_for(unit, xp=np)` — new override
- `LogGaussianPrior.value_for(unit, xp=np)` — new `xp` kwarg
- `AbstractPriorModel.vector_from_unit_vector(unit_vector, xp=np)` — new `xp` kwarg
- `NormalMessage.value_for(unit, xp=np)` — new `xp` kwarg replacing `isinstance` dispatch
- `TruncatedNormalMessage.value_for(unit, xp=np)` — new `xp` kwarg

### Changed Behaviour
- `Prior.value_for(unit, xp=jnp)` — the five concrete subclasses now produce a JAX-traceable closed-form when `xp` is `jax.numpy` (`UniformPrior` linear, `LogUniformPrior` `lower * (upper / lower) ** unit`, `GaussianPrior` / `LogGaussianPrior` via `jax.scipy.special.erfinv`, `TruncatedGaussianPrior` via `jax.scipy.stats.norm.{cdf,ppf}`).
- `UniformPrior.log_prior_from_value(value, xp=jnp)` — now returns `xp.where(in_bounds, 0, -xp.inf)` instead of `0.0`.
- `Model.vector_from_unit_vector(unit, xp=jnp)` — returns a 1-D `xp.stack` array instead of a Python list (NumPy path unchanged).
- `NormalMessage.value_for` — explicit `xp` dispatch replacing the legacy `isinstance(unit, np.ndarray)` runtime sniff; behaviour is identical for both NumPy and JAX inputs.

### Migration
None required. Default `xp=np` preserves all existing call sites. New callers wanting JAX traceability pass `xp=jax.numpy` explicitly:

Before (still works):
```python
physical = model.vector_from_unit_vector(unit_vector)
```

After (new JAX path):
```python
import jax, jax.numpy as jnp
@jax.jit
def cube_to_phys(unit):
    return model.vector_from_unit_vector(unit, xp=jnp)
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)