### PR TITLE
Prefer fit_quick.png in quick-update display candidates

### DIFF
--- a/autofit/non_linear/quick_update.py
+++ b/autofit/non_linear/quick_update.py
@@ -31,13 +31,11 @@ def _convert_jax_to_numpy(instance):
     return instance
 
 
-# Filename the worker looks for under `paths.image_path` when refreshing
-# a live quick-update display. Every dataset-type `subplot_fit` plotter
-# in PyAutoGalaxy / PyAutoLens writes this exact name — the basename
-# `"fit"` is passed to `_save_subplot` / `save_figure`, which appends
-# the `.png` extension. The `subplot_` prefix that the constant used to
-# carry no longer exists on any output anywhere in the codebase.
-_DISPLAY_CANDIDATES = ("fit.png",)
+# Filenames the worker looks for under `paths.image_path` when refreshing
+# a live quick-update display. The first existing file wins. Quick updates
+# write `fit_quick.png` (6-panel subplot); full updates write `fit.png`
+# (12-panel). The quick variant is preferred when both exist.
+_DISPLAY_CANDIDATES = ("fit_quick.png", "fit.png")
 
 
 def _is_ipython_kernel() -> bool:


### PR DESCRIPTION
## Summary

Updates `_DISPLAY_CANDIDATES` in `quick_update.py` to prefer `fit_quick.png` (the new 6-panel quick-update subplot from PyAutoLens PR #546) over `fit.png`. Falls back to `fit.png` for analyses that don't produce the quick variant.

## API Changes

None — internal constant change only.

## Test Plan

- [x] `pytest test_autofit/non_linear/test_quick_update.py` — passes
- [ ] End-to-end: `live_visual_update=True` picks up `fit_quick.png` when available

🤖 Generated with [Claude Code](https://claude.com/claude-code)