### PR TITLE
fix: skip _compute_latent_samples in PYAUTO_TEST_MODE (#1294)

### DIFF
--- a/autofit/non_linear/search/updater.py
+++ b/autofit/non_linear/search/updater.py
@@ -8,6 +8,7 @@ import numpy as np
 import psutil
 
 from autoconf import conf
+from autoconf.test_mode import skip_latents
 
 from autofit import exc
 from autofit.non_linear.paths.database import DatabasePaths
@@ -232,6 +233,8 @@ class SearchUpdater:
         during_analysis: bool,
     ) -> Optional[Samples]:
         """Compute and persist latent variable samples if configured."""
+        if skip_latents():
+            return None
         if not (
             (during_analysis and conf.instance["output"]["latent_during_fit"])
             or (not during_analysis and conf.instance["output"]["latent_after_fit"])

--- a/test_autofit/non_linear/search/test_updater.py
+++ b/test_autofit/non_linear/search/test_updater.py
@@ -1,0 +1,82 @@
+import logging
+from unittest.mock import MagicMock
+
+from autoconf import conf
+
+from autofit.non_linear.search.updater import SearchUpdater
+
+
+def _make_updater() -> SearchUpdater:
+    return SearchUpdater(
+        paths=MagicMock(),
+        timer=MagicMock(),
+        search_logger=logging.getLogger("test_updater"),
+        plot_results_func=MagicMock(),
+        samples_from_func=MagicMock(),
+        disable_output=False,
+        iterations_per_full_update=1.0,
+    )
+
+
+def test__compute_latent_samples__skipped_in_test_mode(monkeypatch):
+    monkeypatch.setenv("PYAUTO_TEST_MODE", "1")
+    monkeypatch.delenv("PYAUTO_SKIP_LATENTS", raising=False)
+
+    analysis = MagicMock()
+    result = _make_updater()._compute_latent_samples(
+        samples=MagicMock(),
+        samples_save=MagicMock(),
+        analysis=analysis,
+        fitness=MagicMock(),
+        during_analysis=False,
+    )
+
+    assert result is None
+    analysis.compute_latent_samples.assert_not_called()
+
+
+def test__compute_latent_samples__skipped_by_explicit_env_var(monkeypatch):
+    monkeypatch.delenv("PYAUTO_TEST_MODE", raising=False)
+    monkeypatch.setenv("PYAUTO_SKIP_LATENTS", "1")
+
+    analysis = MagicMock()
+    result = _make_updater()._compute_latent_samples(
+        samples=MagicMock(),
+        samples_save=MagicMock(),
+        analysis=analysis,
+        fitness=MagicMock(),
+        during_analysis=False,
+    )
+
+    assert result is None
+    analysis.compute_latent_samples.assert_not_called()
+
+
+def test__compute_latent_samples__config_gate_still_works(monkeypatch):
+    """
+    With neither env var set, the existing ``latent_after_fit`` /
+    ``latent_during_fit`` config gate must still short-circuit
+    when both are disabled. Regression for the new skip_latents()
+    check not bypassing the original logic.
+    """
+    monkeypatch.delenv("PYAUTO_TEST_MODE", raising=False)
+    monkeypatch.delenv("PYAUTO_SKIP_LATENTS", raising=False)
+
+    original_after = conf.instance["output"]["latent_after_fit"]
+    original_during = conf.instance["output"]["latent_during_fit"]
+    conf.instance["output"]["latent_after_fit"] = False
+    conf.instance["output"]["latent_during_fit"] = False
+    try:
+        analysis = MagicMock()
+        result = _make_updater()._compute_latent_samples(
+            samples=MagicMock(),
+            samples_save=MagicMock(),
+            analysis=analysis,
+            fitness=MagicMock(),
+            during_analysis=False,
+        )
+        assert result is None
+        analysis.compute_latent_samples.assert_not_called()
+    finally:
+        conf.instance["output"]["latent_after_fit"] = original_after
+        conf.instance["output"]["latent_during_fit"] = original_during


### PR DESCRIPTION
## Summary

Short-circuit `SearchUpdater._compute_latent_samples` to return `None` when `autoconf.test_mode.skip_latents()` is `True`. Eliminates the post-fit latent-processing cost in test-mode runs.

**Root cause.** Under `PYAUTO_TEST_MODE=2` the sampler is already bypassed (mocks the fit), but the post-fit pass still draws `output.latent_draw_via_pdf_size = 100` samples and dispatches `analysis.compute_latent_samples` for each. With PyAutoGalaxy's `AnalysisDataset.LATENT_BATCH_MODE = "jit"` override (forced because the einstein-radius latent's `jax_zero_contour.ZeroSolver` uses `lax.cond` / `lax.while_loop` early-termination and is not `vmap`-compatible), that's a Python loop of 100 JIT dispatches per stage — ~750 s per SLaM fit on CPU. The smoke caller hit the 5-min timeout still inside the first SLaM stage's latent loop.

**Fix.** Two lines at the top of `_compute_latent_samples`: import `skip_latents` from `autoconf.test_mode` and return `None` when it fires. Test-mode runs skip the path entirely; real-mode runs are unchanged. `PYAUTO_SKIP_LATENTS=1` provides the same bypass for real-mode users who don't want the post-fit latent work.

**Validation.** SLaM `slam_start_here.py` end-to-end with the full smoke env (`PYAUTO_TEST_MODE=2 PYAUTO_SKIP_FIT_OUTPUT=1 PYAUTO_SKIP_VISUALIZATION=1 PYAUTO_SKIP_CHECKS=1 PYAUTO_SMALL_DATASETS=1 PYAUTO_FAST_PLOTS=1`) completes in **29.6 s** — all 5 stages (`source_lp[1]` → `source_pix[1]` → `source_pix[2]` → `light[1]` → `mass_total[1]`) run to completion. Previously timed out at 5 min inside `source_lp[1]` latent processing.

**Out of scope.** The deeper architectural fix — splitting `LATENT_BATCH_MODE` per-latent so fast latents `vmap` while `einstein_radius` stays jit-per-sample — is a separate follow-up (real-mode SLaM perf). This PR only unblocks smoke testing.

**Dependency.** Depends on the PyAutoConf PR that adds `skip_latents()`. Merge that one first.

Fixes #1294.

## API Changes

Public API: no change. Purely internal — adds `if skip_latents(): return None` at the top of the private `SearchUpdater._compute_latent_samples` method. The `PYAUTO_SKIP_LATENTS` env var is a new user-facing env knob but documented inline in `autoconf.test_mode.skip_latents()`'s docstring.

See full details below.

## Test Plan

- [x] `python -m pytest test_autofit/` — 1413 passed, 1 skipped.
- [x] New `test_autofit/non_linear/search/test_updater.py` — 3/3 (test-mode trigger, `PYAUTO_SKIP_LATENTS=1` trigger, config-gate regression).
- [x] End-to-end SLaM `slam_start_here.py` with full smoke env completes in 29.6s (previously > 5min, hit timeout).

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed / Renamed

None.

### Added

- `PYAUTO_SKIP_LATENTS=1` environment variable — when set, `SearchUpdater._compute_latent_samples` short-circuits and returns `None`. New env-var knob; previously latent post-processing was only controlled by the `output.latent_after_fit` / `output.latent_during_fit` config gate.

### Changed Behaviour

- `SearchUpdater._compute_latent_samples` (private) now also short-circuits when `autoconf.test_mode.skip_latents()` returns `True` — i.e., any `PYAUTO_TEST_MODE` level set, or `PYAUTO_SKIP_LATENTS=1`. Real-mode runs with neither env var set are unchanged.

### Migration

None for end users. Internal callers do not need to update — the method's `Optional[Samples]` return type already accommodated `None`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)