### PR TITLE
fix(plot): corner plot survives degenerate (no-dynamic-range) columns

### DIFF
--- a/autofit/non_linear/plot/samples_plotters.py
+++ b/autofit/non_linear/plot/samples_plotters.py
@@ -9,6 +9,27 @@ from autofit.non_linear.plot.plot_util import skip_in_test_mode, output_figure
 logger = logging.getLogger(__name__)
 
 
+def _corner_range_from(data):
+    """Per-column ``(min, max)`` plot ranges for a corner figure.
+
+    ``corner`` raises "no dynamic range" if any column has zero spread (every
+    sample equal). That is a legitimate input — a reduced-iteration run (e.g.
+    ``PYAUTO_TEST_MODE=1``) or a parameter that has converged flat — so we hand
+    it an explicit per-column range rather than let it crash. Columns with real
+    spread keep their ``(min, max)``; degenerate columns are widened to a small
+    non-zero window centred on the value so the plot still renders.
+    """
+    mins = np.asarray(data).min(axis=0)
+    maxs = np.asarray(data).max(axis=0)
+    plot_range = []
+    for lower, upper in zip(mins, maxs):
+        if lower == upper:
+            pad = max(abs(lower) * 1e-4, 1e-8)
+            lower, upper = lower - pad, upper + pad
+        plot_range.append((lower, upper))
+    return plot_range
+
+
 @skip_in_test_mode
 def corner_cornerpy(samples, path=None, filename="corner", format="show", **kwargs):
     data = np.asarray(samples.parameter_lists)
@@ -34,6 +55,7 @@ def corner_cornerpy(samples, path=None, filename="corner", format="show", **kwar
         data=data,
         weight_list=samples.weight_list,
         labels=samples.model.parameter_labels_with_superscripts_latex,
+        range=_corner_range_from(data),
     )
 
     output_figure(path=path, filename=filename, format=format)

--- a/test_autofit/non_linear/plot/test_samples_plotters.py
+++ b/test_autofit/non_linear/plot/test_samples_plotters.py
@@ -1,0 +1,43 @@
+import numpy as np
+
+from autofit.non_linear.plot.samples_plotters import _corner_range_from
+
+
+def test__corner_range__real_spread_columns_preserved():
+    data = np.array(
+        [
+            [1.0, 10.0],
+            [2.0, 20.0],
+            [3.0, 30.0],
+        ]
+    )
+
+    plot_range = _corner_range_from(data)
+
+    assert plot_range == [(1.0, 3.0), (10.0, 30.0)]
+
+
+def test__corner_range__degenerate_columns_widened_to_nonzero_span():
+    # Columns 0, 1, 2 have no dynamic range (all samples equal) — the input
+    # that made `corner` raise "no dynamic range". Column 3 has real spread.
+    data = np.array(
+        [
+            [0.0, 5.0, -2.0, 1.0],
+            [0.0, 5.0, -2.0, 2.0],
+            [0.0, 5.0, -2.0, 3.0],
+        ]
+    )
+
+    plot_range = _corner_range_from(data)
+
+    # Every column ends up with a strictly positive width, so `corner` gets a
+    # valid range for all of them and does not raise.
+    for lower, upper in plot_range:
+        assert upper > lower
+
+    # Degenerate windows stay centred on the constant value.
+    for (lower, upper), value in zip(plot_range[:3], [0.0, 5.0, -2.0]):
+        assert lower < value < upper
+
+    # The real-spread column is left untouched.
+    assert plot_range[3] == (1.0, 3.0)


### PR DESCRIPTION
## Problem

`autofit_workspace/scripts/searches/mcmc.py` crashes in `release.yml`'s `run_smoke_tests` job (and Heart's release-fidelity workspace validation) with:

```
ValueError: It looks like the parameter(s) in column(s) 0, 1, 2 have no dynamic range. Please provide a `range` argument.
```

Reproduced locally on current main under the release smoke profile (`PYAUTO_TEST_MODE=1 PYAUTO_SMALL_DATASETS=1 PYAUTO_FAST_PLOTS=1`). The crash is here in the **library**, not the workspace:

```
autofit/non_linear/plot/samples_plotters.py:33  corner.corner(...)
```

`corner_cornerpy` called `corner.corner(...)` with no `range=`. When any column has zero spread — all samples equal, which is expected under reduced-iteration runs and possible for any parameter that converges flat — `corner` raises rather than plotting. This affects **every corner-plotting search** (Emcee/Zeus/Nautilus), so the fix belongs in the library.

## Fix

Compute an explicit per-column `range` (`_corner_range_from`) and pass it to `corner.corner`. Columns with real spread keep their `(min, max)`; degenerate columns are widened to a small non-zero window centred on the value so the plot still renders. This is not a silent guard — the plot is produced, degenerate columns are a legitimate input.

## Verification

- `PYAUTO_TEST_MODE=1 PYAUTO_SMALL_DATASETS=1 PYAUTO_FAST_PLOTS=1 python autofit_workspace/scripts/searches/mcmc.py` now exits 0 and writes `corner.png` (previously crashed).
- New unit test `test_autofit/non_linear/plot/test_samples_plotters.py` (degenerate + real-spread columns).
- `pytest test_autofit/non_linear/plot test_autofit/non_linear/samples` → 35 passed.

pending-release