### PR TITLE
feat(analysis): LATENT_BATCH_MODE attribute (vmap default, jit option)

### DIFF
--- a/autofit/non_linear/analysis/analysis.py
+++ b/autofit/non_linear/analysis/analysis.py
@@ -33,6 +33,28 @@ class Analysis(ABC):
 
     LATENT_KEYS = []
 
+    # Strategy used by `compute_latent_samples` when `use_jax=True`.
+    #
+    # - "vmap" (default): wrap `compute_latent_variables` in
+    #   `jax.jit(jax.vmap(...))` so all posterior samples are evaluated in a
+    #   single batched call. Fastest when the function is fully vmap-safe
+    #   (no Python control flow that depends on traced shapes, no calls into
+    #   external libraries that don't support `jax.vmap`).
+    #
+    # - "jit": wrap in plain `jax.jit(...)` and loop in Python over samples.
+    #   The JIT compile cache is reused across samples, so this is much
+    #   faster than per-sample NumPy but slower than vmap. Use this when the
+    #   inner function calls JAX code that documents vmap incompatibility
+    #   (e.g. `jax_zero_contour.ZeroSolver` which uses `lax.cond` /
+    #   `lax.while_loop` early-termination not safe under vmap).
+    #
+    # Subclasses override this attribute when their `compute_latent_variables`
+    # implementation depends on vmap-incompatible primitives. For example,
+    # `autogalaxy.AnalysisDataset` sets `LATENT_BATCH_MODE = "jit"` because
+    # the lensing latents (Einstein radius via zero-contour) route through
+    # `ZeroSolver`.
+    LATENT_BATCH_MODE = "vmap"
+
     def __init__(
         self,
         use_jax: bool = False,
@@ -188,10 +210,33 @@ class Analysis(ABC):
 
             if self._use_jax:
                 import jax
+                import jax.numpy as jnp
                 start = time.time()
-                logger.info("JAX: Applying vmap and jit to likelihood function for latent variables -- may take a few seconds.")
-                batched_compute_latent = jax.jit(jax.vmap(compute_latent_for_model))
-                logger.info(f"JAX: vmap and jit applied in {time.time() - start} seconds.")
+                if self.LATENT_BATCH_MODE == "vmap":
+                    logger.info("JAX: Applying vmap and jit to likelihood function for latent variables -- may take a few seconds.")
+                    batched_compute_latent = jax.jit(jax.vmap(compute_latent_for_model))
+                elif self.LATENT_BATCH_MODE == "jit":
+                    logger.info("JAX: Applying per-sample jit to latent variables (LATENT_BATCH_MODE='jit') -- may take a few seconds on first sample.")
+                    jitted_compute_latent = jax.jit(compute_latent_for_model)
+
+                    def batched_compute_latent(parameters_batch):
+                        # Per-sample jit returns one (l1, l2, ..., lN) tuple per
+                        # sample. Transpose to a tuple of N batched arrays so the
+                        # downstream `jnp.stack(latent_values_batch, axis=-1)`
+                        # works identically to the vmap path.
+                        sample_results = [
+                            jitted_compute_latent(p) for p in parameters_batch
+                        ]
+                        n_latents = len(sample_results[0])
+                        return tuple(
+                            jnp.stack([s[i] for s in sample_results])
+                            for i in range(n_latents)
+                        )
+                else:
+                    raise ValueError(
+                        f"Unknown LATENT_BATCH_MODE={self.LATENT_BATCH_MODE!r}; expected 'vmap' or 'jit'."
+                    )
+                logger.info(f"JAX: {self.LATENT_BATCH_MODE} dispatch applied in {time.time() - start} seconds.")
             else:
                 n_latents = len(self.LATENT_KEYS)
                 nan_row = np.full(n_latents, np.nan)

--- a/test_autofit/analysis/test_latent_variables.py
+++ b/test_autofit/analysis/test_latent_variables.py
@@ -91,6 +91,44 @@ class AssertionAnalysis(af.Analysis):
         return (instance.fwhm,)
 
 
+def test_latent_batch_mode_default_is_vmap():
+    """
+    Subclasses that don't override `LATENT_BATCH_MODE` must inherit "vmap" so
+    `compute_latent_samples` keeps its existing parallel-batched behaviour
+    on the JAX path. PyAutoGalaxy's `AnalysisDataset` overrides this to "jit"
+    for vmap-incompatible inner calls — that override is what unlocks
+    lensing latents, but it must stay opt-in here.
+    """
+    assert af.Analysis.LATENT_BATCH_MODE == "vmap"
+    assert Analysis.LATENT_BATCH_MODE == "vmap"
+
+
+def test_latent_batch_mode_invalid_value_raises_clear_error():
+    """
+    Misspelt `LATENT_BATCH_MODE` values should fail with a clear ValueError
+    rather than silently falling through. This guards against subclasses
+    setting e.g. `LATENT_BATCH_MODE = "JIT"` (case sensitivity) and getting
+    surprising behaviour.
+    """
+    class BadAnalysis(Analysis):
+        LATENT_BATCH_MODE = "JIT"  # wrong case — should be lowercase
+
+    samples = SamplesPDF(
+        model=af.Model(af.ex.Gaussian),
+        sample_list=[
+            af.Sample(
+                log_likelihood=1.0,
+                log_prior=0.0,
+                weight=1.0,
+                kwargs={"centre": 1.0, "normalization": 2.0, "sigma": 3.0},
+            )
+        ],
+    )
+    bad = BadAnalysis(use_jax=True)
+    with pytest.raises(ValueError, match="LATENT_BATCH_MODE"):
+        bad.compute_latent_samples(samples)
+
+
 def test_compute_latent_samples_skips_fit_exception_samples():
     analysis = AssertionAnalysis()
     latent_samples = analysis.compute_latent_samples(


### PR DESCRIPTION
## Summary

Adds an `Analysis.LATENT_BATCH_MODE` class attribute that controls how `compute_latent_samples` wraps `compute_latent_variables` on the JAX path. Default is `"vmap"` (existing behaviour). Subclasses opt into `"jit"` (per-sample `jax.jit`) when their inner code calls JAX primitives that upstream documents as vmap-incompatible.

The motivating use case is lensing latents: `LensCalc.einstein_radius_jit_from` (added in the companion PyAutoGalaxy PR) wraps `jax_zero_contour.ZeroSolver.zero_contour_finder`, which upstream explicitly warns must not be combined with `jax.vmap` (uses `jax.lax.cond` / `jax.lax.while_loop` for early termination). PyAutoGalaxy's `AnalysisDataset` sets `LATENT_BATCH_MODE = "jit"` so all PyAutoGalaxy/PyAutoLens analyses inherit the per-sample jit path automatically; non-lensing PyAutoFit users keep their current vmap behaviour because the default is unchanged.

## API Changes

New public class attribute `Analysis.LATENT_BATCH_MODE: str` (default `"vmap"`). Two values supported: `"vmap"` and `"jit"`. Other values raise `ValueError` at `compute_latent_samples` time with a clear message.

See full details below.

## Test Plan

- [x] New unit test: `LATENT_BATCH_MODE` defaults to `"vmap"` (existing subclasses unchanged).
- [x] New unit test: invalid `LATENT_BATCH_MODE` value raises `ValueError` with a clear message.
- [x] `pytest test_autofit/analysis/` — 18 passed locally, 1 skipped.
- [x] End-to-end validation via the Euclid pipeline workspace PR (`PyAutoLabs/euclid_strong_lens_modeling_pipeline#14`) — confirms `LATENT_BATCH_MODE = "jit"` propagates through `AnalysisDataset` and produces a finite Einstein radius latent (`2.1002 arcsec`) on a real fit.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- `Analysis.LATENT_BATCH_MODE: str` — class attribute, default `"vmap"`. Controls the JAX dispatch strategy in `compute_latent_samples`.

### Changed Signature
- None.

### Changed Behaviour
- `Analysis.compute_latent_samples` — when `use_jax=True`, branches on `self.LATENT_BATCH_MODE`:
  - `"vmap"` (default, unchanged behaviour): `jax.jit(jax.vmap(compute_latent_for_model))`.
  - `"jit"`: per-sample `jax.jit(compute_latent_for_model)` with a Python loop over samples; JIT cache is reused across samples.
  - Other values: raise `ValueError`.

### Migration
- None required for existing subclasses (default is `"vmap"`).
- Lensing-style subclasses where `compute_latent_variables` calls into `jax_zero_contour` or other vmap-incompatible JAX code should set `LATENT_BATCH_MODE = "jit"`.

</details>

## Companion PRs

- PyAutoGalaxy: `https://github.com/PyAutoLabs/PyAutoGalaxy/pull/435` — adds `LensCalc.einstein_radius_jit_from` and sets `AnalysisDataset.LATENT_BATCH_MODE = "jit"`.
- Workspace: `https://github.com/PyAutoLabs/euclid_strong_lens_modeling_pipeline/pull/15` — wires the Euclid `effective_einstein_radius` latent through the new path.

Closes PyAutoLabs/euclid_strong_lens_modeling_pipeline#14 alongside the companion PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)