### PR TITLE
fix: dedupe number_of_cores in Drawer for from_dict round-trip

### DIFF
--- a/autofit/non_linear/search/mle/drawer/search.py
+++ b/autofit/non_linear/search/mle/drawer/search.py
@@ -66,6 +66,11 @@ class Drawer(AbstractMLE):
             An SQLalchemy session instance so the results of the model-fit are written to an SQLite database.
         """
 
+        # Drawer is single-core only; drop any saved number_of_cores so a
+        # round-tripped search.json (which records the resolved value) can be
+        # deserialized without colliding with the hardcoded kwarg below.
+        kwargs.pop("number_of_cores", None)
+
         super().__init__(
             name=name,
             path_prefix=path_prefix,

--- a/test_autofit/non_linear/search/optimize/test_drawer.py
+++ b/test_autofit/non_linear/search/optimize/test_drawer.py
@@ -1,6 +1,7 @@
 import pytest
 
 import autofit as af
+from autoconf.dictable import from_dict, to_dict
 
 pytestmark = pytest.mark.filterwarnings("ignore::FutureWarning")
 
@@ -21,3 +22,17 @@ def test__explicit_params():
 
     assert search.total_draws == 50
     assert isinstance(search.initializer, af.InitializerBall)
+
+
+def test__dict_round_trip_with_number_of_cores():
+    # A round-tripped Drawer.search.json carries `number_of_cores` at the top
+    # level (the resolved value, always 1). Before the fix, this collided with
+    # the hardcoded super().__init__(number_of_cores=1, **kwargs) call and
+    # raised `TypeError: got multiple values for keyword argument`.
+    dictionary = to_dict(af.Drawer(total_draws=3))
+    assert "number_of_cores" in dictionary["arguments"]
+
+    restored = from_dict(dictionary)
+    assert isinstance(restored, af.Drawer)
+    assert restored.total_draws == 3
+    assert restored.number_of_cores == 1


### PR DESCRIPTION
## Summary

Fix a `TypeError` in `Drawer.__init__` when a saved Drawer search is reconstructed via `autoconf.dictable.from_dict`. The constructor hardcoded `number_of_cores=1` in its `super().__init__(...)` call while also forwarding `**kwargs`; the saved `search.json` of a Drawer fit carries `number_of_cores` at the top level (the resolved value, always `1`), which collided.

The fix pops `number_of_cores` from `kwargs` before forwarding to `super()`. Drawer is single-core only by design, so the saved value is always `1` and discarding it is safe.

Surfaced by the `autogalaxy_workspace/scripts/ellipse/database.py` aggregator example (unparked in the companion workspace PR). Before this fix, scraping any output directory containing a Drawer fit raised:

```
TypeError: AbstractMLE.__init__() got multiple values for keyword argument 'number_of_cores'
```

## API Changes

None — internal bugfix only.

## Test Plan
- [x] New regression test `test__dict_round_trip_with_number_of_cores` in `test_autofit/non_linear/search/optimize/test_drawer.py` round-trips a `Drawer` through `to_dict` / `from_dict` and asserts the resolved `number_of_cores == 1`.
- [x] Full PyAutoFit unit suite — 1243 passed, 1 skipped.
- [x] End-to-end verification: `autogalaxy_workspace/scripts/ellipse/database.py` now completes under `PYAUTO_TEST_MODE=2`, including the aggregator scrape of the `fit_all` Drawer outputs (was previously the failure point).

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
- (none)

### Added
- (none)

### Renamed
- (none)

### Changed Signature
- (none)

### Changed Behaviour
- `autofit.Drawer.__init__` — pops `number_of_cores` from `**kwargs` before forwarding to `AbstractMLE.__init__`. No effect on direct construction (users have never been able to override Drawer's single-core operation); only fixes the previously-broken `from_dict` round-trip.

### Migration
None required — pure bugfix.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)