### PR TITLE
Fix Sample.kwargs mixed string/tuple key bug

### DIFF
--- a/autofit/non_linear/samples/sample.py
+++ b/autofit/non_linear/samples/sample.py
@@ -35,7 +35,7 @@ class Sample:
         self.log_prior = log_prior
         self.weight = weight
         self.kwargs = {
-            tuple(key.split(".")) if isinstance(key, str) and "." in key else key: value
+            tuple(key.split(".")) if isinstance(key, str) else key: value
             for key, value in (kwargs or dict()).items()
         }
 

--- a/test_autofit/analysis/test_latent_variables.py
+++ b/test_autofit/analysis/test_latent_variables.py
@@ -47,7 +47,7 @@ def test_set_database_paths(session, latent_samples):
         latent_samples=latent_samples,
     )
     loaded = database_paths.load_latent_samples()
-    assert loaded.max_log_likelihood_sample.kwargs == {"fwhm": 7.0644601350928475}
+    assert loaded.max_log_likelihood_sample.kwargs == {("fwhm",): 7.0644601350928475}
 
 
 @pytest.fixture(name="latent_samples")
@@ -73,7 +73,7 @@ def make_latent_samples():
 
 
 def test_compute_latent_samples(latent_samples):
-    assert latent_samples.sample_list[0].kwargs == {"fwhm": 7.0644601350928475}
+    assert latent_samples.sample_list[0].kwargs == {("fwhm",): 7.0644601350928475}
     assert latent_samples.model.instance_from_vector([1.0]).fwhm == 1.0
 
 
@@ -113,7 +113,7 @@ def test_compute_latent_samples_skips_fit_exception_samples():
         ),
     )
     assert len(latent_samples.sample_list) == 1
-    assert latent_samples.sample_list[0].kwargs == {"fwhm": 7.0644601350928475}
+    assert latent_samples.sample_list[0].kwargs == {("fwhm",): 7.0644601350928475}
 
 
 def test_info(latent_samples):

--- a/test_autofit/database/paths/test_samples.py
+++ b/test_autofit/database/paths/test_samples.py
@@ -49,7 +49,7 @@ def test_serialise_sample(sample):
     sample = m.Object.from_object(
         sample
     )()
-    assert "centre" in sample.kwargs
+    assert ("centre",) in sample.kwargs
 
 
 def test_load_samples(

--- a/test_autofit/non_linear/samples/test_efficient.py
+++ b/test_autofit/non_linear/samples/test_efficient.py
@@ -46,13 +46,13 @@ def test_values(efficient):
 
     sample_1, sample_2 = samples.sample_list
 
-    assert sample_1.kwargs["centre"] == 1.0
-    assert sample_1.kwargs["normalization"] == 2.0
-    assert sample_1.kwargs["sigma"] == 3.0
+    assert sample_1.kwargs[("centre",)] == 1.0
+    assert sample_1.kwargs[("normalization",)] == 2.0
+    assert sample_1.kwargs[("sigma",)] == 3.0
 
-    assert sample_2.kwargs["centre"] == 4.0
-    assert sample_2.kwargs["normalization"] == 5.0
-    assert sample_2.kwargs["sigma"] == 6.0
+    assert sample_2.kwargs[("centre",)] == 4.0
+    assert sample_2.kwargs[("normalization",)] == 5.0
+    assert sample_2.kwargs[("sigma",)] == 6.0
 
 
 def test_database(efficient, session):

--- a/test_autofit/non_linear/samples/test_samples.py
+++ b/test_autofit/non_linear/samples/test_samples.py
@@ -241,3 +241,26 @@ def test__addition_of_samples__raises_error_if_model_mismatch(samples_x5):
 
     with pytest.raises(af.exc.SamplesException):
         samples_x5 + samples_different_model
+
+
+def test__sample_kwargs__mixed_dotted_and_dotless_string_keys():
+    sample = af.Sample(
+        log_likelihood=1.0,
+        log_prior=0.0,
+        weight=1.0,
+        kwargs={
+            "mock_class_1.one": 10.0,
+            "dummy_0": 99.0,
+        },
+    )
+
+    assert all(isinstance(key, tuple) for key in sample.kwargs)
+    assert sample.is_path_kwargs is True
+    assert sample.kwargs[("dummy_0",)] == 99.0
+    assert sample.kwargs[("mock_class_1", "one")] == 10.0
+
+    paths = [
+        [("mock_class_1", "one")],
+        [("dummy_0",)],
+    ]
+    assert sample.parameter_lists_for_paths(paths) == [10.0, 99.0]


### PR DESCRIPTION
## Summary

`Sample.__init__` previously converted string kwargs to tuple paths only when the key contained a dot. A model with both nested params (e.g. `'ellipses.11.centre.centre_0'`) and top-level dotless params (e.g. `'dummy_0'`) produced a **mixed-type** kwargs dict. `Sample.is_path_kwargs` inspected only the first key, misclassified the sample as path-keyed, and `parameter_lists_for_paths` then raised `KeyError: "Could not find any of the following keys in kwargs (('dummy_0',),)"` when the aggregator loaded results into the database.

The fix drops the `"." in key` guard so every string key is uniformly converted to a tuple. Single-name keys become single-element tuples (`'dummy_0'` → `('dummy_0',)`) that match the path produced by `model.all_paths`. The `dict()` / database JSON round-trip remains symmetric because `dict()` joins tuples back to dotted strings on serialize.

Bug reported by Sam in the aggregator-to-database flow.

## API Changes

Internal in-memory representation of `Sample.kwargs` is now uniformly tuple-keyed — single-name keys become `('name',)` instead of staying as raw strings. All serialized forms (CSV headers, database JSON via `Sample.dict()`) are unchanged because they already join tuples back to dotted strings on serialize, and `Sample.__init__` re-tuples them on deserialize, so the round-trip is symmetric. The change also silently repairs `Samples.values_for_path` and the aggregator CSV `Column.value` lookup, both of which expected tuple keys but would have silently failed on dotless-name kwargs pre-fix.

See full details below.

## Test Plan

- [x] New regression test `test__sample_kwargs__mixed_dotted_and_dotless_string_keys` in `test_autofit/non_linear/samples/test_samples.py` exercises Sam's exact scenario
- [x] Full `test_autofit/` suite: 1399 passed, 1 skipped
- [x] `test_autofit/aggregator/` (49 tests) green
- [x] `test_autofit/database/` (144 tests) green
- [x] `test_autofit/mapper/functionality/test_by_path.py` + `test_autofit/non_linear/result/` (28 tests) green — directly exercise `Samples.values_for_path` → `sample.kwargs[path]`
- [x] `autofit_workspace` smoke tests (7 scripts including `cookbooks/samples.py`, which exercises latent variables, `with_paths`, `parameter_lists`) all pass

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour

- `Sample.__init__` (`autofit/non_linear/samples/sample.py:38`) — all `str` keys in `kwargs` are now converted to `tuple` paths via `tuple(key.split("."))`, regardless of whether the key contains `"."`. Previously only dotted keys were converted; dotless keys stayed as raw `str`.

- `Sample.kwargs` — in-memory representation is now uniformly `Dict[Tuple[str, ...], float]` for string-input construction. A `Sample` built with `kwargs={"fwhm": 7.0}` now stores `{("fwhm",): 7.0}` instead of `{"fwhm": 7.0}`.

- `Sample.is_path_kwargs` — returns `True` consistently for any string-input construction (no longer depends on whether the first key happens to contain a dot).

- `Samples.values_for_path(path: Tuple[str, ...])` — previously raised `KeyError` for any sample whose kwargs were constructed with dotless string keys; now succeeds.

### Migration

No user-facing migration required. Public serialization (`Sample.dict()`, CSV, database JSON) is unchanged: `dict()` joins tuple keys back to dotted strings on serialize, and `Sample.__init__` re-tuples them on deserialize, so the round-trip is symmetric.

The only consumer surface that observes the change is direct in-memory indexing of `sample.kwargs[...]`. A grep across PyAutoFit, PyAutoArray, PyAutoGalaxy, PyAutoLens, and all workspaces found zero non-test consumers using raw-string indexing for dotless keys. Four test assertions inside PyAutoFit codified the pre-fix raw-string shape and have been updated to use single-element tuples (`("centre",)`, `("fwhm",)`).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)