### PR TITLE
fix: expand bypass-mode fake samples

### DIFF
--- a/autofit/non_linear/search/abstract_search.py
+++ b/autofit/non_linear/search/abstract_search.py
@@ -917,22 +917,27 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
         """
         Build a minimal list of fake Sample objects for test mode bypass.
 
-        Creates two samples: the "best" at the prior median and a second
-        with slightly perturbed parameters and worse likelihood, so that
-        SamplesPDF methods like median_pdf work correctly.
+        Creates a small deterministic sample set: the "best" at the prior
+        median and additional slightly perturbed parameters with worse
+        likelihoods. Four samples keeps bypass mode cheap while allowing
+        downstream structural checks to exercise multi-batch sample handling.
         """
         from autofit.non_linear.samples.sample import Sample
 
-        perturbed = [
-            p * 1.001 if p != 0.0 else 0.001 for p in parameter_vector
-        ]
+        parameter_lists = [parameter_vector]
+        for scale in (1.001, 0.999, 1.002):
+            parameter_lists.append(
+                [p * scale if p != 0.0 else scale - 1.0 for p in parameter_vector]
+            )
 
         return Sample.from_lists(
             model=model,
-            parameter_lists=[parameter_vector, perturbed],
-            log_likelihood_list=[log_likelihood, log_likelihood - 1.0],
-            log_prior_list=[0.0, 0.0],
-            weight_list=[1.0, 0.5],
+            parameter_lists=parameter_lists,
+            log_likelihood_list=[
+                log_likelihood - offset for offset in range(len(parameter_lists))
+            ],
+            log_prior_list=[0.0] * len(parameter_lists),
+            weight_list=[1.0, 0.5, 0.25, 0.125],
         )
 
     @abstractmethod

--- a/test_autofit/non_linear/search/test_abstract_search.py
+++ b/test_autofit/non_linear/search/test_abstract_search.py
@@ -111,6 +111,27 @@ class TestSearchConfig:
         assert "nwalkers" in emcee.__identifier_fields__
         assert "nlive" in dynesty.__identifier_fields__
 
+    def test__bypass_fake_samples_support_multi_batch_checks(self):
+        model = af.Model(af.m.MockClassx2)
+        parameter_vector = [1.0, 2.0]
+
+        sample_list = af.DynestyStatic._build_fake_samples(
+            model=model,
+            parameter_vector=parameter_vector,
+            log_likelihood=-10.0,
+        )
+
+        assert len(sample_list) == 4
+        assert sample_list[0].parameter_lists_for_model(model) == parameter_vector
+        assert sample_list[0].log_likelihood == -10.0
+        assert [sample.log_likelihood for sample in sample_list] == [
+            -10.0,
+            -11.0,
+            -12.0,
+            -13.0,
+        ]
+        assert all(sample.weight > 0.0 for sample in sample_list)
+
 
 class TestUpdaterPathsRefresh:
     """


### PR DESCRIPTION
## Summary
Expands bypass-mode fake samples from two to four deterministic samples so downstream latent-variable checks can exercise multi-batch sample handling in `PYAUTO_TEST_MODE=2/3` without running a real sampler.

## API Changes
`PYAUTO_TEST_MODE=2/3` bypass results now include four deterministic fake samples instead of two. No public signatures changed.
See full details below.

## Test Plan
- [x] `NUMBA_CACHE_DIR=/tmp/numba_cache MPLCONFIGDIR=/tmp/matplotlib python -m pytest test_autofit/non_linear/search/test_abstract_search.py -q`
- [x] `NUMBA_CACHE_DIR=/tmp/numba_cache MPLCONFIGDIR=/tmp/matplotlib python -m pytest -q`
- [x] `PYAUTO_TEST_MODE=2 PYAUTO_SKIP_FIT_OUTPUT=1 PYAUTO_SKIP_VISUALIZATION=1 PYAUTO_SKIP_CHECKS=1 PYAUTO_SMALL_DATASETS=1 PYAUTO_DISABLE_JAX=1 PYAUTO_FAST_PLOTS=1 JAX_ENABLE_X64=True python scripts/features/latent_nan_robustness.py` in `autofit_workspace_test`
- [x] `PYAUTO_TEST_MODE=2 PYAUTO_SKIP_FIT_OUTPUT=1 PYAUTO_SKIP_VISUALIZATION=1 PYAUTO_SKIP_CHECKS=1 PYAUTO_SMALL_DATASETS=1 PYAUTO_DISABLE_JAX=1 PYAUTO_FAST_PLOTS=1 JAX_ENABLE_X64=True python scripts/latent/latent_nan_robustness.py` in `autogalaxy_workspace_test`
- [x] `PYAUTO_TEST_MODE=2 PYAUTO_SKIP_FIT_OUTPUT=1 PYAUTO_SKIP_VISUALIZATION=1 PYAUTO_SKIP_CHECKS=1 PYAUTO_SMALL_DATASETS=1 PYAUTO_DISABLE_JAX=1 PYAUTO_FAST_PLOTS=1 JAX_ENABLE_X64=True python scripts/latent/latent_nan_robustness.py` in `autolens_workspace_test`

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
- None

### Added
- None

### Renamed
- None

### Changed Signature
- None

### Changed Behaviour
- `autofit.non_linear.search.abstract_search.NonLinearSearch._build_fake_samples(...)` now returns four deterministic samples instead of two for bypass-mode search results. This keeps bypass mode cheap while allowing downstream consumers to test multi-batch sample handling.

### Migration
- None

</details>
