### PR TITLE
fix: add quick_update kwarg to VisualizerExample.visualize_combined

### DIFF
--- a/autofit/example/visualize.py
+++ b/autofit/example/visualize.py
@@ -179,6 +179,7 @@ class VisualizerExample(af.Visualizer):
         paths: af.DirectoryPaths,
         instance: af.ModelInstance,
         during_analysis: bool,
+        quick_update: bool = False,
     ):
         """
         Multiple instances of the `Analysis` class can be summed together, meaning that the model is fitted to all


### PR DESCRIPTION
## Summary
Adds the \`quick_update: bool = False\` kwarg to \`VisualizerExample.visualize_combined\` (\`autofit/example/visualize.py:177\`). Mirrors the plumbing introduced by commit a1e360567 ("Fix \`AnalysisFactor.visualize_combined\` dispatch in FactorGraph") which updated the base \`Visualizer.visualize_combined\` and \`AnalysisFactor.visualize_combined\` to accept and forward \`quick_update\` — but missed \`VisualizerExample\`.

Today any \`FactorGraphModel\` fit that uses the example Analysis class crashes on the first quick-update iteration with \`TypeError: VisualizerExample.visualize_combined() got an unexpected keyword argument 'quick_update'\`. This broke four integration / tutorial scripts:

- \`autofit_workspace_test/scripts/graphical/simultaneous.py\`
- \`autofit_workspace_test/scripts/graphical/hierarchical.py\`
- \`autofit_workspace/scripts/features/graphical_models.py\`
- \`autofit_workspace/scripts/cookbooks/multiple_datasets.py\`

The change is purely additive — the kwarg defaults to \`False\` and the body remains \`pass\` (the example does not implement combined visualization).

A matching one-line fix for \`PyAutoGalaxy/autogalaxy/imaging/model/visualizer.py\` ships in parallel on the same branch name in [PyAutoLabs/PyAutoGalaxy#414](https://github.com/PyAutoLabs/PyAutoGalaxy/pull/414).

This was a follow-up surfaced during the validation phase of #1262 (priors-jax-native). The other follow-up surfaced in that work — a deeper \`log_prior_from_value\` sign-convention bug across the Gaussian-family priors — is tracked separately in #1266.

## API Changes
Added \`quick_update: bool = False\` kwarg to \`VisualizerExample.visualize_combined\`. Purely additive — existing call sites still work because the kwarg has a default.
See full details below.

## Test Plan
- [x] \`pytest test_autofit\` — 1242 passed, 1 skipped on this branch (full sweep)
- [x] \`pytest test_autofit/graphical\` — 184 passed (covers \`AnalysisFactor.visualize_combined\` forwarder)
- [x] \`autofit_workspace_test/scripts/graphical/simultaneous.py\` — previously broken, now passes
- [x] \`autofit_workspace_test/scripts/graphical/hierarchical.py\` — previously broken, now passes
- [x] \`autofit_workspace/scripts/features/graphical_models.py\` — previously broken, now passes
- [x] \`autofit_workspace/scripts/cookbooks/multiple_datasets.py\` — previously broken, now passes

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- \`VisualizerExample.visualize_combined(analyses, paths, instance, during_analysis, quick_update=False)\` — new \`quick_update\` kwarg matching the base class signature.

### Migration
None required. Pure addition with a default value.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)