### PR TITLE
fix: coerce figure_of_metric return to Python float for Drawer + JAX

### DIFF
--- a/autofit/non_linear/initializer.py
+++ b/autofit/non_linear/initializer.py
@@ -35,7 +35,7 @@ class AbstractInitializer(ABC):
             if np.isnan(figure_of_merit) or figure_of_merit < -1e98:
                 return None
 
-            return figure_of_merit
+            return float(figure_of_merit)
         except exc.FitException:
             return None
 

--- a/test_autofit/non_linear/test_initializer.py
+++ b/test_autofit/non_linear/test_initializer.py
@@ -334,3 +334,36 @@ def test_missing_parameter(model):
         assert 0.5 <= parameter <= 1.0
 
     assert 0.5 in parameter_list
+
+
+class MockFitnessNonFloat:
+    def __call__(self, parameters):
+        import numpy as _np
+        return _np.array(-1.5 - 0.01 * _np.random.rand())
+
+
+def test__figure_of_metric__coerces_non_float_scalar_to_python_float():
+    import json
+    import numpy as _np
+
+    model = af.Model(af.m.MockClassx4)
+    model.one = af.UniformPrior(lower_limit=0.099, upper_limit=0.101)
+    model.two = af.UniformPrior(lower_limit=0.199, upper_limit=0.201)
+    model.three = af.UniformPrior(lower_limit=0.299, upper_limit=0.301)
+    model.four = af.UniformPrior(lower_limit=0.399, upper_limit=0.401)
+
+    initializer = af.InitializerPrior()
+
+    _, _, figures_of_merit_list = initializer.samples_from_model(
+        total_points=3,
+        model=model,
+        fitness=MockFitnessNonFloat(),
+        paths=af.DirectoryPaths(),
+        test_mode_samples=False,
+    )
+
+    for fom in figures_of_merit_list:
+        assert type(fom) is float
+        assert not isinstance(fom, _np.ndarray)
+
+    json.dumps(figures_of_merit_list)


### PR DESCRIPTION
## Summary

Fix a `TypeError: Object of type ArrayImpl is not JSON serializable` raised when `af.Drawer` runs against a JAX-backed `Fitness` (reported running `autogalaxy_workspace/scripts/ellipse.py`-style code with `use_jax=True`).

Root cause is in `AbstractInitializer.figure_of_metric` (`autofit/non_linear/initializer.py`): it returned the raw value from `fitness(parameters=...)`, which under JAX is a 0-d `jax.Array`. Those scalars propagated into `figures_of_merit_list` → `Drawer._fit`'s `search_internal["log_posterior_list"]` → `Samples.samples_info` → `DirectoryPaths.save_json` → `json.dump` → crash.

Drawer is the only search that stuffs the full `search_internal` dict (with raw `parameter_lists` and `log_posterior_list`) into `samples_info`; `DynestyStatic` / `Emcee` / etc. build a scalar-metadata-only `samples_info`, so they don't hit this. The existing `float(figure_of_merit)` coercion in `Fitness.call_wrap` (`fitness.py:243`) covers the complementary path but only fires when `use_jax_jit=True`, and `Drawer._fit` constructs `Fitness` with the default `use_jax_jit=False` — so the existing safeguard never fires on this codepath.

Coerce at the producer (`figure_of_metric`). The function already returned `Optional[float]`; this just makes the runtime value match the annotation.

## API Changes

None — internal bugfix only.
See full details below.

## Test Plan
- [x] New regression test `test__figure_of_metric__coerces_non_float_scalar_to_python_float` in `test_autofit/non_linear/test_initializer.py`. Uses a numpy 0-d array fitness (library unit tests stay numpy-only) — the same JSON-unserializable shape as a JAX `ArrayImpl`. Asserts every entry of `figures_of_merit_list` is exactly `float` and that the list survives a bare `json.dumps`.
- [x] Full PyAutoFit unit suite — 1259 passed, 1 skipped.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
- (none)

### Added
- (none)

### Renamed
- (none)

### Changed Signature
- (none)

### Changed Behaviour
- `autofit.non_linear.initializer.AbstractInitializer.figure_of_metric` — return value is now coerced via `float(...)`. Previously returned the raw `fitness(parameters=...)` output, which under a JAX-backed `Fitness` is a 0-d `jax.Array`. The function's annotation has always been `Optional[float]`; this makes the runtime value match.

### Migration
None required — pure bugfix.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)