### PR TITLE
Add live_visual_update flag for opt-in on-the-fly visualization

### DIFF
--- a/autofit/config/general.yaml
+++ b/autofit/config/general.yaml
@@ -2,6 +2,7 @@ updates:
   iterations_per_quick_update: 1e99 # Non-linear search iterations between every quick update, which just displays the maximum likelihood model fit.
   iterations_per_full_update: 1e99  # Non-linear search iterations between every full update, which outputs all visuals and result fits (e.g. model.result, search.summary), this exits the search and can be slow.
   quick_update_background: false    # If True, quick-update visualization runs on a background thread so sampling is not blocked.
+  live_visual_update: false         # If True, quick-update visuals are pushed to a live surface (a Jupyter cell when in a kernel, a matplotlib viewer subprocess otherwise) in addition to being written to disk.
 hpc:
   hpc_mode: false                   # If True, use HPC mode, which disables GUI visualization, logging to screen and other settings which are not suited to running on a super computer.
   iterations_per_quick_update: 1e99 #  Non-linear search iterations between every quick update, which just displays the maximum likelihood model fit.

--- a/autofit/non_linear/fitness.py
+++ b/autofit/non_linear/fitness.py
@@ -46,6 +46,7 @@ class Fitness:
         batch_size : Optional[int] = None,
         iterations_per_quick_update: Optional[int] = None,
         background_quick_update: bool = False,
+        live_visual_update: bool = False,
     ):
         """
         Interfaces with any non-linear search to fit the model to the data and return a log likelihood via
@@ -130,11 +131,13 @@ class Fitness:
 
         self.batch_size = batch_size
         self.iterations_per_quick_update = iterations_per_quick_update
+        self.live_visual_update = live_visual_update
         self.quick_update_max_lh_parameters = None
         self.quick_update_max_lh = -self._xp.inf
         self.quick_update_count = 0
 
         self._background_quick_update = None
+        self._live_display = None
 
         if background_quick_update and self.iterations_per_quick_update is not None:
             from autofit.non_linear.quick_update import BackgroundQuickUpdate
@@ -146,7 +149,16 @@ class Fitness:
 
             self._background_quick_update = BackgroundQuickUpdate(
                 convert_jax=convert_jax,
+                live_visual_update=self.live_visual_update,
             )
+        elif self.live_visual_update and self.iterations_per_quick_update is not None:
+            # Synchronous quick-update path: BackgroundQuickUpdate is off
+            # but the user still asked for live visuals. Manage display
+            # surfaces via a standalone LiveDisplay; the rendering itself
+            # still runs on the main thread inside `manage_quick_update`.
+            from autofit.non_linear.quick_update import LiveDisplay
+
+            self._live_display = LiveDisplay(live_visual_update=True)
 
         if self.paths is not None:
             self.check_log_likelihood(fitness=self)
@@ -346,6 +358,14 @@ class Fitness:
                     self.analysis.perform_quick_update(self.paths, instance)
                 except NotImplementedError:
                     pass
+                else:
+                    if self._live_display is not None:
+                        try:
+                            self._live_display.update(self.paths)
+                        except Exception:
+                            logger.exception(
+                                "Live display update raised an exception (ignored)."
+                            )
 
             result_info = text_util.result_max_lh_info_from(
                 max_log_likelihood_sample=self.quick_update_max_lh_parameters.tolist(),
@@ -362,10 +382,15 @@ class Fitness:
             logger.info(f"Quick update complete in {time.time() - start_time} seconds.")
 
     def shutdown_quick_update(self):
-        """Shut down the background quick-update worker, if one is running."""
+        """Shut down the background quick-update worker and any live
+        display surfaces (matplotlib viewer subprocess) that were spawned
+        for this fitness instance."""
         if self._background_quick_update is not None:
             self._background_quick_update.shutdown()
             self._background_quick_update = None
+        if self._live_display is not None:
+            self._live_display.shutdown()
+            self._live_display = None
 
     @timeout(timeout_seconds)
     def __call__(self, parameters, *kwargs):

--- a/autofit/non_linear/live_viewer.py
+++ b/autofit/non_linear/live_viewer.py
@@ -1,0 +1,142 @@
+"""
+Standalone matplotlib viewer process for live quick-update visualization.
+
+Invoked by :class:`BackgroundQuickUpdate` (via ``subprocess.Popen``) when
+``live_visual_update=True`` and the search is running in plain script mode
+(i.e. not inside a Jupyter / Colab kernel — in a kernel the cell update
+path is used instead).
+
+The viewer owns its own matplotlib window in its own process. Running in
+a subprocess sidesteps two issues:
+
+- matplotlib Figures are not thread-safe, so the existing
+  ``BackgroundQuickUpdate`` daemon-thread can't open windows itself.
+- A GUI event loop in the search process would compete with the sampler
+  for the main thread.
+
+Invocation::
+
+    python -m autofit.non_linear.live_viewer <image_path> [--title TITLE]
+
+The viewer polls ``<image_path>`` (typically
+``<output>/image/subplot_fit.png``) every 0.5s. On ``st_mtime`` change it
+reloads the PNG and redraws. Exits cleanly on SIGINT / SIGTERM / window
+close. Logs a single warning and exits 0 if the configured matplotlib
+backend cannot display a window (e.g. headless WSL2 with MPLBACKEND=Agg).
+"""
+
+import argparse
+import logging
+import os
+import signal
+import sys
+import time
+from pathlib import Path
+
+logger = logging.getLogger("autofit.live_viewer")
+
+
+POLL_SECONDS = 0.5
+HEADLESS_BACKENDS = {"agg", "pdf", "ps", "svg", "cairo", "template"}
+
+
+def _backend_can_show() -> bool:
+    """Return True if the active matplotlib backend can display a window."""
+    import matplotlib
+
+    backend = matplotlib.get_backend().lower()
+    return not any(backend.startswith(name) for name in HEADLESS_BACKENDS)
+
+
+def _install_signal_handlers(stop_event):
+    def _handle(signum, frame):
+        stop_event["stop"] = True
+
+    signal.signal(signal.SIGINT, _handle)
+    signal.signal(signal.SIGTERM, _handle)
+
+
+def run(image_path: Path, title: str) -> int:
+    import matplotlib
+
+    if not _backend_can_show():
+        logger.warning(
+            "live_viewer: matplotlib backend %r cannot display a window; "
+            "live visualization disabled (PNG writes to %s continue normally).",
+            matplotlib.get_backend(),
+            image_path,
+        )
+        return 0
+
+    import matplotlib.image as mpimg
+    import matplotlib.pyplot as plt
+
+    plt.ion()
+    fig = plt.figure(num=title)
+    fig.canvas.manager.set_window_title(title)
+    ax = fig.add_subplot(1, 1, 1)
+    ax.set_axis_off()
+    fig.tight_layout()
+
+    im = None
+    last_mtime: float | None = None
+    stop = {"stop": False}
+    _install_signal_handlers(stop)
+
+    def _window_closed(_event):
+        stop["stop"] = True
+
+    fig.canvas.mpl_connect("close_event", _window_closed)
+
+    while not stop["stop"]:
+        try:
+            mtime = image_path.stat().st_mtime if image_path.exists() else None
+        except OSError:
+            mtime = None
+
+        if mtime is not None and mtime != last_mtime:
+            try:
+                img = mpimg.imread(str(image_path))
+            except Exception:
+                img = None
+
+            if img is not None:
+                if im is None:
+                    im = ax.imshow(img)
+                else:
+                    im.set_data(img)
+                fig.canvas.draw_idle()
+                last_mtime = mtime
+
+        try:
+            plt.pause(POLL_SECONDS)
+        except Exception:
+            break
+
+    try:
+        plt.close(fig)
+    except Exception:
+        pass
+    return 0
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(prog="autofit.live_viewer")
+    parser.add_argument("image_path", help="Path to the PNG to display.")
+    parser.add_argument(
+        "--title",
+        default="PyAutoFit — quick update",
+        help="Window title.",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=os.environ.get("PYAUTO_LIVE_VIEWER_LOG", "WARNING"),
+        format="%(levelname)s %(name)s: %(message)s",
+    )
+
+    return run(Path(args.image_path), args.title)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/autofit/non_linear/live_viewer.py
+++ b/autofit/non_linear/live_viewer.py
@@ -18,9 +18,9 @@ Invocation::
 
     python -m autofit.non_linear.live_viewer <image_path> [--title TITLE]
 
-The viewer polls ``<image_path>`` (typically
-``<output>/image/subplot_fit.png``) every 0.5s. On ``st_mtime`` change it
-reloads the PNG and redraws. Exits cleanly on SIGINT / SIGTERM / window
+The viewer polls ``<image_path>`` (typically ``<output>/image/fit.png``,
+the canonical filename written by ``subplot_fit`` across all dataset
+types) every 0.5s. On ``st_mtime`` change it reloads the PNG and redraws. Exits cleanly on SIGINT / SIGTERM / window
 close. Logs a single warning and exits 0 if the configured matplotlib
 backend cannot display a window (e.g. headless WSL2 with MPLBACKEND=Agg).
 """

--- a/autofit/non_linear/quick_update.py
+++ b/autofit/non_linear/quick_update.py
@@ -31,13 +31,13 @@ def _convert_jax_to_numpy(instance):
     return instance
 
 
-# Filenames the worker will look for under `paths.image_path`, in priority
-# order, when refreshing a live quick-update display. The first existing
-# file wins. PyAutoGalaxy / PyAutoLens `subplot_fit` plotters save under
-# `fit.png` (the literal "fit" basename is passed to `_save_subplot`);
-# `subplot_tracer.png` is the fallback name used by some dataset-model
-# variants that don't have a fit subplot per se.
-_DISPLAY_CANDIDATES = ("fit.png", "subplot_tracer.png")
+# Filename the worker looks for under `paths.image_path` when refreshing
+# a live quick-update display. Every dataset-type `subplot_fit` plotter
+# in PyAutoGalaxy / PyAutoLens writes this exact name — the basename
+# `"fit"` is passed to `_save_subplot` / `save_figure`, which appends
+# the `.png` extension. The `subplot_` prefix that the constant used to
+# carry no longer exists on any output anywhere in the codebase.
+_DISPLAY_CANDIDATES = ("fit.png",)
 
 
 def _is_ipython_kernel() -> bool:

--- a/autofit/non_linear/quick_update.py
+++ b/autofit/non_linear/quick_update.py
@@ -1,8 +1,11 @@
 import copy
 import logging
 import os
+import subprocess
+import sys
 import threading
 from pathlib import Path
+from typing import Optional
 
 import numpy as np
 
@@ -36,6 +39,196 @@ def _convert_jax_to_numpy(instance):
 _DISPLAY_CANDIDATES = ("subplot_fit.png", "fit.png", "subplot_tracer.png")
 
 
+def _is_ipython_kernel() -> bool:
+    """
+    Return ``True`` if running inside a Jupyter / Colab IPython kernel,
+    ``False`` otherwise (script mode, REPL, IPython terminal).
+
+    Detection works by importing ``IPython.get_ipython`` and checking
+    that the returned shell has ``IPKernelApp`` registered in its
+    config — only kernel-based shells (Jupyter, Colab, JupyterLab) do.
+    A plain IPython terminal returns a shell without the kernel app,
+    so it does not match. ``ImportError`` (IPython not installed) and
+    any other exception are swallowed so detection stays decoupled
+    from the optional IPython dependency.
+    """
+    try:
+        from IPython import get_ipython
+    except ImportError:
+        return False
+    try:
+        ipy = get_ipython()
+        if ipy is None:
+            return False
+        return "IPKernelApp" in getattr(ipy, "config", {})
+    except Exception:
+        return False
+
+
+def _resolve_display_image_path(paths) -> Optional[Path]:
+    """
+    Return the first existing PNG under ``paths.image_path`` that matches
+    one of the canonical quick-update filenames, or ``None`` if none of
+    them exist yet (e.g. the analysis ran with ``PYAUTO_FAST_PLOTS=1``
+    and wrote no figures this iteration).
+    """
+    image_path = getattr(paths, "image_path", None)
+    if image_path is None:
+        return None
+    base = Path(image_path)
+    for name in _DISPLAY_CANDIDATES:
+        candidate = base / name
+        if candidate.exists():
+            return candidate
+    return None
+
+
+class LiveDisplay:
+    """
+    Manages live display surfaces for quick-update PNGs.
+
+    When ``live_visual_update=True`` this object dispatches each refresh
+    to one of two surfaces:
+
+    - **Jupyter / Colab kernel** — pushes the freshly-written PNG into a
+      single cell output element using a stable ``display_id`` so the
+      image updates in place.
+    - **Script mode** — lazily spawns a small subprocess
+      (``python -m autofit.non_linear.live_viewer``) that owns its own
+      matplotlib window and polls the PNG on disk. Spawning is deferred
+      until the first call because we need ``paths.image_path`` from the
+      first work item.
+
+    When ``live_visual_update=False`` every method is a no-op — disk PNG
+    writes still happen elsewhere, but no live surface is opened. This
+    is the default; users must opt in explicitly per-search.
+
+    The opt-out env var ``PYAUTO_DISABLE_IPYTHON_DISPLAY=1`` continues to
+    suppress kernel-side display side-effects (papermill / nbconvert
+    pipelines that want PNGs on disk only).
+    """
+
+    def __init__(
+        self,
+        live_visual_update: bool = False,
+        display_id: str = "pyauto_fit_progress",
+    ):
+        self.live_visual_update = live_visual_update
+        self.display_id = display_id
+
+        self._display_initialised = False
+        self._viewer_proc: Optional[subprocess.Popen] = None
+        self._viewer_attempted = False
+
+        self._is_kernel = _is_ipython_kernel() if live_visual_update else False
+
+    def update(self, paths) -> None:
+        """
+        Refresh the live display surface using whatever PNG has just been
+        written under ``paths.image_path``. Called by the quick-update
+        path immediately after :py:meth:`Analysis.perform_quick_update`
+        returns.
+
+        No-op when ``live_visual_update=False``.
+        """
+        if not self.live_visual_update:
+            return
+
+        if self._is_kernel:
+            self._push_to_ipython(paths)
+        else:
+            self._ensure_viewer(paths)
+
+    def shutdown(self, timeout: float = 5.0) -> None:
+        """
+        Tear down any spawned viewer subprocess. Safe to call when no
+        viewer is running.
+        """
+        proc = self._viewer_proc
+        self._viewer_proc = None
+        if proc is None:
+            return
+        try:
+            proc.terminate()
+        except Exception:
+            return
+        try:
+            proc.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+        except Exception:
+            pass
+
+    def _push_to_ipython(self, paths) -> None:
+        """
+        Display or refresh the latest quick-update subplot in the active
+        IPython cell using a stable ``display_id``.
+
+        The image is read from disk as PNG bytes — we deliberately do
+        **not** touch matplotlib Figure objects here because callers may
+        invoke this from a daemon thread, and matplotlib Figures are not
+        thread-safe.
+
+        Skipped entirely when ``PYAUTO_DISABLE_IPYTHON_DISPLAY=1`` is set.
+        """
+        if os.environ.get("PYAUTO_DISABLE_IPYTHON_DISPLAY") == "1":
+            return
+
+        png_path = _resolve_display_image_path(paths)
+        if png_path is None:
+            return
+
+        try:
+            from IPython.display import Image, display, update_display
+        except ImportError:
+            return
+
+        img = Image(filename=str(png_path))
+        if self._display_initialised:
+            update_display(img, display_id=self.display_id)
+        else:
+            display(img, display_id=self.display_id)
+            self._display_initialised = True
+
+    def _ensure_viewer(self, paths) -> None:
+        """
+        Lazily spawn the matplotlib viewer subprocess on first call. If
+        the viewer is already running, this is a no-op. If a spawn was
+        already attempted (successful or not), we do not retry — closing
+        the window is treated as opt-out for the rest of the run.
+        """
+        if self._viewer_proc is not None:
+            return
+        if self._viewer_attempted:
+            return
+
+        png_path = _resolve_display_image_path(paths)
+        if png_path is None:
+            return
+
+        self._viewer_attempted = True
+
+        try:
+            self._viewer_proc = subprocess.Popen(
+                [
+                    sys.executable,
+                    "-m",
+                    "autofit.non_linear.live_viewer",
+                    str(png_path),
+                ],
+                stdin=subprocess.DEVNULL,
+            )
+        except Exception:
+            logger.exception(
+                "Failed to launch live_viewer subprocess; live "
+                "visualization disabled for this run."
+            )
+            self._viewer_proc = None
+
+
 class BackgroundQuickUpdate:
     """
     Runs ``analysis.perform_quick_update`` on a background daemon thread so
@@ -44,38 +237,38 @@ class BackgroundQuickUpdate:
     Uses a **latest-only** pattern: if a new best-fit arrives before the
     previous visualisation finishes, the stale request is silently replaced.
 
-    When the search is running inside a Jupyter / Colab kernel, the worker
-    additionally pushes the freshly-written subplot PNG to the active cell
-    via :func:`IPython.display.update_display` with a stable ``display_id``,
-    so the cell that ran ``search.fit(...)`` shows a single self-updating
-    image rather than just writing PNGs to disk. Outside a kernel (plain
-    ``python my_fit.py``) this layer is silently skipped — PNGs still land
-    on disk and no IPython side effects fire. Users can opt out inside a
-    kernel by setting ``PYAUTO_DISABLE_IPYTHON_DISPLAY=1`` (e.g. for
-    papermill / automated nbconvert pipelines).
+    After each ``perform_quick_update`` completes, the worker delegates to
+    a :class:`LiveDisplay` to push the freshly-written PNG to either a
+    Jupyter cell or a script-mode matplotlib viewer subprocess (only when
+    ``live_visual_update=True``).
 
     Parameters
     ----------
     convert_jax
         If ``True``, JAX arrays on the model instance are converted to
         NumPy before handing them to the worker thread.
+    live_visual_update
+        If ``True``, enable live display surfaces (Jupyter cell update
+        when running inside a kernel, matplotlib viewer subprocess
+        otherwise). Defaults to ``False`` — disk PNG writes always
+        happen regardless of this flag.
     display_id
         Stable identifier passed to ``IPython.display.update_display`` so
         every quick-update frame refreshes the same cell output element
-        rather than appending a new one. Default
-        ``"pyauto_fit_progress"`` is fine for almost all uses; override
-        only when running two concurrent searches in the same kernel and
-        wanting each in its own cell output.
+        rather than appending a new one.
     """
 
     def __init__(
         self,
         convert_jax: bool = False,
+        live_visual_update: bool = False,
         display_id: str = "pyauto_fit_progress",
     ):
         self._convert_jax = convert_jax
-        self._display_id = display_id
-        self._display_initialised = False
+        self._live_display = LiveDisplay(
+            live_visual_update=live_visual_update,
+            display_id=display_id,
+        )
 
         self._lock = threading.Lock()
         self._pending = None
@@ -108,84 +301,7 @@ class BackgroundQuickUpdate:
         self._stop.set()
         self._has_work.set()
         self._thread.join(timeout=timeout)
-
-    @staticmethod
-    def _is_ipython_kernel() -> bool:
-        """
-        Return ``True`` if running inside a Jupyter / Colab IPython kernel,
-        ``False`` otherwise (script mode, REPL, IPython terminal).
-
-        Detection works by importing ``IPython.get_ipython`` and checking
-        that the returned shell has ``IPKernelApp`` registered in its
-        config — only kernel-based shells (Jupyter, Colab, JupyterLab) do.
-        A plain IPython terminal returns a shell without the kernel app,
-        so it does not match. ``ImportError`` (IPython not installed) and
-        any other exception are swallowed: the worker stays decoupled from
-        the optional IPython dependency.
-        """
-        try:
-            from IPython import get_ipython
-        except ImportError:
-            return False
-        try:
-            ipy = get_ipython()
-            if ipy is None:
-                return False
-            return "IPKernelApp" in getattr(ipy, "config", {})
-        except Exception:
-            return False
-
-    def _resolve_display_image_path(self, paths):
-        """
-        Return the first existing PNG under ``paths.image_path`` that
-        matches one of the canonical quick-update filenames, or ``None``
-        if none of them exist yet (e.g. the analysis ran with
-        ``PYAUTO_FAST_PLOTS=1`` and wrote no figures this iteration).
-        """
-        image_path = getattr(paths, "image_path", None)
-        if image_path is None:
-            return None
-        base = Path(image_path)
-        for name in _DISPLAY_CANDIDATES:
-            candidate = base / name
-            if candidate.exists():
-                return candidate
-        return None
-
-    def _push_to_ipython(self, paths):
-        """
-        Display or refresh the latest quick-update subplot in the active
-        IPython cell using a stable ``display_id``.
-
-        The first call publishes the image via ``display(... display_id=...)``;
-        subsequent calls update it in place via
-        ``update_display(... display_id=...)``. The image is read from disk
-        as PNG bytes — we deliberately do **not** touch matplotlib Figure
-        objects here because this method runs on the daemon worker thread
-        and matplotlib Figures are not thread-safe.
-
-        Skipped entirely when ``PYAUTO_DISABLE_IPYTHON_DISPLAY=1`` is set
-        — useful for papermill / nbconvert pipelines that want PNGs on
-        disk but no inline display side effects.
-        """
-        if os.environ.get("PYAUTO_DISABLE_IPYTHON_DISPLAY") == "1":
-            return
-
-        png_path = self._resolve_display_image_path(paths)
-        if png_path is None:
-            return
-
-        try:
-            from IPython.display import Image, display, update_display
-        except ImportError:
-            return
-
-        img = Image(filename=str(png_path))
-        if self._display_initialised:
-            update_display(img, display_id=self._display_id)
-        else:
-            display(img, display_id=self._display_id)
-            self._display_initialised = True
+        self._live_display.shutdown()
 
     def _process_pending(self):
         with self._lock:
@@ -207,17 +323,12 @@ class BackgroundQuickUpdate:
             )
             return
 
-        # If running inside a Jupyter / Colab kernel, push the freshly-
-        # written subplot PNG to the active cell so the user sees the fit
-        # update in place. Any failure here is logged-and-swallowed so a
-        # display problem never takes the search down.
-        if self._is_ipython_kernel():
-            try:
-                self._push_to_ipython(paths)
-            except Exception:
-                logger.exception(
-                    "IPython display update raised an exception (ignored)."
-                )
+        try:
+            self._live_display.update(paths)
+        except Exception:
+            logger.exception(
+                "Live display update raised an exception (ignored)."
+            )
 
     def _worker(self):
         while True:

--- a/autofit/non_linear/quick_update.py
+++ b/autofit/non_linear/quick_update.py
@@ -32,11 +32,12 @@ def _convert_jax_to_numpy(instance):
 
 
 # Filenames the worker will look for under `paths.image_path`, in priority
-# order, when pushing a quick-update frame to a Jupyter / Colab cell. The
-# first existing file wins. Imaging analyses write `subplot_fit.png`;
-# interferometer / dataset-model variants may write `fit.png` or
-# `subplot_tracer.png`.
-_DISPLAY_CANDIDATES = ("subplot_fit.png", "fit.png", "subplot_tracer.png")
+# order, when refreshing a live quick-update display. The first existing
+# file wins. PyAutoGalaxy / PyAutoLens `subplot_fit` plotters save under
+# `fit.png` (the literal "fit" basename is passed to `_save_subplot`);
+# `subplot_tracer.png` is the fallback name used by some dataset-model
+# variants that don't have a fit subplot per se.
+_DISPLAY_CANDIDATES = ("fit.png", "subplot_tracer.png")
 
 
 def _is_ipython_kernel() -> bool:

--- a/autofit/non_linear/search/abstract_search.py
+++ b/autofit/non_linear/search/abstract_search.py
@@ -130,6 +130,7 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
         initializer: Initializer = None,
         iterations_per_quick_update: Optional[int] = None,
         iterations_per_full_update: int = None,
+        live_visual_update: Optional[bool] = None,
         number_of_cores: int = 1,
         silence: bool = False,
         session: Optional[sa.orm.Session] = None,
@@ -217,6 +218,14 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
         self.quick_update_background = bool(
             conf.instance["general"]["updates"].get(
                 "quick_update_background", False,
+            )
+        )
+
+        self.live_visual_update = bool(
+            live_visual_update
+            if live_visual_update is not None
+            else conf.instance["general"]["updates"].get(
+                "live_visual_update", False,
             )
         )
 

--- a/autofit/non_linear/search/nest/nautilus/search.py
+++ b/autofit/non_linear/search/nest/nautilus/search.py
@@ -194,6 +194,7 @@ class Nautilus(abstract_nest.AbstractNest):
                 resample_figure_of_merit=-1.0e99,
                 iterations_per_quick_update=self.iterations_per_quick_update,
                 background_quick_update=self.quick_update_background,
+                live_visual_update=self.live_visual_update,
                 use_jax_vmap=self.use_jax_vmap,
                 batch_size=self.n_batch,
             )
@@ -214,6 +215,7 @@ class Nautilus(abstract_nest.AbstractNest):
                 resample_figure_of_merit=-1.0e99,
                 iterations_per_quick_update=self.iterations_per_quick_update,
                 background_quick_update=self.quick_update_background,
+                live_visual_update=self.live_visual_update,
             )
 
             search_internal = self.fit_multiprocessing(

--- a/test_autofit/non_linear/test_dict.py
+++ b/test_autofit/non_linear/test_dict.py
@@ -25,6 +25,7 @@ def make_dynesty_dict():
             "inplace": False,
             "iterations_per_full_update": 1e99,
             "iterations_per_quick_update": 1e99,
+            "live_visual_update": False,
             "logl_max": float("inf"),
             "max_move": 100,
             "maxcall": None,

--- a/test_autofit/non_linear/test_quick_update.py
+++ b/test_autofit/non_linear/test_quick_update.py
@@ -4,7 +4,12 @@ import time
 import numpy as np
 import pytest
 
-from autofit.non_linear.quick_update import BackgroundQuickUpdate, _convert_jax_to_numpy
+from autofit.non_linear.quick_update import (
+    BackgroundQuickUpdate,
+    LiveDisplay,
+    _convert_jax_to_numpy,
+    _is_ipython_kernel,
+)
 
 
 class MockPaths:
@@ -178,11 +183,7 @@ class TestIPythonDisplayLayer:
         detection helper must return False. This is the script-mode
         fallback path users rely on when running `python my_fit.py`.
         """
-        worker = BackgroundQuickUpdate()
-        try:
-            assert worker._is_ipython_kernel() is False
-        finally:
-            worker.shutdown()
+        assert _is_ipython_kernel() is False
 
     def test_push_to_ipython_no_op_when_png_missing(self, tmp_path):
         """
@@ -194,13 +195,10 @@ class TestIPythonDisplayLayer:
         class Paths:
             image_path = tmp_path  # exists but contains no PNGs
 
-        worker = BackgroundQuickUpdate()
-        try:
-            # No exception expected, no display side effects.
-            worker._push_to_ipython(Paths())
-            assert worker._display_initialised is False
-        finally:
-            worker.shutdown()
+        live = LiveDisplay(live_visual_update=True)
+        # No exception expected, no display side effects.
+        live._push_to_ipython(Paths())
+        assert live._display_initialised is False
 
     def test_push_to_ipython_display_then_update_sequence(
         self, tmp_path, monkeypatch
@@ -244,13 +242,12 @@ class TestIPythonDisplayLayer:
         class Paths:
             image_path = tmp_path
 
-        worker = BackgroundQuickUpdate(display_id="test-display-id")
-        try:
-            worker._push_to_ipython(Paths())
-            worker._push_to_ipython(Paths())
-            worker._push_to_ipython(Paths())
-        finally:
-            worker.shutdown()
+        live = LiveDisplay(
+            live_visual_update=True, display_id="test-display-id"
+        )
+        live._push_to_ipython(Paths())
+        live._push_to_ipython(Paths())
+        live._push_to_ipython(Paths())
 
         # First call uses `display`, subsequent calls use `update_display`,
         # and the display_id is stable across all of them so the cell
@@ -260,4 +257,97 @@ class TestIPythonDisplayLayer:
             ("update_display", "test-display-id"),
             ("update_display", "test-display-id"),
         ]
-        assert worker._display_initialised is True
+        assert live._display_initialised is True
+
+
+class TestLiveVisualUpdateFlag:
+    """
+    Covers the opt-in `live_visual_update` flag. Default-off means no
+    Jupyter cell push and no script-mode viewer subprocess, even when
+    the surrounding environment would otherwise enable them.
+    """
+
+    def test_default_is_no_op_even_in_simulated_kernel(self, tmp_path, monkeypatch):
+        """
+        With ``live_visual_update=False`` (the default), ``LiveDisplay.update``
+        must never call into IPython.display, even if a Jupyter kernel is
+        present. This protects users who explicitly want PNGs-on-disk only.
+        """
+        import sys
+        import types
+
+        png_path = tmp_path / "subplot_fit.png"
+        png_path.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+        calls = []
+
+        def fake_display(obj, display_id=None):
+            calls.append("display")
+
+        def fake_update_display(obj, display_id=None):
+            calls.append("update_display")
+
+        fake_display_module = types.ModuleType("IPython.display")
+        fake_display_module.display = fake_display
+        fake_display_module.update_display = fake_update_display
+        fake_display_module.Image = type("Image", (), {"__init__": lambda self, **kw: None})
+
+        monkeypatch.setitem(sys.modules, "IPython.display", fake_display_module)
+
+        class Paths:
+            image_path = tmp_path
+
+        live = LiveDisplay(live_visual_update=False)
+        live.update(Paths())
+
+        assert calls == []
+        assert live._display_initialised is False
+        assert live._viewer_proc is None
+        assert live._viewer_attempted is False
+
+    def test_script_mode_spawns_viewer_subprocess(self, tmp_path, monkeypatch):
+        """
+        With ``live_visual_update=True`` outside a kernel, the first call
+        to ``update`` must lazily spawn the live_viewer subprocess against
+        the resolved PNG path.
+        """
+        png_path = tmp_path / "subplot_fit.png"
+        png_path.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+        spawn_calls = []
+
+        class FakePopen:
+            def __init__(self, args, **kwargs):
+                spawn_calls.append(args)
+                self.args = args
+
+            def poll(self):
+                return None
+
+            def terminate(self):
+                pass
+
+            def wait(self, timeout=None):
+                return 0
+
+        import autofit.non_linear.quick_update as qu
+
+        monkeypatch.setattr(qu.subprocess, "Popen", FakePopen)
+
+        class Paths:
+            image_path = tmp_path
+
+        live = LiveDisplay(live_visual_update=True)
+        # Force script-mode dispatch regardless of detection result.
+        live._is_kernel = False
+
+        live.update(Paths())
+        live.update(Paths())  # second call must not re-spawn
+
+        assert len(spawn_calls) == 1
+        argv = spawn_calls[0]
+        assert "autofit.non_linear.live_viewer" in argv
+        assert str(png_path) in argv
+
+        live.shutdown()
+        assert live._viewer_proc is None

--- a/test_autofit/non_linear/test_quick_update.py
+++ b/test_autofit/non_linear/test_quick_update.py
@@ -213,7 +213,7 @@ class TestIPythonDisplayLayer:
         import sys
         import types
 
-        png_path = tmp_path / "subplot_fit.png"
+        png_path = tmp_path / "fit.png"
         png_path.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)  # fake PNG header
 
         calls = []
@@ -276,7 +276,7 @@ class TestLiveVisualUpdateFlag:
         import sys
         import types
 
-        png_path = tmp_path / "subplot_fit.png"
+        png_path = tmp_path / "fit.png"
         png_path.write_bytes(b"\x89PNG\r\n\x1a\n")
 
         calls = []
@@ -311,7 +311,7 @@ class TestLiveVisualUpdateFlag:
         to ``update`` must lazily spawn the live_viewer subprocess against
         the resolved PNG path.
         """
-        png_path = tmp_path / "subplot_fit.png"
+        png_path = tmp_path / "fit.png"
         png_path.write_bytes(b"\x89PNG\r\n\x1a\n")
 
         spawn_calls = []


### PR DESCRIPTION
## Summary

Adds `live_visual_update` (default `False`) to `NonLinearSearch`. When `True`:

- **Script mode** — a lightweight `python -m autofit.non_linear.live_viewer` subprocess opens a matplotlib window that polls `subplot_fit.png` for mtime changes and redraws on each quick-update.
- **Jupyter / Colab** — the existing `display_id`-stable cell update fires.

When `False` (the default), only disk PNG writes happen — no live surface is opened.

**Behaviour change to call out:** today's implicit "if a kernel is detected, push image to cell" is now opt-in. Notebook users who relied on the implicit path must add `live_visual_update=True` to their search constructor to keep the old experience. Disk-only workflows need no change.

## API Changes

`NonLinearSearch.__init__` gains optional `live_visual_update` kwarg (default `None`, falls back to `general.updates.live_visual_update` in config — defaults `false`). `Fitness.__init__` and `BackgroundQuickUpdate.__init__` gain the same flag. A new `LiveDisplay` helper class composes the display surfaces and replaces the inline IPython-push logic that lived on `BackgroundQuickUpdate`. New standalone module `autofit.non_linear.live_viewer` for the script-mode subprocess. New config default `general.updates.live_visual_update: false`. See full details below.

## Test Plan

- [x] `pytest test_autofit/` — 1226 passed, 1 skipped
- [x] `pytest test_autofit/non_linear/test_quick_update.py` — 14 passed; new `TestLiveVisualUpdateFlag` covers the opt-in gate (default does not push to a simulated kernel) and the script-mode viewer subprocess spawn
- [x] `python -m autofit.non_linear.live_viewer /tmp/nonexistent.png` under `MPLBACKEND=Agg` exits 0 with a single warning (headless backend safety check)
- [ ] Manual: run `start_here.py` in `autolens_workspace` with `live_visual_update=True` on `af.Nautilus(...)` and confirm a matplotlib window appears and refreshes every quick update
- [ ] Manual: run the same script in a Jupyter notebook with `live_visual_update=True` and confirm the cell output refreshes in place

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added

- `autofit.non_linear.search.NonLinearSearch(..., live_visual_update: Optional[bool] = None, ...)` — new kwarg. When `None`, reads `general.updates.live_visual_update` from config (defaults `false`). Stored as `self.live_visual_update`.
- `autofit.non_linear.fitness.Fitness(..., live_visual_update: bool = False)` — new kwarg threaded through from the search.
- `autofit.non_linear.quick_update.LiveDisplay(live_visual_update=False, display_id="pyauto_fit_progress")` — new helper class that owns kernel-vs-script dispatch and (in script mode) lazily spawns the viewer subprocess on first update.
- `autofit.non_linear.quick_update.BackgroundQuickUpdate(..., live_visual_update: bool = False)` — new kwarg; composes a `LiveDisplay` internally.
- `autofit.non_linear.live_viewer` — new module. Run as `python -m autofit.non_linear.live_viewer <png_path>`. Polls the file on disk every 0.5s and redraws a matplotlib window on mtime change. Exits cleanly on headless backends (Agg/PDF/SVG/etc.) with a single warning.
- Config: `general.updates.live_visual_update: false` in `autofit/config/general.yaml`.

### Changed Behaviour

- The previously-implicit "if a Jupyter / Colab kernel is detected, push the image to a cell via `display_id`" behaviour is now gated on `live_visual_update=True`. Existing notebook users who relied on the implicit path must opt in explicitly.
- The IPython push logic (`_push_to_ipython`, kernel detection, image-path resolution) moved off `BackgroundQuickUpdate` and into a new `LiveDisplay` helper / module-level functions. These are all private (`_`-prefixed) APIs; tests that referenced them have been updated.
- Disk PNG writes (`subplot_fit.png`, `fit.png`, `subplot_tracer.png`) continue every quick update regardless of the flag.

### Migration

- **Before (notebook user, implicit live cell updates):**
  ```python
  search = af.Nautilus(name=..., iterations_per_quick_update=1000)
  ```
- **After (to keep the same behaviour):**
  ```python
  search = af.Nautilus(name=..., iterations_per_quick_update=1000, live_visual_update=True)
  ```
- **Disk-only workflows need no change** — the default (`False`) preserves "write PNG, no live surface".

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)