### PR TITLE
Disable model.graph output by default

### DIFF
--- a/autofit/config/output.yaml
+++ b/autofit/config/output.yaml
@@ -100,3 +100,5 @@ data: true # `data.json`: The value of every data point in the data.
 noise_map: true # `noise_map.json`: The value of every RMS noise map value.
 
 search_log: true # `search.log`: logging produced whilst running the fit method
+
+model_graph: false # `model.graph`: graphical-model factor graph summary. Only meaningful for graphical models (autofit.graphical); empty for ordinary PriorModel/Collection fits, so disabled by default.

--- a/autofit/non_linear/paths/directory.py
+++ b/autofit/non_linear/paths/directory.py
@@ -470,11 +470,9 @@ class DirectoryPaths(AbstractPaths):
         with open_(self.output_path / "model.info", "w+") as f:
             f.write(model.info)
 
-        try:
+        if should_output("model_graph") and hasattr(model, "graph_info"):
             with open_(self.output_path / "model.graph", "w+") as f:
-                f.write( model.graph_info)
-        except AttributeError:
-            pass
+                f.write(model.graph_info)
 
     def _save_model_start_point(self, info):
         """


### PR DESCRIPTION
## Summary

`model.graph` is now gated by a new `model_graph` flag in `autofit/config/output.yaml` (default `false`). Previously the file was always opened — and stayed empty for ordinary `PriorModel`/`Collection` fits because `model.graph_info` raised `AttributeError` after the file had already been created. This left an empty `model.graph` in every fit output folder.

The `metadata` file is intentionally unchanged: it is the sentinel `Aggregator.from_directory()` (autofit/aggregator/aggregator.py:177) uses to detect search output directories, and `SearchOutput.__init__` parses its `name=...` / `non_linear_search=...` lines into attributes (autofit/aggregator/search_output.py:207-217).

## API Changes

- New config key `output.model_graph` (default `false`) in `autofit/config/output.yaml`.
- Default behaviour change: `model.graph` is no longer written for any fit unless `model_graph: true` is set in the user's `output.yaml`. Graphical-model users who want the factor-graph summary file must opt in.

No public Python symbols are added, removed, renamed, or changed in signature.

See full details below.

## Test Plan

- [ ] `pytest test_autofit/non_linear/paths -x` passes.
- [ ] Run a small workspace fit (e.g. `autofit_workspace/scripts/overview/simple/fit.py`) — confirm `model.graph` is NOT present in the output folder.
- [ ] Set `model_graph: true` in `output.yaml` and run a graphical-model fit; confirm `model.graph` is written with the factor-graph summary.
- [ ] Aggregator regression: `Aggregator.from_directory(...)` still discovers fits (sentinel `metadata` file is unchanged).

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- Config key `output.model_graph` in `autofit/config/output.yaml` — boolean, default `false`. When `true`, `_save_model_info` writes `model.graph` for models that expose a `graph_info` attribute.

### Changed Behaviour
- `DirectoryPaths._save_model_info` no longer creates an empty `model.graph` for non-graphical models. The write is now gated by `should_output("model_graph") and hasattr(model, "graph_info")`. Replaces the previous `try/except AttributeError` block that opened the file before checking for the attribute.

### Removed
- None.

### Migration
- Default users: no migration — empty `model.graph` files simply stop being produced.
- Graphical-model users who relied on `model.graph` being present: add `model_graph: true` to your workspace's `config/output.yaml`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)