### PR TITLE
fix: log_prior_from_value sign convention — density form across Prior subclasses

### DIFF
--- a/autofit/mapper/prior/log_gaussian.py
+++ b/autofit/mapper/prior/log_gaussian.py
@@ -142,6 +142,17 @@ class LogGaussianPrior(Prior):
         return f"mean = {self.mean}, sigma = {self.sigma}"
 
     def log_prior_from_value(self, value, xp=np):
+        """
+        Compute the log prior density of a given physical value under this log-Gaussian prior.
+
+        The change-of-variables Jacobian for the log transform contributes
+        ``-log(value)``; the underlying Gaussian-in-log-space contributes the
+        density-form quadratic via ``NormalMessage.log_prior_from_value``.
+        Out-of-support (``value <= 0``) returns ``-inf``.
+
+        See ``NormalMessage.log_prior_from_value`` for the constant-dropping
+        convention.
+        """
         if xp is np:
             if value <= 0:
                 return float("-inf")
@@ -150,5 +161,5 @@ class LogGaussianPrior(Prior):
             ) - np.log(value)
 
         log_value = xp.log(value)
-        base_log_prior = (log_value - self.mean) ** 2 / (2 * self.sigma ** 2)
-        return xp.where(value > 0, base_log_prior - log_value, xp.inf)
+        base_log_prior = -((log_value - self.mean) ** 2) / (2 * self.sigma ** 2)
+        return xp.where(value > 0, base_log_prior - log_value, -xp.inf)

--- a/autofit/mapper/prior/log_uniform.py
+++ b/autofit/mapper/prior/log_uniform.py
@@ -110,21 +110,36 @@ class LogUniformPrior(Prior):
 
     __identifier_fields__ = ("lower_limit", "upper_limit")
 
-    def log_prior_from_value(self, value, xp=np) -> float:
+    def log_prior_from_value(self, value, xp=np):
         """
-        Returns the log prior of a physical value, so the log likelihood of a model evaluation can be converted to a
-        posterior as log_prior + log_likelihood.
+        Returns the log prior density at a physical value, used by Emcee / Zeus
+        / MLE searches to form a log-posterior via ``log_likelihood + sum(log_priors)``.
 
-        This is used by certain non-linear searches (e.g. Emcee) in the log likelihood function evaluation.
+        For a log-uniform prior on ``[lower_limit, upper_limit]`` the density is
+        ``p(x) = 1 / (x * log(upper_limit / lower_limit))``, giving
+        ``log p(x) = -log(x) - log(log(upper_limit / lower_limit))``. The
+        normalisation constant ``-log(log(upper_limit / lower_limit))`` is
+        dropped (it is irrelevant to posterior shape), matching the convention
+        used by ``UniformPrior.log_prior_from_value`` which drops ``-log(b - a)``
+        to return ``0.0``.
+
+        Out-of-support (``value`` outside ``[lower_limit, upper_limit]``) returns
+        ``-inf`` on the JAX path; the NumPy path returns ``-log(value)`` without
+        bounds-checking to mirror the existing ``UniformPrior`` NumPy semantics
+        which trust the search to stay inside bounds.
 
         Parameters
         ----------
-        value : float
-            The physical value of this prior's corresponding parameter in a `NonLinearSearch` sample.
+        value
+            The physical value of this prior's corresponding parameter in a
+            ``NonLinearSearch`` sample.
         xp
             Array-module to dispatch on (``numpy`` or ``jax.numpy``). Default ``numpy``.
         """
-        return 1.0 / value
+        if xp is np:
+            return -np.log(value)
+        in_bounds = (value >= self.lower_limit) & (value <= self.upper_limit)
+        return xp.where(in_bounds, -xp.log(value), -xp.inf)
 
     def value_for(self, unit, xp=np):
         """

--- a/autofit/messages/normal.py
+++ b/autofit/messages/normal.py
@@ -427,22 +427,33 @@ class NormalMessage(AbstractMessage):
         inv = erfinv(2.0 * unit - 1.0)
         return self.mean + self.sigma * xp.sqrt(2.0) * inv
 
-    def log_prior_from_value(self, value: float, xp=np) -> float:
+    def log_prior_from_value(self, value, xp=np):
         """
-        Compute the log prior probability of a given physical value under this Gaussian prior.
+        Compute the log prior density of a given physical value under this Gaussian prior.
 
-        Used to convert a likelihood to a posterior in non-linear searches (e.g., Emcee).
+        Returns ``log p(value)`` in density form: negative for values far from
+        the mean, zero at the mode. ``Fitness._call`` adds this directly to the
+        log-likelihood to form ``log_posterior = log_likelihood + sum(log_priors)``,
+        which Emcee / Zeus / MLE-Drawer / LBFGS then maximise (LBFGS via
+        ``-2 * figure_of_merit`` minimisation).
+
+        The constant ``-log(sigma * sqrt(2*pi))`` is dropped (it is a true
+        constant in the prior, irrelevant to posterior shape), matching the
+        convention used by ``UniformPrior.log_prior_from_value`` which drops
+        ``-log(b - a)`` to return ``0.0``.
 
         Parameters
         ----------
         value
             A physical parameter value for which the log prior is evaluated.
+        xp
+            Array-module to dispatch on (``numpy`` or ``jax.numpy``). Default ``numpy``.
 
         Returns
         -------
-        The log prior probability of the given value.
+        The log prior density at the given value, up to an additive constant.
         """
-        return (value - self.mean) ** 2.0 / (2 * self.sigma**2.0)
+        return -((value - self.mean) ** 2.0) / (2 * self.sigma**2.0)
 
     def __str__(self):
         """

--- a/test_autofit/mapper/model/test_model_mapper.py
+++ b/test_autofit/mapper/model/test_model_mapper.py
@@ -432,7 +432,11 @@ class TestInstances:
 
         log_prior_list = mapper.log_prior_list_from_vector(vector=[0.0, 5.0])
 
-        assert log_prior_list == [0.125, 0.2]
+        # Density-form log-priors (PyAutoLabs/PyAutoFit#1266):
+        #   Gaussian(mean=1, sigma=2) at value=0:   -(0-1)**2 / (2*4) = -0.125
+        #   LogUniform(...)            at value=5:  -log(5)
+        assert log_prior_list[0] == -0.125
+        assert log_prior_list[1] == pytest.approx(-np.log(5.0), 1.0e-12)
 
     def test_random_unit_vector_within_limits(self):
         mapper = af.ModelMapper()

--- a/test_autofit/mapper/prior/test_prior.py
+++ b/test_autofit/mapper/prior/test_prior.py
@@ -1,5 +1,6 @@
 import math
 
+import numpy as np
 import pytest
 
 import autofit as af
@@ -190,33 +191,30 @@ class TestLogUniformPrior:
         assert log_uniform_half.value_for(0.5) == pytest.approx(0.70710678118, 1.0e-4)
 
     def test__log_prior_from_value(self):
-        gaussian_simple = af.LogUniformPrior(lower_limit=1e-8, upper_limit=1.0)
+        # LogUniformPrior log-density: -log(value), dropping the normalisation
+        # constant -log(log(upper / lower)). Consistent with UniformPrior's
+        # convention of returning 0.0 (dropping -log(b - a)).
+        log_uniform = af.LogUniformPrior(lower_limit=1e-8, upper_limit=1.0)
 
-        log_prior = gaussian_simple.log_prior_from_value(value=1.0)
+        assert log_uniform.log_prior_from_value(value=1.0) == 0.0
+        assert log_uniform.log_prior_from_value(value=2.0) == pytest.approx(
+            -np.log(2.0), 1.0e-12
+        )
+        assert log_uniform.log_prior_from_value(value=4.0) == pytest.approx(
+            -np.log(4.0), 1.0e-12
+        )
 
-        assert log_prior == 1.0
+        # The normalisation constant being dropped means the returned values
+        # do NOT depend on the (lower_limit, upper_limit) pair — only on `value`.
+        log_uniform = af.LogUniformPrior(lower_limit=50.0, upper_limit=100.0)
 
-        log_prior = gaussian_simple.log_prior_from_value(value=2.0)
-
-        assert log_prior == 0.5
-
-        log_prior = gaussian_simple.log_prior_from_value(value=4.0)
-
-        assert log_prior == 0.25
-
-        gaussian_simple = af.LogUniformPrior(lower_limit=50.0, upper_limit=100.0)
-
-        log_prior = gaussian_simple.log_prior_from_value(value=1.0)
-
-        assert log_prior == 1.0
-
-        log_prior = gaussian_simple.log_prior_from_value(value=2.0)
-
-        assert log_prior == 0.5
-
-        log_prior = gaussian_simple.log_prior_from_value(value=4.0)
-
-        assert log_prior == 0.25
+        assert log_uniform.log_prior_from_value(value=1.0) == 0.0
+        assert log_uniform.log_prior_from_value(value=2.0) == pytest.approx(
+            -np.log(2.0), 1.0e-12
+        )
+        assert log_uniform.log_prior_from_value(value=4.0) == pytest.approx(
+            -np.log(4.0), 1.0e-12
+        )
 
     def test__lower_limit_zero_or_below_raises_error(self):
         with pytest.raises(exc.PriorException):
@@ -244,13 +242,16 @@ class TestGaussianPrior:
     @pytest.mark.parametrize(
         "mean, sigma, value, expected",
         [
+            # Density-form log-prior: -(value - mean)**2 / (2 * sigma**2), with
+            # the -log(sigma * sqrt(2 * pi)) normalisation constant dropped.
+            # Maximum at value == mean (returns 0), negative elsewhere.
             (0.0, 1.0, 0.0, 0.0),
-            (0.0, 1.0, 1.0, 0.5),
-            (0.0, 1.0, 2.0, 2.0),
-            (1.0, 2.0, 0.0, 0.125),
+            (0.0, 1.0, 1.0, -0.5),
+            (0.0, 1.0, 2.0, -2.0),
+            (1.0, 2.0, 0.0, -0.125),
             (1.0, 2.0, 1.0, 0.0),
-            (1.0, 2.0, 2.0, 0.125),
-            (30.0, 60.0, 2.0, pytest.approx(0.108888, 1.0e-4)),
+            (1.0, 2.0, 2.0, -0.125),
+            (30.0, 60.0, 2.0, pytest.approx(-0.108888, 1.0e-4)),
         ],
     )
     def test__log_prior_from_value(self, mean, sigma, value, expected):
@@ -265,4 +266,10 @@ def test_log_gaussian_prior_log_prior_from_value():
     )
 
     assert log_gaussian_prior.log_prior_from_value(value=0.0) == float("-inf")
-    assert log_gaussian_prior.log_prior_from_value(value=0.5) == 0.9333736875190459
+    # Density form: -(log(value) - mean)**2 / (2 * sigma**2) - log(value),
+    # where the second term is the Jacobian of the log-space transform.
+    log_half = math.log(0.5)
+    expected = -(log_half ** 2) / 2.0 - log_half
+    assert log_gaussian_prior.log_prior_from_value(value=0.5) == pytest.approx(
+        expected, 1.0e-12
+    )


### PR DESCRIPTION
## Summary

Switches `Prior.log_prior_from_value` to return log p(x) in **density form** (negative for low-density values, zero at the mode) across `NormalMessage` (Gaussian/TruncatedGaussian base), `LogGaussianPrior`, and `LogUniformPrior`. Closes #1266.

**This is a behaviour-change fix that affects every MCMC / MLE fit with a non-uniform prior.** Read the migration warning below before pulling.

### What was broken

`Fitness._call` (`autofit/non_linear/fitness.py:200`) computes:

```python
figure_of_merit = log_likelihood + sum(log_priors)
```

Emcee / Zeus / MLE-Drawer maximise `figure_of_merit`; LBFGS / BFGS minimise `-2 * figure_of_merit`. Both interpretations assume `log_priors` is in **density form** so that the maximand equals the log-posterior. But the existing concrete bodies returned **cost form** (`+½z²` for Gaussian, `1/value` for LogUniform), inverting the sign of the prior contribution. Adding `+cost` to `log_likelihood` makes the maximand `log_lik − log_prior_density`, which pushes MCMC samples *away* from prior modes and makes LBFGS *minimise* the prior-mean direction.

Empirically demonstrated by two regression scripts added in the matching `autofit_workspace_test` PR — Emcee with a flat log-likelihood and `GaussianPrior(mean=5, sigma=1)` diverges to ~10^146 (should cluster at 5.0); LBFGS converges to 8e143 (should converge to 5.0). After this fix both behave correctly.

This regression has existed since commit `db4016db42` (4 May 2022, "refactored priors into package") for `LogUniformPrior` and pre-dates that for the Gaussian family. Most production usage on this codebase is nested-sampler-based, which is why it stayed hidden — `prior_transform`-based samplers (Dynesty / Nautilus) bypass `log_prior_from_value` entirely.

## API Changes

`Prior.log_prior_from_value` is a behaviour change, not a signature change. The kwarg surface is unchanged (`(value, xp=np)`). Returned values are sign-flipped on the JAX-family priors and replaced with the correct density-form expression on `LogUniformPrior`. The normalisation constants `-log(σ · √(2π))` and `-log(log(b/a))` are dropped from the returned value, matching `UniformPrior.log_prior_from_value` which drops `-log(b-a)` to return `0.0`. The math of the search is invariant to these constants.

See full details below.

## Migration warning — IMPORTANT

**Cached `samples.csv` from Emcee / Zeus / MLE-Drawer / LBFGS / BFGS fits with ANY non-uniform prior (Gaussian, LogGaussian, TruncatedGaussian, LogUniform) are biased and should be re-run after this PR.**

| Sampler family | Cached chains | Stored `log_prior` column |
|---|---|---|
| Dynesty / Nautilus | **unaffected** (priors via `prior_transform`, never touch `log_prior_from_value`) | wrong-signed but **auto-recovers** when `Aggregator` re-runs `model.log_prior_list_from_vector` against existing parameter columns |
| Emcee / Zeus / MLE-Drawer / LBFGS / BFGS | **biased** for non-uniform priors — re-run required | will be correct in newly-written outputs |

If you have important results from before this PR that used Emcee or LBFGS with a non-`UniformPrior` prior, re-run them. Uniform-prior-only fits are unaffected on any sampler.

## Test Plan

- [x] `pytest test_autofit` — 1242 passed, 1 skipped
- [x] `test_autofit/mapper/prior/test_prior.py` — three pins updated to density-form values
- [x] `test_autofit/mapper/model/test_model_mapper.py::test_log_prior_list_from_vector` — one pin updated to density-form values
- [x] `autofit_workspace_test/scripts/jax_assertions/priors_xp_dispatch.py` — 28 assertions pass (existing parity + 4 new density-form gates)
- [x] `autofit_workspace_test/scripts/prior_correctness/emcee_gaussian_bias_check.py` — new permanent regression: Emcee samples cluster at mean=5.0 ± 0.2 with std≈1.0 (was diverging to 10^146 before)
- [x] `autofit_workspace_test/scripts/prior_correctness/lbfgs_gaussian_bias_check.py` — new permanent regression: L-BFGS-B converges to 5.0 ± 0.01 (was diverging to 8e143 before)
- [x] `autofit_workspace/scripts/searches/{mcmc,mle,nest,start_point}.py` — all 4 pass
- [x] `autofit_workspace_test/scripts/graphical/ep.py` — full EP loop runs to completion (EP uses `Message.logpdf` directly, confirmed unaffected by the bug)
- [x] Smoke pass: autofit_workspace 9/9, autogalaxy_workspace 8/8, autolens_workspace 9/9, autolens_workspace_test 12/12, HowToLens 6/6 — **44/44 across 5 workspaces**

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour

- `NormalMessage.log_prior_from_value(value, xp=np)` — now returns `-(value - mean)**2 / (2 sigma**2)` (density form, was the cost form `+(value - mean)**2 / (2 sigma**2)`). The constant `-log(sigma * sqrt(2 * pi))` is dropped, matching `UniformPrior`'s convention of dropping `-log(b - a)`.
- `LogGaussianPrior.log_prior_from_value(value, xp=np)` — now returns `-(log(value) - mean)**2 / (2 sigma**2) - log(value)` (density-form quadratic plus the change-of-variables Jacobian). NumPy and JAX paths both updated; out-of-support (`value <= 0`) returns `-inf`.
- `LogUniformPrior.log_prior_from_value(value, xp=np)` — now returns `-log(value)` (NumPy path) or `xp.where(in_bounds, -xp.log(value), -xp.inf)` (JAX path). Previously returned `1.0 / value` which was neither a density nor a cost — it was the Jacobian gradient `d(log x)/dx`.

### Not Changed

- `UniformPrior.log_prior_from_value` — already returned `0.0` (sign-agnostic, correct).
- `TruncatedNormalMessage.log_prior_from_value` — already returned density form with `-inf` out-of-bounds.
- `Fitness._call`, `Fitness.call_wrap`, `Fitness._jit`, `Fitness._vmap` — sign-invariant after the prior layer is corrected.
- The entire `autofit/graphical/` framework (factor graphs, expectation propagation, Laplace approximation) — EP routes priors through `Message.logpdf` / `Message.cdf` / `Message.pdf` directly and does not consult `Prior.log_prior_from_value` on the hot path.

### Migration

No API migration required (signatures unchanged). Downstream callers see returned values with flipped sign (Gaussian family) or a different formula entirely (LogUniform). Existing `Fitness._call`-based math is now correct without changes.

Numerical values are different in three regression-test pinned locations, all updated:
- `test_autofit/mapper/prior/test_prior.py::TestLogUniformPrior::test__log_prior_from_value`
- `test_autofit/mapper/prior/test_prior.py::TestGaussianPrior::test__log_prior_from_value`
- `test_autofit/mapper/prior/test_prior.py::test_log_gaussian_prior_log_prior_from_value`
- `test_autofit/mapper/model/test_model_mapper.py::TestInstances::test_log_prior_list_from_vector`

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)