### PR TITLE
feat: default use_jax_for_visualization to follow use_jax in Analysis.__init__

### DIFF
--- a/autofit/non_linear/analysis/analysis.py
+++ b/autofit/non_linear/analysis/analysis.py
@@ -36,9 +36,23 @@ class Analysis(ABC):
     def __init__(
         self,
         use_jax: bool = False,
-        use_jax_for_visualization: bool = False,
+        use_jax_for_visualization: Optional[bool] = None,
         **kwargs,
     ):
+        """
+        Parameters
+        ----------
+        use_jax
+            Run the likelihood through ``jax.jit`` for the fast path. When JAX
+            is unavailable this silently falls back to numpy with a warning.
+        use_jax_for_visualization
+            Whether ``fit_for_visualization`` should dispatch through the
+            ``jax.jit``-cached path. ``None`` (default) follows ``use_jax`` —
+            users who set ``use_jax=True`` automatically get JIT visualization.
+            Pass ``False`` to force the eager NumPy plotter even when
+            ``use_jax=True``; pass ``True`` to opt in explicitly. Passing
+            ``True`` while ``use_jax=False`` logs a warning and disables it.
+        """
         import os
         if os.environ.get("PYAUTO_DISABLE_JAX") == "1":
             use_jax = False
@@ -68,6 +82,9 @@ class Analysis(ABC):
                 use_jax = False
                 use_jax_for_visualization = False
 
+        if use_jax_for_visualization is None:
+            use_jax_for_visualization = use_jax
+
         if use_jax_for_visualization and not use_jax:
             logger.warning(
                 "use_jax_for_visualization=True requires use_jax=True; "
@@ -83,15 +100,21 @@ class Analysis(ABC):
         """
         Build the fit used by the visualizer.
 
-        Dispatch over ``self.fit_from`` with an opt-in ``jax.jit`` fast path:
+        Dispatch over ``self.fit_from`` with a ``jax.jit`` fast path that
+        follows ``use_jax`` by default:
 
-        * ``use_jax_for_visualization=False`` (default) — plain
-          ``self.fit_from(instance)``. Untouched by JAX.
-        * ``use_jax_for_visualization=True`` — lazily construct
+        * ``self._use_jax_for_visualization`` is ``False`` — plain
+          ``self.fit_from(instance)``. Untouched by JAX. This is the
+          resolved state when ``use_jax=False`` (the parameter default),
+          or when the user explicitly passed
+          ``use_jax_for_visualization=False`` to opt out.
+        * ``self._use_jax_for_visualization`` is ``True`` — lazily construct
           ``jax.jit(self.fit_from)`` on the first call and cache it on the
           instance as ``_jitted_fit_from``, then call that for every
           subsequent visualization. The first call pays the compile cost;
-          subsequent calls reuse the cached compiled function.
+          subsequent calls reuse the cached compiled function. This is the
+          resolved state when ``use_jax=True`` (the sentinel default
+          ``use_jax_for_visualization=None`` follows ``use_jax``).
 
         Caching is per-``Analysis`` instance so each analysis gets its own
         compiled function keyed off that instance's closed-over state
@@ -108,8 +131,9 @@ class Analysis(ABC):
         nested autoarray / galaxy / lens type it carries) must be pytree-
         registered. That wiring lives in each analysis subclass (see
         ``AnalysisImaging._register_fit_imaging_pytrees`` in PyAutoLens).
-        Variants that have not yet been pytree-audited must leave
-        ``use_jax_for_visualization`` at its default of ``False``.
+        Variants that have not yet been pytree-audited must pass
+        ``use_jax_for_visualization=False`` explicitly when constructing
+        the analysis (or simply leave ``use_jax=False``).
         """
         if not self._use_jax_for_visualization:
             return self.fit_from(instance=instance)

--- a/test_autofit/analysis/test_use_jax_for_visualization.py
+++ b/test_autofit/analysis/test_use_jax_for_visualization.py
@@ -67,6 +67,17 @@ def test_pyauto_disable_jax_env_var_clears_both_flags(monkeypatch):
     assert analysis._use_jax_for_visualization is False
 
 
+def test_pyauto_disable_jax_overrides_sentinel_default(monkeypatch):
+    """PYAUTO_DISABLE_JAX=1 must still force both off even when the user
+    constructs Analysis(use_jax=True) and lets the sentinel resolve. This is
+    a numpy-only check — JAX-conditional sentinel-resolution assertions live
+    in autofit_workspace_test/scripts/jax_assertions/fitness_dispatch.py."""
+    monkeypatch.setenv("PYAUTO_DISABLE_JAX", "1")
+    analysis = af.Analysis(use_jax=True)
+    assert analysis._use_jax is False
+    assert analysis._use_jax_for_visualization is False
+
+
 def test_fit_for_visualization_works_without_flag():
     analysis = _FittableAnalysis()
     result = analysis.fit_for_visualization(instance="sentinel")


### PR DESCRIPTION
## Summary
Phase 2 of the JAX visualization roadmap (`z_features/jax_visualization.md`).
Change the default of `use_jax_for_visualization` on `Analysis.__init__` from
`False` to `None` — a sentinel meaning "follow `use_jax`". Users who set
`use_jax=True` now automatically get the JIT-cached visualization path. The
explicit opt-out (`use_jax_for_visualization=False`) still works for callers
who want JAX likelihoods with the eager NumPy plotter. The
`PYAUTO_DISABLE_JAX=1` env override and the JAX-not-installed fallback both
continue to hard-disable both flags.

Closes #1275.

## API Changes
- `Analysis.__init__(use_jax_for_visualization=...)` default changes from
  `False` → `None`. Type annotation widens from `bool` to `Optional[bool]`.
- When `use_jax=True` and no explicit visualization flag is given, the JIT
  visualization path is now ON by default (previously had to be opted into).
- All existing call sites that pass `True` or `False` explicitly are
  unaffected. Existing scripts that set only `use_jax=True` will now also
  hit the JIT viz path — that is the intended Phase 2 behaviour change.

See full details below.

## Test Plan
- [x] `pytest test_autofit/analysis/test_use_jax_for_visualization.py` —
      existing tests still pass, 1 new numpy-only case added covering
      `PYAUTO_DISABLE_JAX=1` over the new sentinel default.
- [x] Three JAX-conditional sentinel-resolution assertions added to
      `autofit_workspace_test/scripts/jax_assertions/fitness_dispatch.py`
      (ships in the workspace follow-up PR) — all pass locally.
- [ ] Reviewer: confirm no production workspace script today sets
      `use_jax_for_visualization=` explicitly (audited 2026-05-08 / re-verified
      2026-05-16 — zero hits across autolens_workspace, autogalaxy_workspace,
      autofit_workspace).

<details>
<summary>Full API Changes (for automation &amp; release notes)</summary>

### Changed Signature
- `autofit.non_linear.analysis.analysis.Analysis.__init__`:
  - `use_jax_for_visualization: bool = False` → `use_jax_for_visualization: Optional[bool] = None`

### Changed Behaviour
- `Analysis(use_jax=True)` — previously: `_use_jax_for_visualization` resolved
  to `False`. Now: resolves to `True` (sentinel `None` follows `use_jax`).
- `Analysis(use_jax=True, use_jax_for_visualization=False)` — unchanged
  (explicit opt-out continues to disable JIT viz).
- `Analysis(use_jax=False, use_jax_for_visualization=True)` — unchanged
  (still logs warning and forces both off).
- `PYAUTO_DISABLE_JAX=1` env override — unchanged (still forces both off).
- JAX-not-installed fallback — unchanged (still forces both off with warning).

### Migration
- No required migration. Scripts that currently set both flags explicitly
  keep their existing behaviour. Scripts that pass only `use_jax=True` will
  pick up the JIT visualization path automatically — this is the desired
  Phase 2 behaviour. To preserve old behaviour, pass
  `use_jax_for_visualization=False` explicitly.

### Roadmap context
- Phase 0 (pytree registration + dispatch swaps) — shipped (#390, #401, plus
  PyAutoFit/PyAutoLens fit_imaging_pytree series).
- Phase 1 (workspace_test coverage for every dataset type) — shipped
  (#500/#506 PyAutoLens; #44/#46/#48 autogalaxy_workspace_test; #87/#91
  autolens_workspace_test).
- **Phase 2 (this PR)** — flip the default.
- Phase 3 (production tutorial adoption) — separate prompt.
- Phase 4 (subprocess visualization) — separate prompt.
- Phase 5 (live Jupyter/Colab cell) — separate prompt.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)