### PR TITLE
ci: call the reusable lib-tests workflow from PyAutoHeart (not PyAutoPulse)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,12 +2,12 @@ name: Tests
 
 on: [push, pull_request]
 
-# Unit tests are defined once, centrally, in PyAutoPulse's reusable workflow
-# (Pulse owns all health/readiness checking). This thin caller preserves PR-time
+# Unit tests are defined once, centrally, in PyAutoHeart's reusable workflow
+# (Heart owns all health/readiness checking). This thin caller preserves PR-time
 # gating: the `unittest` job is the required status check on this repo.
 jobs:
   unittest:
-    uses: PyAutoLabs/PyAutoPulse/.github/workflows/lib-tests.yml@main
+    uses: PyAutoLabs/PyAutoHeart/.github/workflows/lib-tests.yml@main
     with:
       package: autofit
     secrets: inherit


### PR DESCRIPTION
## What & why

`.github/workflows/main.yml`'s `unittest` job referenced `PyAutoLabs/PyAutoPulse/.github/workflows/lib-tests.yml@main`, which only resolved via GitHub's **repo-rename redirect** (PyAutoPulse → PyAutoHeart) — a fragile dependency on the legacy name.

## Change

Point the `uses:` ref directly at `PyAutoLabs/PyAutoHeart/.github/workflows/lib-tests.yml@main` (+ update the two comment lines). Same reusable workflow, **no behaviour change**.

Please confirm the `unittest` required check still goes green on this PR. Part of retiring the legacy PyAutoPulse name (Phase 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016ik7bPcH2AyW9JLd61xWVt)_