### PR TITLE
fix: PYAUTO_TEST_MODE should write to a separate output dir

### DIFF
--- a/autofit/database/__init__.py
+++ b/autofit/database/__init__.py
@@ -7,6 +7,7 @@ from autoconf import conf
 from .aggregator import *
 from .migration.steps import migrator
 from .model import *
+from autofit.non_linear.paths.abstract import _test_mode_segment
 
 
 def open_database(
@@ -60,6 +61,9 @@ def open_database(
         output_path = conf.instance.output_path
 
         if not filename.startswith("/"):
+            segment = _test_mode_segment()
+            if segment:
+                output_path = f"{output_path}/{segment}"
             filename = f"{output_path}/{filename}"
 
         os.makedirs(

--- a/autofit/non_linear/paths/abstract.py
+++ b/autofit/non_linear/paths/abstract.py
@@ -22,6 +22,19 @@ logger = logging.getLogger(__name__)
 pattern = re.compile(r"(?<!^)(?=[A-Z])")
 
 
+def _test_mode_segment() -> Optional[str]:
+    """
+    Returns ``"test_mode"`` when ``PYAUTO_TEST_MODE`` is set in the
+    environment, else ``None``.
+
+    Inserted into the output-path composition so that smoke runs land
+    under ``output/test_mode/...`` instead of sharing a directory with
+    real runs. Without this, a cached test-mode result short-circuits
+    a later real run at the same paths ("Fit Already Completed").
+    """
+    return "test_mode" if os.environ.get("PYAUTO_TEST_MODE") else None
+
+
 class AbstractPaths(ABC):
     def __init__(
         self,
@@ -52,6 +65,15 @@ class AbstractPaths(ABC):
         The output path of the `NonLinearSearch` results will be:
 
         /path/to/output/folder_0/folder_1/name
+
+        If the ``PYAUTO_TEST_MODE`` environment variable is set, a
+        ``test_mode`` segment is inserted directly after the output
+        root:
+
+        /path/to/output/test_mode/folder_0/folder_1/name
+
+        This keeps smoke-test artefacts in a sibling tree so they
+        cannot be picked up by a later real run with the same paths.
 
         Parameters
         ----------
@@ -246,6 +268,7 @@ class AbstractPaths(ABC):
                 None,
                 [
                     str(conf.instance.output_path),
+                    _test_mode_segment(),
                     str(self.path_prefix),
                     self.unique_tag,
                     str(self.name),

--- a/autofit/non_linear/paths/directory.py
+++ b/autofit/non_linear/paths/directory.py
@@ -16,7 +16,7 @@ from autofit.text import formatter
 from autofit.tools.util import open_
 from autofit.non_linear.samples.samples import Samples
 
-from .abstract import AbstractPaths
+from .abstract import AbstractPaths, _test_mode_segment
 
 from ..samples import load_from_table
 from autofit.non_linear.samples.pdf import SamplesPDF
@@ -530,7 +530,11 @@ class DirectoryPaths(AbstractPaths):
         The path terminates with the identifier, unless the identifier has already
         been added to the path.
         """
-        path_ = Path(conf.instance.output_path) / self.path_prefix / self.name
+        path_ = Path(conf.instance.output_path)
+        segment = _test_mode_segment()
+        if segment:
+            path_ = path_ / segment
+        path_ = path_ / self.path_prefix / self.name
         if self.is_identifier_in_paths:
             path_ = path_ / self.identifier
         return path_

--- a/test_autofit/non_linear/paths/test_paths.py
+++ b/test_autofit/non_linear/paths/test_paths.py
@@ -75,3 +75,33 @@ def test_serialize(model):
 def test_unique_tag():
     paths = af.DirectoryPaths(unique_tag="unique_tag")
     assert "unique_tag" in paths.output_path.parts
+
+
+class TestTestModeOutputPath:
+    """
+    PYAUTO_TEST_MODE must namespace the AutoFit output path so smoke
+    runs cannot poison the cache for a later real run at the same
+    paths. Regression for the "Fit Already Completed" silent skip.
+    """
+
+    def test_output_path_contains_test_mode_segment_when_env_set(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("PYAUTO_TEST_MODE", "2")
+        paths = af.DirectoryPaths(name="name", path_prefix="prefix")
+        assert "test_mode" in paths.output_path.parts
+
+    def test_output_path_excludes_segment_when_env_unset(self, monkeypatch):
+        monkeypatch.delenv("PYAUTO_TEST_MODE", raising=False)
+        paths = af.DirectoryPaths(name="name", path_prefix="prefix")
+        assert "test_mode" not in paths.output_path.parts
+
+    def test_make_path_contains_segment_when_env_set(self, monkeypatch):
+        monkeypatch.setenv("PYAUTO_TEST_MODE", "2")
+        paths = af.DirectoryPaths(name="name", path_prefix="prefix")
+        assert "test_mode" in paths._make_path().parts
+
+    def test_make_path_excludes_segment_when_env_unset(self, monkeypatch):
+        monkeypatch.delenv("PYAUTO_TEST_MODE", raising=False)
+        paths = af.DirectoryPaths(name="name", path_prefix="prefix")
+        assert "test_mode" not in paths._make_path().parts


### PR DESCRIPTION
## Summary
When a script is smoke-tested under `PYAUTO_TEST_MODE` and then run for real, AutoFit silently returns the cached test-mode result ("Fit Already Completed: skipping non-linear search") because the output path is identical between the two runs. The proper run never happens — symptom is every recovered σ on the supposedly-real run being exactly 0.

This PR namespaces the test-mode output path so smoke and prod outputs are physically co-resident under `output/test_mode/...` and cannot collide. The previous workaround — `rm -rf output/<path-prefix>/` before the first proper run — is no longer required.

## API Changes
No public symbol additions, removals, or signature changes.

Behaviour change: when the `PYAUTO_TEST_MODE` environment variable is set (any truthy value), AutoFit search output paths get a `test_mode/` segment inserted directly after `conf.instance.output_path`. This affects every search-output path including SQLite database files opened via `open_database()` with a relative filename.

See full details below.

## Test Plan
- [x] New regression tests in `test_autofit/non_linear/paths/test_paths.py` cover both `output_path` and `_make_path` with `PYAUTO_TEST_MODE` set vs unset (4 tests, all pass)
- [x] Full PyAutoFit unit suite: 1408 passed / 1 skipped / 0 failed
- [ ] Validation sweep across workspaces (`/health_check` + per-workspace `/smoke_test` on autofit/autogalaxy/autolens workspaces + ic50_workspace) — see linked issue. Risk being checked: any script that secretly relied on smoke and prod sharing an output path

Closes #1291

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
None.

### Added
- `autofit.non_linear.paths.abstract._test_mode_segment()` — private module-level helper returning `"test_mode"` when `PYAUTO_TEST_MODE` env var is set, else `None`.

### Renamed
None.

### Changed Signature
None.

### Changed Behaviour
- `AbstractPaths.output_path` property — when `PYAUTO_TEST_MODE` is set, the returned path includes a `test_mode/` segment right after the configured output root.
- `DirectoryPaths._make_path()` — same `test_mode/` segment injection when env var is set.
- `autofit.database.open_database(filename)` — when called with a relative `filename` ending in `.sqlite`, the resolved path is prefixed with `test_mode/` under the output root when env var is set. Absolute filenames are unchanged.

### Migration
No code changes required for callers. After this lands, you can stop running `rm -rf output/<path-prefix>/` between a smoke run and a real run at the same paths.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)