### PR TITLE
fix: skip latent computation without keys

### DIFF
--- a/autofit/non_linear/analysis/latent.py
+++ b/autofit/non_linear/analysis/latent.py
@@ -102,6 +102,9 @@ def latent_samples_from(
     )
     keys = latent.keys(analysis)
 
+    if not keys:
+        return None
+
     try:
 
         start_latent = time.time()


### PR DESCRIPTION
## Summary
Fixes a latent-refactor edge case where `compute_latent_samples(...)` could still enter the JAX batching path when an analysis had no enabled latent keys, leading to `jnp.stack([])` failures during downstream visualization/update scripts.

## API Changes
`Analysis.compute_latent_samples(...)` now returns `None` immediately when the analysis has no enabled latent keys, matching the existing no-latent contract instead of attempting an empty latent batch.
See full details below.

## Test Plan
- [x] `NUMBA_CACHE_DIR=/tmp/numba_cache MPLCONFIGDIR=/tmp/matplotlib python -m pytest test_autofit/analysis/test_latent.py test_autofit/analysis/test_latent_variables.py test_autofit/analysis/test_use_jax_for_visualization.py -q`
- [x] `NUMBA_CACHE_DIR=/tmp/numba_cache MPLCONFIGDIR=/tmp/matplotlib python -m pytest -q`
- [x] Targeted Group A release scripts pass against the task worktree.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
- None

### Added
- None

### Renamed
- None

### Changed Signature
- None

### Changed Behaviour
- `autofit.non_linear.analysis.latent.latent_samples_from(...)` returns `None` when `analysis.Latent.keys(analysis)` is empty, rather than entering the batching path and crashing on an empty stack.

### Migration
- None. Analyses with no enabled latents now follow the same `None` result contract as other no-latent paths.

</details>
