### PR TITLE
refactor(latent): first-class Latent class + engine extraction (Phase 1)

### DIFF
--- a/autofit/__init__.py
+++ b/autofit/__init__.py
@@ -70,6 +70,7 @@ from .mapper.prior_model.prior_model import Model
 from .mapper.prior_model.array import Array
 from .non_linear.search.abstract_search import NonLinearSearch
 from .non_linear.analysis.visualize import Visualizer
+from .non_linear.analysis.latent import Latent
 from .non_linear.analysis.analysis import Analysis
 from .non_linear.grid.grid_search import GridSearchResult
 from .non_linear.grid.sensitivity import Sensitivity

--- a/autofit/non_linear/analysis/analysis.py
+++ b/autofit/non_linear/analysis/analysis.py
@@ -1,9 +1,7 @@
 import inspect
 import logging
 from abc import ABC
-import functools
 import numpy as np
-import time
 from typing import Optional, Dict
 
 from autofit import exc
@@ -13,10 +11,9 @@ from autofit.non_linear.samples.summary import SamplesSummary
 from autofit.non_linear.samples.pdf import SamplesPDF
 from autofit.non_linear.result import Result
 from autofit.non_linear.samples.samples import Samples
-from autofit.non_linear.samples.sample import Sample
 
 from .visualize import Visualizer
-from ..samples.util import simple_model_for_kwargs
+from .latent import Latent, latent_samples_from
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +27,14 @@ class Analysis(ABC):
 
     Result = Result
     Visualizer = Visualizer
+    Latent = Latent
 
+    # Legacy latent extension points, kept for backwards compatibility. The
+    # preferred way to define latents is to subclass ``Latent`` (see
+    # ``autofit/non_linear/analysis/latent.py``) and declare ``Latent = MyLatent``
+    # here, mirroring ``Visualizer``. The default ``Latent`` reads the two
+    # attributes below + ``compute_latent_variables`` so existing overrides
+    # keep working unchanged.
     LATENT_KEYS = []
 
     # Strategy used by `compute_latent_samples` when `use_jax=True`.
@@ -127,219 +131,17 @@ class Analysis(ABC):
             return jnp
         return np
 
-    def compute_latent_samples(self, samples: Samples, batch_size : Optional[int] = None) -> Optional[Samples]:
+    def compute_latent_samples(self, samples: Samples, batch_size: Optional[int] = None) -> Optional[Samples]:
         """
-        Compute latent variables from a model instance.
+        Compute latent-variable samples for every posterior sample.
 
-        A latent variable is not itself a free parameter of the model but can be derived from it.
-        Latent variables may provide physically meaningful quantities that help interpret a model
-        fit, and their values (with errors) are stored in `latent.csv` in parallel with `samples.csv`.
-
-        This implementation is designed to be compatible with both NumPy and JAX:
-
-        - It is written to be side-effect free, so it can be JIT-compiled with `jax.jit`.
-        - It can be vectorized over many parameter sets at once using `jax.vmap`, enabling efficient
-          batched evaluation of latent variables for multiple samples.
-        - Returned values should be simple JAX/NumPy scalars or arrays (no Python objects), so they
-          can be stacked into arrays of shape `(n_samples, n_latents)` for batching.
-        - Any NaNs introduced (e.g. from invalid model states) can be masked or replaced downstream.
-
-        Parameters
-        ----------
-        parameters : array-like
-            The parameter vector of the model sample. This will typically come from the non-linear search.
-            Inside this method it is mapped back to a model instance via `model.instance_from_vector`.
-        model : Model
-            The model object defining how the parameter vector is mapped to an instance. Passed explicitly
-            so that this function can be used inside JAX transforms (`vmap`, `jit`) with `functools.partial`.
-
-        Returns
-        -------
-        tuple of (float or jax.numpy scalar)
-            A tuple containing the latent variables in a fixed order:
-            `(intensity_total, magnitude, angle)`. Each entry may be NaN if the corresponding component
-            of the model is not present.
+        Thin wrapper around
+        :func:`autofit.non_linear.analysis.latent.latent_samples_from`, which
+        reads which latents to compute (and how) from ``self.Latent`` (see
+        :class:`Latent`). Kept as a method for backwards compatibility — it is
+        the entry point called by ``SearchUpdater._compute_latent_samples``.
         """
-        batch_size = batch_size or 10
-
-        try:
-
-            start_latent = time.time()
-
-            compute_latent_for_model = functools.partial(self.compute_latent_variables, model=samples.model)
-
-            if self._use_jax:
-                import jax
-                import jax.numpy as jnp
-                start = time.time()
-                if self.LATENT_BATCH_MODE == "vmap":
-                    logger.info("JAX: Applying vmap and jit to likelihood function for latent variables -- may take a few seconds.")
-                    # vmap traces `compute_latent_variables` once for the whole
-                    # batch, so a per-sample try/except is not possible here —
-                    # latent functions on the vmap path must express failures as
-                    # NaN (e.g. `jnp.where`), never by raising. The `jit` and
-                    # numpy paths below do guard per sample.
-                    batched_compute_latent = jax.jit(jax.vmap(compute_latent_for_model))
-                elif self.LATENT_BATCH_MODE == "jit":
-                    logger.info("JAX: Applying per-sample jit to latent variables (LATENT_BATCH_MODE='jit') -- may take a few seconds on first sample.")
-                    jitted_compute_latent = jax.jit(compute_latent_for_model)
-                    n_latents = len(self.LATENT_KEYS)
-                    nan_tuple = tuple(jnp.nan for _ in range(n_latents))
-
-                    def _safe_jitted(p):
-                        # A latent that raises (any exception, not just
-                        # FitException) becomes a NaN row, which the global mask
-                        # below drops — one bad sample must not abort the batch.
-                        try:
-                            return jitted_compute_latent(p)
-                        except Exception:
-                            return nan_tuple
-
-                    def batched_compute_latent(parameters_batch):
-                        # Per-sample jit returns one (l1, l2, ..., lN) tuple per
-                        # sample. Transpose to a tuple of N batched arrays so the
-                        # downstream `jnp.stack(latent_values_batch, axis=-1)`
-                        # works identically to the vmap path.
-                        sample_results = [
-                            _safe_jitted(p) for p in parameters_batch
-                        ]
-                        n_latents = len(sample_results[0])
-                        return tuple(
-                            jnp.stack([s[i] for s in sample_results])
-                            for i in range(n_latents)
-                        )
-                else:
-                    raise ValueError(
-                        f"Unknown LATENT_BATCH_MODE={self.LATENT_BATCH_MODE!r}; expected 'vmap' or 'jit'."
-                    )
-                logger.info(f"JAX: {self.LATENT_BATCH_MODE} dispatch applied in {time.time() - start} seconds.")
-            else:
-                n_latents = len(self.LATENT_KEYS)
-                nan_row = np.full(n_latents, np.nan)
-
-                def _safe_compute(xx):
-                    # Any exception (not just FitException) becomes a NaN row,
-                    # which the global mask below drops — a single failing latent
-                    # evaluation must not abort the whole post-fit latent pass.
-                    try:
-                        return compute_latent_for_model(xx)
-                    except Exception:
-                        return nan_row
-
-                def batched_compute_latent(x):
-                    return np.array([_safe_compute(xx) for xx in x])
-
-            from autoconf.test_mode import inject_latent_nans
-
-            parameter_array = np.array(samples.parameter_lists)
-
-            # Compute every batch first and accumulate the raw, UN-masked latent
-            # values into one (n_samples, n_latents) array. Masking is then done
-            # ONCE, globally, after the loop (see below).
-            #
-            # Doing the finite mask per batch (the previous behaviour) was a bug:
-            # a latent that went NaN for a single sample in one batch had its whole
-            # column dropped *for that batch only*, while other batches kept it.
-            # The resulting `Sample` objects then carried inconsistent kwargs key
-            # sets, and `Samples.summary()` raised `KeyError` building its model
-            # from the first sample's keys. Masking globally guarantees every
-            # retained sample shares one identical key set.
-            all_values = []
-            all_samples = []
-            for i in range(0, len(parameter_array), batch_size):
-
-                batch = parameter_array[i:i + batch_size]
-                batch_samples = samples.sample_list[i:i + batch_size]
-
-                # batched JAX call on this chunk
-                latent_values_batch = batched_compute_latent(batch)
-
-                if self._use_jax:
-                    import jax.numpy as jnp
-                    latent_values_batch = jnp.stack(latent_values_batch, axis=-1)  # (batch, n_latents)
-
-                # Unify to NumPy so the global masking below is a single code path
-                # for both backends (latent values are scalars, host transfer is
-                # cheap and was already forced by the downstream `float(v)`).
-                latent_values_batch = np.asarray(latent_values_batch)
-
-                # Test-only NaN injection (no-op unless PYAUTO_LATENT_NAN_INJECT set).
-                latent_values_batch = inject_latent_nans(latent_values_batch, start_index=i)
-
-                all_values.append(latent_values_batch)
-                all_samples.extend(batch_samples)
-
-            if all_values:
-                all_values = np.concatenate(all_values, axis=0)
-            else:
-                all_values = np.empty((0, len(self.LATENT_KEYS)))
-
-            # Global masking. Every retained sample must share one identical,
-            # fully-finite latent key set (a `Samples` object is a rectangular
-            # samples x latents block; NaNs anywhere break `quantile`).
-            #
-            # 1. Drop a latent column that is non-finite for EVERY sample
-            #    (genuinely degenerate, e.g. a µJy latent with no magzero).
-            kept_idx = [
-                i
-                for i in range(all_values.shape[1])
-                if np.isfinite(all_values[:, i]).any()
-            ]
-
-            # 2. Keep samples that are finite across all currently-kept latents.
-            #    Normally at least one sample is finite everywhere and we stop
-            #    immediately (behaviour unchanged). But if NaNs are anti-correlated
-            #    across latents — every sample NaN in some latent — the rectangular
-            #    block is empty. Rather than discard ALL latent output, greedily
-            #    sacrifice the worst-coverage latent and retry, retaining the
-            #    maximal-coverage latents and their finite samples.
-            while kept_idx:
-                row_mask = np.isfinite(all_values[:, kept_idx]).all(axis=1)
-                if row_mask.any():
-                    break
-                nan_counts = (~np.isfinite(all_values[:, kept_idx])).sum(axis=0)
-                kept_idx.pop(int(np.argmax(nan_counts)))
-
-            print(f"Time to compute latent variables: {time.time() - start_latent} seconds for {len(samples)} samples.")
-
-            if not kept_idx:
-                logger.warning(
-                    "compute_latent_samples: no finite latent samples remained "
-                    "after masking; skipping latent output."
-                )
-                return None
-
-            kept_keys = [self.LATENT_KEYS[i] for i in kept_idx]
-            kept_values = all_values[:, kept_idx]
-            row_mask = np.isfinite(kept_values).all(axis=1)
-            kept_values = kept_values[row_mask]
-            kept_samples = [s for s, keep in zip(all_samples, row_mask) if keep]
-
-            if len(kept_samples) == 0:
-                logger.warning(
-                    "compute_latent_samples: no finite latent samples remained "
-                    "after masking; skipping latent output."
-                )
-                return None
-
-            latent_samples = [
-                Sample(
-                    log_likelihood=sample.log_likelihood,
-                    log_prior=sample.log_prior,
-                    weight=sample.weight,
-                    kwargs={k: float(v) for k, v in zip(kept_keys, values)},
-                )
-                for sample, values in zip(kept_samples, kept_values)
-            ]
-
-            return type(samples)(
-                sample_list=latent_samples,
-                model=simple_model_for_kwargs(latent_samples[0].kwargs),
-                samples_info=samples.samples_info,
-            )
-
-        except NotImplementedError:
-            return None
+        return latent_samples_from(self, samples, batch_size=batch_size)
 
     def compute_latent_variables(self, parameters, model) -> Dict[str, float]:
         """

--- a/autofit/non_linear/analysis/latent.py
+++ b/autofit/non_linear/analysis/latent.py
@@ -1,0 +1,284 @@
+"""
+First-class latent-variable extension point and computation engine.
+
+This module holds the two halves of PyAutoFit's latent-variable machinery,
+extracted from ``Analysis`` so the concern is self-contained (mirroring how
+``Visualizer`` and ``Result`` are declared on an ``Analysis``):
+
+- :class:`Latent` — the user/library extension point. Declare it on an analysis
+  as ``Latent = MyLatent`` (just like ``Visualizer = MyVisualizer``) and override
+  :meth:`Latent.keys` / :meth:`Latent.variables` to define latent variables.
+  Methods are ``@staticmethod`` taking ``analysis`` first, matching the
+  ``Visualizer`` convention.
+
+- :func:`latent_samples_from` — the batched evaluation engine (JAX vmap/jit or
+  NumPy dispatch, global NaN masking + greedy salvage). ``Analysis.compute_latent_samples``
+  is now a thin wrapper around it.
+
+Backwards compatibility: the default :class:`Latent` delegates to the (now
+legacy) ``Analysis.LATENT_KEYS`` / ``Analysis.compute_latent_variables`` /
+``Analysis.LATENT_BATCH_MODE``, so analyses that still override those keep
+working unchanged. New code should subclass :class:`Latent` instead.
+"""
+import functools
+import logging
+import time
+from typing import Optional
+
+import numpy as np
+
+from autofit.non_linear.samples.sample import Sample
+from autofit.non_linear.samples.samples import Samples
+from autofit.non_linear.samples.util import simple_model_for_kwargs
+
+logger = logging.getLogger(__name__)
+
+
+class Latent:
+    """
+    Latent-variable extension point, declared on an analysis as
+    ``Analysis.Latent = MyLatent`` (mirrors ``Visualizer`` / ``Result``).
+
+    Subclass and override :meth:`keys` and :meth:`variables` to define a
+    catalogue of latent variables. All methods are ``@staticmethod`` and take
+    the ``analysis`` as their first argument, so per-fit state (e.g.
+    ``analysis.kwargs["magzero"]``) is reachable without an instance lifecycle.
+
+    The base implementation is a **backwards-compatibility shim**: it reads the
+    legacy ``Analysis.LATENT_KEYS`` and ``Analysis.compute_latent_variables``,
+    so existing analyses that override those continue to work without declaring
+    a ``Latent``. New code should subclass this class instead.
+    """
+
+    # JAX batch strategy: "vmap" or "jit". ``None`` means "defer to
+    # ``analysis.LATENT_BATCH_MODE``" — used by the back-compat shim so that an
+    # analysis which set ``LATENT_BATCH_MODE = "jit"`` (e.g. autogalaxy's
+    # ``AnalysisDataset``) keeps that choice without declaring a ``Latent``.
+    BATCH_MODE = None
+
+    @staticmethod
+    def keys(analysis) -> list:
+        """The ordered list of enabled latent names (back-compat: ``LATENT_KEYS``)."""
+        return list(analysis.LATENT_KEYS)
+
+    @staticmethod
+    def variables(analysis, parameters, model):
+        """
+        Compute the latent values for one sample, returned as a tuple/dict
+        positionally aligned with :meth:`keys`. Back-compat default delegates
+        to ``analysis.compute_latent_variables``.
+        """
+        return analysis.compute_latent_variables(parameters, model)
+
+
+def latent_samples_from(
+    analysis, samples: Samples, batch_size: Optional[int] = None
+) -> Optional[Samples]:
+    """
+    Compute latent-variable samples for every posterior sample.
+
+    A latent variable is not a free parameter of the model but can be derived
+    from it; its values (with errors) are stored in ``latent/`` alongside
+    ``samples.csv``. The latents to compute and how to compute them come from
+    ``analysis.Latent`` (:meth:`Latent.keys` / :meth:`Latent.variables`).
+
+    Compatible with NumPy and JAX: the per-sample computation is side-effect
+    free, batched via ``jax.vmap`` or per-sample ``jax.jit`` (selected by
+    ``Latent.BATCH_MODE``), and any NaN/Inf values are masked out globally
+    (degenerate latents dropped; samples carrying a NaN in a surviving latent
+    dropped; anti-correlated NaNs salvaged by sacrificing the worst-coverage
+    latent rather than discarding everything).
+
+    Returns ``None`` when no finite latent samples remain (or no latents are
+    defined).
+    """
+    batch_size = batch_size or 10
+
+    latent = analysis.Latent
+    batch_mode = (
+        latent.BATCH_MODE
+        if latent.BATCH_MODE is not None
+        else analysis.LATENT_BATCH_MODE
+    )
+    keys = latent.keys(analysis)
+
+    try:
+
+        start_latent = time.time()
+
+        compute_latent_for_model = functools.partial(
+            latent.variables, analysis, model=samples.model
+        )
+
+        if analysis._use_jax:
+            import jax
+            import jax.numpy as jnp
+            start = time.time()
+            if batch_mode == "vmap":
+                logger.info("JAX: Applying vmap and jit to likelihood function for latent variables -- may take a few seconds.")
+                # vmap traces `variables` once for the whole batch, so a
+                # per-sample try/except is not possible here — latent functions
+                # on the vmap path must express failures as NaN (e.g.
+                # `jnp.where`), never by raising. The `jit` and numpy paths
+                # below do guard per sample.
+                batched_compute_latent = jax.jit(jax.vmap(compute_latent_for_model))
+            elif batch_mode == "jit":
+                logger.info("JAX: Applying per-sample jit to latent variables (LATENT_BATCH_MODE='jit') -- may take a few seconds on first sample.")
+                jitted_compute_latent = jax.jit(compute_latent_for_model)
+                n_latents = len(keys)
+                nan_tuple = tuple(jnp.nan for _ in range(n_latents))
+
+                def _safe_jitted(p):
+                    # A latent that raises (any exception, not just
+                    # FitException) becomes a NaN row, which the global mask
+                    # below drops — one bad sample must not abort the batch.
+                    try:
+                        return jitted_compute_latent(p)
+                    except Exception:
+                        return nan_tuple
+
+                def batched_compute_latent(parameters_batch):
+                    # Per-sample jit returns one (l1, l2, ..., lN) tuple per
+                    # sample. Transpose to a tuple of N batched arrays so the
+                    # downstream `jnp.stack(latent_values_batch, axis=-1)`
+                    # works identically to the vmap path.
+                    sample_results = [
+                        _safe_jitted(p) for p in parameters_batch
+                    ]
+                    n_latents = len(sample_results[0])
+                    return tuple(
+                        jnp.stack([s[i] for s in sample_results])
+                        for i in range(n_latents)
+                    )
+            else:
+                raise ValueError(
+                    f"Unknown LATENT_BATCH_MODE={batch_mode!r}; expected 'vmap' or 'jit'."
+                )
+            logger.info(f"JAX: {batch_mode} dispatch applied in {time.time() - start} seconds.")
+        else:
+            n_latents = len(keys)
+            nan_row = np.full(n_latents, np.nan)
+
+            def _safe_compute(xx):
+                # Any exception (not just FitException) becomes a NaN row,
+                # which the global mask below drops — a single failing latent
+                # evaluation must not abort the whole post-fit latent pass.
+                try:
+                    return compute_latent_for_model(xx)
+                except Exception:
+                    return nan_row
+
+            def batched_compute_latent(x):
+                return np.array([_safe_compute(xx) for xx in x])
+
+        from autoconf.test_mode import inject_latent_nans
+
+        parameter_array = np.array(samples.parameter_lists)
+
+        # Compute every batch first and accumulate the raw, UN-masked latent
+        # values into one (n_samples, n_latents) array. Masking is then done
+        # ONCE, globally, after the loop (see below).
+        #
+        # Doing the finite mask per batch (the previous behaviour) was a bug:
+        # a latent that went NaN for a single sample in one batch had its whole
+        # column dropped *for that batch only*, while other batches kept it.
+        # The resulting `Sample` objects then carried inconsistent kwargs key
+        # sets, and `Samples.summary()` raised `KeyError` building its model
+        # from the first sample's keys. Masking globally guarantees every
+        # retained sample shares one identical key set.
+        all_values = []
+        all_samples = []
+        for i in range(0, len(parameter_array), batch_size):
+
+            batch = parameter_array[i:i + batch_size]
+            batch_samples = samples.sample_list[i:i + batch_size]
+
+            # batched JAX call on this chunk
+            latent_values_batch = batched_compute_latent(batch)
+
+            if analysis._use_jax:
+                import jax.numpy as jnp
+                latent_values_batch = jnp.stack(latent_values_batch, axis=-1)  # (batch, n_latents)
+
+            # Unify to NumPy so the global masking below is a single code path
+            # for both backends (latent values are scalars, host transfer is
+            # cheap and was already forced by the downstream `float(v)`).
+            latent_values_batch = np.asarray(latent_values_batch)
+
+            # Test-only NaN injection (no-op unless PYAUTO_LATENT_NAN_INJECT set).
+            latent_values_batch = inject_latent_nans(latent_values_batch, start_index=i)
+
+            all_values.append(latent_values_batch)
+            all_samples.extend(batch_samples)
+
+        if all_values:
+            all_values = np.concatenate(all_values, axis=0)
+        else:
+            all_values = np.empty((0, len(keys)))
+
+        # Global masking. Every retained sample must share one identical,
+        # fully-finite latent key set (a `Samples` object is a rectangular
+        # samples x latents block; NaNs anywhere break `quantile`).
+        #
+        # 1. Drop a latent column that is non-finite for EVERY sample
+        #    (genuinely degenerate, e.g. a µJy latent with no magzero).
+        kept_idx = [
+            i
+            for i in range(all_values.shape[1])
+            if np.isfinite(all_values[:, i]).any()
+        ]
+
+        # 2. Keep samples that are finite across all currently-kept latents.
+        #    Normally at least one sample is finite everywhere and we stop
+        #    immediately (behaviour unchanged). But if NaNs are anti-correlated
+        #    across latents — every sample NaN in some latent — the rectangular
+        #    block is empty. Rather than discard ALL latent output, greedily
+        #    sacrifice the worst-coverage latent and retry, retaining the
+        #    maximal-coverage latents and their finite samples.
+        while kept_idx:
+            row_mask = np.isfinite(all_values[:, kept_idx]).all(axis=1)
+            if row_mask.any():
+                break
+            nan_counts = (~np.isfinite(all_values[:, kept_idx])).sum(axis=0)
+            kept_idx.pop(int(np.argmax(nan_counts)))
+
+        print(f"Time to compute latent variables: {time.time() - start_latent} seconds for {len(samples)} samples.")
+
+        if not kept_idx:
+            logger.warning(
+                "compute_latent_samples: no finite latent samples remained "
+                "after masking; skipping latent output."
+            )
+            return None
+
+        kept_keys = [keys[i] for i in kept_idx]
+        kept_values = all_values[:, kept_idx]
+        row_mask = np.isfinite(kept_values).all(axis=1)
+        kept_values = kept_values[row_mask]
+        kept_samples = [s for s, keep in zip(all_samples, row_mask) if keep]
+
+        if len(kept_samples) == 0:
+            logger.warning(
+                "compute_latent_samples: no finite latent samples remained "
+                "after masking; skipping latent output."
+            )
+            return None
+
+        latent_samples = [
+            Sample(
+                log_likelihood=sample.log_likelihood,
+                log_prior=sample.log_prior,
+                weight=sample.weight,
+                kwargs={k: float(v) for k, v in zip(kept_keys, values)},
+            )
+            for sample, values in zip(kept_samples, kept_values)
+        ]
+
+        return type(samples)(
+            sample_list=latent_samples,
+            model=simple_model_for_kwargs(latent_samples[0].kwargs),
+            samples_info=samples.samples_info,
+        )
+
+    except NotImplementedError:
+        return None

--- a/test_autofit/analysis/test_latent.py
+++ b/test_autofit/analysis/test_latent.py
@@ -1,0 +1,201 @@
+"""
+Tests for the first-class ``Latent`` extension class and the
+``latent_samples_from`` engine (``autofit/non_linear/analysis/latent.py``).
+
+These cover the NEW class-based path (subclass ``af.Latent``, declare
+``Analysis.Latent = ...``). The legacy method-override path
+(``compute_latent_variables`` / ``LATENT_KEYS``) is covered by
+``test_latent_variables.py``, which also exercises the back-compat shim.
+"""
+import numpy as np
+import pytest
+
+import autofit as af
+from autofit import SamplesPDF
+from autofit.non_linear.analysis.latent import latent_samples_from
+
+# fwhm for a Gaussian with sigma=3.0 (2 * sqrt(2 ln2) * 3).
+FWHM_SIGMA_3 = 7.0644601350928475
+
+
+def _samples(sample_list):
+    return SamplesPDF(model=af.Model(af.ex.Gaussian), sample_list=sample_list)
+
+
+def _sample(centre=1.0, sigma=3.0, weight=1.0, log_likelihood=1.0):
+    return af.Sample(
+        log_likelihood=log_likelihood,
+        log_prior=0.0,
+        weight=weight,
+        kwargs={"centre": centre, "normalization": 2.0, "sigma": sigma},
+    )
+
+
+class FwhmLatent(af.Latent):
+    @staticmethod
+    def keys(analysis):
+        return ["fwhm"]
+
+    @staticmethod
+    def variables(analysis, parameters, model):
+        instance = model.instance_from_vector(vector=parameters)
+        return (instance.fwhm,)
+
+
+class FwhmAnalysis(af.Analysis):
+    Latent = FwhmLatent
+
+    def log_likelihood_function(self, instance):
+        return 1.0
+
+
+def test_latent_class_path_matches_method_override():
+    """Declaring `Latent = FwhmLatent` produces the same latent samples the
+    legacy `compute_latent_variables` override would (see test_latent_variables)."""
+    latent = FwhmAnalysis().compute_latent_samples(_samples([_sample()]))
+    assert latent.sample_list[0].kwargs == {("fwhm",): FWHM_SIGMA_3}
+    assert latent.model.instance_from_vector([1.0]).fwhm == 1.0
+
+
+def test_latent_samples_from_callable_directly():
+    """The engine is usable as a free function, decoupled from the Analysis."""
+    latent = latent_samples_from(FwhmAnalysis(), _samples([_sample(), _sample(centre=2.0)]))
+    assert latent is not None
+    assert len(latent.sample_list) == 2
+
+
+class LegacyAndLatentAnalysis(af.Analysis):
+    """A `Latent` subclass must win over the legacy attrs when both are present."""
+
+    Latent = FwhmLatent
+    LATENT_KEYS = ["should_not_be_used"]
+
+    def compute_latent_variables(self, parameters, model):
+        raise AssertionError(
+            "legacy compute_latent_variables must not be called when Latent overrides variables()"
+        )
+
+    def log_likelihood_function(self, instance):
+        return 1.0
+
+
+def test_latent_class_overrides_legacy_attrs():
+    latent = LegacyAndLatentAnalysis().compute_latent_samples(_samples([_sample()]))
+    assert set(latent.sample_list[0].kwargs) == {("fwhm",)}
+
+
+def test_default_latent_shim_reads_legacy_attrs():
+    """The default base `Latent` delegates to the legacy attrs (back-compat)."""
+
+    class LegacyAnalysis(af.Analysis):
+        LATENT_KEYS = ["fwhm"]
+
+        def compute_latent_variables(self, parameters, model):
+            instance = model.instance_from_vector(vector=parameters)
+            return (instance.fwhm,)
+
+        def log_likelihood_function(self, instance):
+            return 1.0
+
+    analysis = LegacyAnalysis()
+    assert af.Analysis.Latent.keys(analysis) == ["fwhm"]
+    latent = analysis.compute_latent_samples(_samples([_sample()]))
+    assert latent.sample_list[0].kwargs == {("fwhm",): FWHM_SIGMA_3}
+
+
+def test_default_latent_batch_mode_is_none_fallback():
+    """`BATCH_MODE = None` is the sentinel meaning 'defer to analysis.LATENT_BATCH_MODE'."""
+    assert af.Latent.BATCH_MODE is None
+    assert af.Analysis.LATENT_BATCH_MODE == "vmap"
+
+
+class RaisingLatent(af.Latent):
+    @staticmethod
+    def keys(analysis):
+        return ["fwhm"]
+
+    @staticmethod
+    def variables(analysis, parameters, model):
+        if parameters[0] < 0:
+            raise ValueError("boom from latent function")
+        instance = model.instance_from_vector(vector=parameters)
+        return (instance.fwhm,)
+
+
+class RaisingAnalysis(af.Analysis):
+    Latent = RaisingLatent
+
+    def log_likelihood_function(self, instance):
+        return 1.0
+
+
+def test_new_path_skips_arbitrary_exception_samples():
+    latent = RaisingAnalysis().compute_latent_samples(
+        _samples([_sample(centre=1.0), _sample(centre=-1.0, weight=0.0)])
+    )
+    assert len(latent.sample_list) == 1
+    assert latent.sample_list[0].kwargs == {("fwhm",): FWHM_SIGMA_3}
+
+
+class AntiCorrelatedNaNLatent(af.Latent):
+    @staticmethod
+    def keys(analysis):
+        return ["a", "b"]
+
+    @staticmethod
+    def variables(analysis, parameters, model):
+        c = parameters[0]
+        return (np.nan if c < 0 else 1.0, np.nan if c >= 0 else 2.0)
+
+
+class AntiCorrelatedNaNAnalysis(af.Analysis):
+    Latent = AntiCorrelatedNaNLatent
+
+    def log_likelihood_function(self, instance):
+        return 1.0
+
+
+def test_new_path_salvages_anti_correlated_nans():
+    latent = AntiCorrelatedNaNAnalysis().compute_latent_samples(
+        _samples([_sample(centre=cv) for cv in (1.0, -1.0, 2.0, -2.0)])
+    )
+    assert latent is not None
+    surviving = set(latent.sample_list[0].kwargs)
+    assert surviving == {("b",)}
+    assert all(set(s.kwargs) == surviving for s in latent.sample_list)
+
+
+class OneSurvivorLatent(af.Latent):
+    @staticmethod
+    def keys(analysis):
+        return ["fwhm"]
+
+    @staticmethod
+    def variables(analysis, parameters, model):
+        if parameters[0] != 1.0:
+            return (np.nan,)
+        instance = model.instance_from_vector(vector=parameters)
+        return (instance.fwhm,)
+
+
+class OneSurvivorAnalysis(af.Analysis):
+    Latent = OneSurvivorLatent
+
+    def log_likelihood_function(self, instance):
+        return 1.0
+
+
+def test_new_path_single_survivor_summary_does_not_crash():
+    latent = OneSurvivorAnalysis().compute_latent_samples(
+        _samples([
+            _sample(centre=1.0, weight=0.5),
+            _sample(centre=2.0, weight=0.3),
+            _sample(centre=3.0, weight=0.2),
+        ])
+    )
+    assert latent is not None
+    assert len(latent.sample_list) == 1
+    assert latent.pdf_converged  # weight 0.5 <= 0.99 => median_pdf routes to quantile (n=1)
+    _ = latent.summary()
+    instance = latent.median_pdf()
+    assert instance.fwhm == pytest.approx(FWHM_SIGMA_3)


### PR DESCRIPTION
## Summary
Phase 1 of the latent-variable redesign (`PyAutoPrompt/autofit/latent_class_redesign.md`). Decouples latent handling from `Analysis` into a first-class, subclassable `Latent` class — mirroring how `Visualizer`/`Result` are declared on an analysis, and the earlier `SearchUpdater` extraction. **Pure refactor, no behaviour change**, with a back-compat shim so PyAutoGalaxy/PyAutoLens/Euclid/workspaces run unchanged.

- New `autofit/non_linear/analysis/latent.py`:
  - `Latent` base — static `keys(analysis)` / `variables(analysis, parameters, model)` + `BATCH_MODE`; declared as `Analysis.Latent = MyLatent` and subclassed by users.
  - `latent_samples_from(analysis, samples, batch_size)` — the batched engine (JAX vmap/jit dispatch, global mask + greedy salvage) moved verbatim out of `Analysis`.
- `analysis.py`: `Latent = Latent` class attr; `compute_latent_samples` is now a thin delegator; engine removed (**585 → 387 lines**).
- `af.Latent` exported.

## API Changes
No signature changes. New extension point `af.Latent` (declare `Analysis.Latent = ...`, override `keys`/`variables`). The legacy `Analysis.LATENT_KEYS` / `LATENT_BATCH_MODE` / `compute_latent_variables` still work — the default `Latent` delegates to them (back-compat shim).
See full details below.

## Test Plan
- [x] `pytest test_autofit/non_linear test_autofit/analysis` — 298 passed, 14 skipped (NSS optional-dep)
- [x] new-path coverage `test_autofit/analysis/test_latent.py` + back-compat `test_latent_variables.py` + quantile — 32 passed
- [x] cross-library back-compat (live autofit on PYTHONPATH): autofit / autogalaxy / autolens `latent_nan_robustness.py` PASS; autolens `latent_variables_smoke.py` (test-mode) PASS — all via the shim, unchanged

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- `autofit.non_linear.analysis.latent.Latent` (exported as `af.Latent`) — latent extension class; override `keys`/`variables`, set `BATCH_MODE`; declare `Analysis.Latent = MyLatent`.
- `autofit.non_linear.analysis.latent.latent_samples_from(analysis, samples, batch_size=None)` — the latent batching/masking engine, usable standalone.

### Changed (internal, back-compat preserved)
- `Analysis.compute_latent_samples` is now a thin delegator to `latent_samples_from`. The engine body moved out of `analysis.py`.
- `Analysis.LATENT_KEYS`, `Analysis.LATENT_BATCH_MODE`, `Analysis.compute_latent_variables` retained as a back-compat shim (the default `Latent` reads them). Preferred path is now subclassing `Latent`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)