### PR TITLE
test: skip NSS tests without optional dependency

### DIFF
--- a/test_autofit/non_linear/search/nest/nss/test_checkpoint.py
+++ b/test_autofit/non_linear/search/nest/nss/test_checkpoint.py
@@ -21,6 +21,10 @@ from autofit.non_linear.search.nest.nss.search import (
 
 
 pytestmark = pytest.mark.filterwarnings("ignore::FutureWarning")
+requires_nss = pytest.mark.skipif(
+    not nss_search_module._HAS_NSS,
+    reason="requires optional `nss` extra",
+)
 
 
 jax = pytest.importorskip("jax")
@@ -119,6 +123,7 @@ def test__save_checkpoint_is_atomic(tmp_path):
     assert path.read_bytes() == good_blob
 
 
+@requires_nss
 def test__nss_checkpoint_path_is_none_for_null_paths():
     """Without a real output dir (NullPaths), checkpoint resolution returns None.
 
@@ -131,6 +136,7 @@ def test__nss_checkpoint_path_is_none_for_null_paths():
     assert search.checkpoint_file is None
 
 
+@requires_nss
 def test__init_accepts_checkpoint_interval():
     search = af.NSS(checkpoint_interval=25)
     assert search.checkpoint_interval == 25
@@ -139,6 +145,7 @@ def test__init_accepts_checkpoint_interval():
     assert default.checkpoint_interval == 100
 
 
+@requires_nss
 def test__init_iterations_per_quick_update_no_longer_warns(caplog):
     """Phase 1's no-op log when the kwarg is set is gone in Phase 3 (the kwarg
     is now actually wired). The warning text must not appear.
@@ -151,6 +158,7 @@ def test__init_iterations_per_quick_update_no_longer_warns(caplog):
     )
 
 
+@requires_nss
 def test__load_checkpoint_called_when_file_exists(tmp_path):
     """Verify ``_load_checkpoint`` is invoked from ``_fit`` when a checkpoint
     file exists at the resolved path.

--- a/test_autofit/non_linear/search/nest/nss/test_search.py
+++ b/test_autofit/non_linear/search/nest/nss/test_search.py
@@ -17,8 +17,13 @@ from autofit.non_linear.search.nest.nss.samples import NSSamples
 
 
 pytestmark = pytest.mark.filterwarnings("ignore::FutureWarning")
+requires_nss = pytest.mark.skipif(
+    not nss_search_module._HAS_NSS,
+    reason="requires optional `nss` extra",
+)
 
 
+@requires_nss
 def test__explicit_params():
     search = af.NSS(
         n_live=500,
@@ -70,6 +75,7 @@ def test__chunked_update_strategy_factory():
         ]
 
 
+@requires_nss
 def test__chunked_nss_algorithm_factory():
     """``build_chunked_nss_algorithm`` returns a ``blackjax.SamplingAlgorithm``-
     shape NamedTuple with ``init`` and ``step`` attributes. This is what
@@ -106,12 +112,14 @@ def test__chunked_nss_algorithm_factory():
     assert isinstance(algo_unchunked, blackjax.SamplingAlgorithm)
 
 
+@requires_nss
 def test__identifier_fields():
     search = af.NSS()
     for field in ("n_live", "num_mcmc_steps", "num_delete", "termination", "seed"):
         assert field in search.__identifier_fields__
 
 
+@requires_nss
 def test__test_mode_loosens_termination():
     search = af.NSS(termination=-3.0)
     search.apply_test_mode()
@@ -124,6 +132,7 @@ def test__init_raises_when_nss_unavailable(monkeypatch):
         af.NSS()
 
 
+@requires_nss
 def test__init_warns_when_number_of_cores_gt_one(caplog):
     with caplog.at_level("WARNING"):
         af.NSS(number_of_cores=4)
@@ -157,6 +166,7 @@ def _make_synthetic_internal(n_live=20, ndim=2, seed=0):
     )
 
 
+@requires_nss
 def test__samples_info_from_synthetic_internal():
     search = af.NSS()
     internal = _make_synthetic_internal()
@@ -178,6 +188,7 @@ def test__samples_info_from_synthetic_internal():
     assert info["sampling_time"] == pytest.approx(10.0, abs=1e-12)
 
 
+@requires_nss
 def test__samples_via_internal_from_returns_nssamples():
     model = af.Model(af.m.MockClassx2)
     model.one = af.UniformPrior(lower_limit=-3.0, upper_limit=3.0)
@@ -201,6 +212,7 @@ def test__samples_via_internal_from_returns_nssamples():
     )
 
 
+@requires_nss
 def test__samples_weight_normalisation_handles_zero_total():
     """When every log_weight is -inf (e.g. catastrophic underflow) we should
     not divide by zero. The implementation clamps via max-subtraction so this
@@ -222,6 +234,7 @@ def test__samples_weight_normalisation_handles_zero_total():
     assert np.allclose(weights, 1.0 / 10, atol=1e-12)
 
 
+@requires_nss
 def test__nssamples_log_evidence_error_property():
     model = af.Model(af.m.MockClassx2)
     model.one = af.UniformPrior(lower_limit=-3.0, upper_limit=3.0)


### PR DESCRIPTION
## Summary
Skip NSS-specific unit tests when the optional `nss` / matching `blackjax.ns` stack is not installed. This keeps the default PyAutoFit test environment green while preserving pure checkpoint serialization coverage and the explicit unavailable-extra ImportError test.

## API Changes
None — test-only changes.

## Test Plan
- [x] `python -m pytest test_autofit/non_linear/search/nest/nss/test_checkpoint.py test_autofit/non_linear/search/nest/nss/test_search.py -q`
- [x] `python -m pytest test_autofit/ -x`

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
- None.

### Added
- None.

### Renamed
- None.

### Changed Signature
- None.

### Changed Behaviour
- None.

### Migration
- None.

</details>
