### PR TITLE
fix(priors): width-modifier safety + sigma validation agreement

### DIFF
--- a/autofit/mapper/prior/width_modifier.py
+++ b/autofit/mapper/prior/width_modifier.py
@@ -22,9 +22,14 @@ class WidthModifier(ABC):
 
     @classmethod
     def from_dict(cls, width_modifier_dict):
-        return width_modifier_type_dict[width_modifier_dict["type"]](
-            value=width_modifier_dict["value"]
-        )
+        # Forward every key except "type" so optional keys (e.g. the
+        # RelativeWidthModifier absolute_floor) round-trip from config.
+        kwargs = {
+            key: value
+            for key, value in width_modifier_dict.items()
+            if key != "type"
+        }
+        return width_modifier_type_dict[width_modifier_dict["type"]](**kwargs)
 
     @abstractmethod
     def __call__(self, mean):
@@ -72,12 +77,47 @@ class WidthModifier(ABC):
             return RelativeWidthModifier(0.5)
 
     def __eq__(self, other):
-        return self.__class__ is other.__class__ and self.value == other.value
+        return self.__class__ is other.__class__ and self.dict == other.dict
 
 
 class RelativeWidthModifier(WidthModifier):
+    def __init__(self, value, absolute_floor=None):
+        """
+        Prior-passing width proportional to the magnitude of the posterior
+        median: ``sigma = value * abs(mean)`` (#1331 Decision 5).
+
+        ``abs`` guards the negative-median case, which previously produced a
+        negative sigma that flowed silently into the passed prior and flipped
+        its scale. For medians at (or very near) zero the relative width
+        collapses; set ``absolute_floor`` (here or via the ``width_modifier``
+        entry in the priors config) to impose a minimum width. Without a floor,
+        a zero width is rejected loudly at prior-passing time.
+
+        Parameters
+        ----------
+        value
+            The proportionality constant applied to ``abs(mean)``.
+        absolute_floor
+            Optional minimum width. When set, the returned width is
+            ``max(value * abs(mean), absolute_floor)``.
+        """
+        super().__init__(value)
+        self.absolute_floor = (
+            float(absolute_floor) if absolute_floor is not None else None
+        )
+
     def __call__(self, mean):
-        return self.value * mean
+        sigma = self.value * abs(mean)
+        if self.absolute_floor is not None:
+            sigma = max(sigma, self.absolute_floor)
+        return sigma
+
+    @property
+    def dict(self):
+        d = super().dict
+        if self.absolute_floor is not None:
+            d["absolute_floor"] = self.absolute_floor
+        return d
 
 
 class AbsoluteWidthModifier(WidthModifier):

--- a/autofit/mapper/prior_model/abstract.py
+++ b/autofit/mapper/prior_model/abstract.py
@@ -1053,6 +1053,20 @@ class AbstractPriorModel(AbstractModel):
                 width = r * mean
             else:
                 width = width_modifier(mean)
+                if width <= 0:
+                    path = ".".join(map(str, self.path_for_prior(prior)))
+                    raise exc.PriorException(
+                        f"Prior passing produced a non-positive width "
+                        f"(sigma={width}) for parameter '{path}' (posterior "
+                        f"median mean={mean}). This happens when the posterior "
+                        "median is zero and the parameter's width modifier is "
+                        "relative with no floor. Configure an "
+                        "AbsoluteWidthModifier or set absolute_floor on the "
+                        "RelativeWidthModifier for this parameter in the "
+                        "priors config. (Explicit a=/r= widths are exempt from "
+                        "this check and keep their historical point-mass "
+                        "semantics at mean=0.)"
+                    )
 
             if no_limits:
                 limits = (float("-inf"), float("inf"))

--- a/autofit/messages/normal.py
+++ b/autofit/messages/normal.py
@@ -24,25 +24,32 @@ def is_nan(value):
     return is_nan_
 
 def assert_sigma_non_negative(sigma, xp=np):
+    """
+    Reject ``sigma < 0`` on the NumPy path (#1331 Decision 2), matching
+    ``TruncatedNormalMessage`` — the two classes previously disagreed, so a
+    negative sigma (e.g. from a negative posterior median through a relative
+    width modifier) constructed a ``NormalMessage`` silently and flipped the
+    scale of ``value_for`` / ``sample``.
 
-    is_negative = sigma < 0
+    ``sigma == 0`` is deliberately permitted: it is the established point-mass
+    idiom — the latent-variables machinery wraps known values as
+    ``GaussianPrior(mean=value, sigma=0.0)`` (``non_linear/samples/util.py``),
+    ``from_mode(..., covariance=0)`` requests a point-mass projection, and
+    ``model_centred_relative`` pins ``sigma == 0`` for zero-centred parameters.
 
-    if xp.__name__.startswith("jax"):
-        import jax
-        # JAX path: cannot convert to Python bool
-        # Raise using JAX control flow:
-        return jax.lax.cond(
-            is_negative,
-            lambda _: (_ for _ in ()).throw(
-                ValueError("Sigma cannot be negative")
-            ),
-            lambda _: None,
-            operand=None,
-        )
-    else:
-        # NumPy path: normal boolean works
-        if bool(is_negative):
-            raise ValueError("Sigma cannot be negative")
+    The JAX path is a deliberate no-op: a traced ``sigma`` cannot be converted
+    to a Python bool, so validity defers to NaN propagation. (The previous
+    ``jax.lax.cond`` branch here never worked — ``lax.cond`` traces both
+    branches, so the generator-throw lambda was suppressed under ``jit``.)
+    """
+    if xp is np:
+        if (np.asarray(sigma) < 0).any():
+            raise exc.MessageException(
+                f"NormalMessage sigma cannot be negative, got sigma={sigma}. "
+                "Negative widths typically come from prior passing with a "
+                "parameter whose posterior median is negative — see "
+                "RelativeWidthModifier in the priors config."
+            )
 
 class NormalMessage(AbstractMessage):
 
@@ -84,7 +91,7 @@ class NormalMessage(AbstractMessage):
             The mean (μ) of the normal distribution.
 
         sigma
-            The standard deviation (σ) of the distribution. Must be non-negative.
+            The standard deviation (σ) of the distribution. Must be strictly positive.
 
         log_norm
             An additive constant to the log probability of the message. Used internally for message-passing normalization.
@@ -100,7 +107,7 @@ class NormalMessage(AbstractMessage):
             import jax.numpy as jnp
             xp = jnp
 
-        # assert_sigma_non_negative(sigma, xp=xp)
+        assert_sigma_non_negative(sigma, xp=xp)
 
         super().__init__(
             mean,

--- a/autofit/messages/truncated_normal.py
+++ b/autofit/messages/truncated_normal.py
@@ -88,7 +88,7 @@ class TruncatedNormalMessage(AbstractMessage):
         mean
             The mean (μ) of the normal distribution.
         sigma
-            The standard deviation (σ) of the distribution. Must be non-negative.
+            The standard deviation (σ) of the distribution. Must be strictly positive.
         log_norm
             An additive constant to the log probability of the message. Used internally for message-passing normalization.
             Default is 0.0.
@@ -96,7 +96,9 @@ class TruncatedNormalMessage(AbstractMessage):
             An optional unique identifier used to track the message in larger probabilistic graphs or models.
         """
         if (np.array(sigma) < 0).any():
-            raise exc.MessageException("Sigma cannot be negative")
+            raise exc.MessageException(
+                f"TruncatedNormalMessage sigma cannot be negative, got sigma={sigma}."
+            )
 
         super().__init__(
             mean,

--- a/test_autofit/mapper/prior/test_prior_width_safety.py
+++ b/test_autofit/mapper/prior/test_prior_width_safety.py
@@ -1,0 +1,114 @@
+"""Regression tests for the width-modifier safety pair (PyAutoFit #1346,
+Phase 2 of decision hub #1331 — Decisions 5 + 2). Numpy-only.
+"""
+import pytest
+
+import autofit as af
+from autofit import exc
+from autofit.mapper.prior.width_modifier import (
+    RelativeWidthModifier,
+    WidthModifier,
+)
+from autofit.messages.normal import NormalMessage
+from autofit.messages.truncated_normal import TruncatedNormalMessage
+
+
+# --- Decision 5: RelativeWidthModifier uses abs(mean), optional absolute_floor ---
+
+def test__relative_width_modifier_abs_mean():
+    mod = RelativeWidthModifier(0.5)
+    # A negative posterior median previously produced a negative sigma that
+    # flowed silently into the passed prior and flipped its scale.
+    assert mod(-2.0) == 1.0
+    assert mod(2.0) == 1.0
+    # The bare modifier still returns 0.0 at mean=0; prior passing rejects it
+    # loudly downstream (see the chained tests below).
+    assert mod(0.0) == 0.0
+
+
+def test__relative_width_modifier_floor():
+    mod = RelativeWidthModifier(0.5, absolute_floor=0.1)
+    assert mod(0.0) == 0.1     # floor engages at zero median
+    assert mod(0.1) == 0.1     # 0.5 * 0.1 = 0.05 < floor
+    assert mod(10.0) == 5.0    # a floor, not a cap
+
+
+def test__relative_width_modifier_dict_round_trip():
+    mod = RelativeWidthModifier(0.5, absolute_floor=0.1)
+    assert mod.dict == {"type": "Relative", "value": 0.5, "absolute_floor": 0.1}
+    assert WidthModifier.from_dict(mod.dict) == mod
+
+    bare = RelativeWidthModifier(0.5)
+    assert bare.dict == {"type": "Relative", "value": 0.5}
+    assert WidthModifier.from_dict(bare.dict) == bare
+    assert bare != mod
+
+
+# --- Decision 2 (evidence-adjusted): both message classes now agree — sigma < 0
+# rejected, sigma == 0 permitted as the established point-mass idiom (latent
+# variables' simple_model_for_kwargs, from_mode(covariance=0),
+# model_centred_relative at mean=0 all depend on it) ---
+
+def test__normal_message_rejects_negative_sigma():
+    with pytest.raises(exc.MessageException):
+        NormalMessage(mean=0.0, sigma=-1.0)
+
+
+def test__truncated_normal_message_rejects_negative_sigma():
+    with pytest.raises(exc.MessageException):
+        TruncatedNormalMessage(
+            mean=0.0, sigma=-1.0, lower_limit=-1.0, upper_limit=1.0
+        )
+
+
+def test__sigma_zero_point_mass_still_constructs():
+    # The point-mass carrier used by the latent-variables machinery
+    # (non_linear/samples/util.py) and from_mode(covariance=0) must keep working.
+    m = NormalMessage(mean=3.0, sigma=0.0)
+    assert m.sigma == 0.0
+    p = af.GaussianPrior(mean=3.0, sigma=0.0)
+    assert p.sigma == 0.0
+
+
+def test__gaussian_prior_rejects_negative_sigma():
+    # Previously constructed silently with deceptive variance = sigma**2 > 0
+    # and a sign-flipped value_for.
+    with pytest.raises(exc.MessageException):
+        af.GaussianPrior(mean=0.0, sigma=-0.5)
+
+
+# --- The mean=0 chained-parameter regression (the Phase-2 sequencing gate:
+# yesterday's silent delta-freeze must become a clear, parameter-named error,
+# and the floor must be the working remedy) ---
+
+def _mapper_with_relative_widths(absolute_floor=None):
+    mapper = af.ModelMapper(mock_class=af.m.MockClassx2)
+    for prior in mapper.priors:
+        prior.width_modifier = RelativeWidthModifier(
+            0.5, absolute_floor=absolute_floor
+        )
+    return mapper
+
+
+def test__prior_passing_mean_zero_raises_with_guidance():
+    mapper = _mapper_with_relative_widths()
+    with pytest.raises(exc.PriorException) as err:
+        mapper.mapper_from_prior_means([0.0, 5.0])
+    # The error must name the parameter and point at the remedy.
+    assert "mock_class" in str(err.value)
+    assert "absolute_floor" in str(err.value)
+
+
+def test__prior_passing_mean_zero_with_floor_passes():
+    mapper = _mapper_with_relative_widths(absolute_floor=0.1)
+    result = mapper.mapper_from_prior_means([0.0, 5.0])
+    assert result.mock_class.one.mean == 0.0
+    assert result.mock_class.one.sigma == 0.1   # floor engaged
+    assert result.mock_class.two.sigma == 2.5   # 0.5 * 5.0, floor irrelevant
+
+
+def test__prior_passing_negative_mean_gets_positive_width():
+    mapper = _mapper_with_relative_widths()
+    result = mapper.mapper_from_prior_means([-2.0, 5.0])
+    assert result.mock_class.one.mean == -2.0
+    assert result.mock_class.one.sigma == 1.0   # 0.5 * abs(-2.0)


### PR DESCRIPTION
## Summary

Phase 2 of the #1331 priors/messages batch (tracker #1346; Phase 1 merged via #1345) — the behaviour-changing width-modifier pair, shipped as one PR by design so the width fix and the sigma check land together. `RelativeWidthModifier` now returns `value * abs(mean)` with an opt-in, config-round-tripping `absolute_floor`; the default prior-passing path raises a parameter-named `PriorException` with remediation guidance when a computed width is still ≤ 0 (previously: a silent σ=0 delta prior froze the parameter); and `NormalMessage` finally rejects negative sigma, agreeing with `TruncatedNormalMessage` — the actual defect behind Decision 2.

**One evidence-based deviation from the #1331 rec, disclosed in detail on #1346:** strict σ ≤ 0 rejection broke 20 tests across three subsystems that deliberately use σ = 0 as a point-mass idiom (latent variables' `simple_model_for_kwargs`, `from_mode(covariance=0)`, `model_centred_relative` pinning `sigma == 0` at `mean=0`). This PR ships the permissive variant #1331 itself listed as the alternative: **σ < 0 rejected, σ = 0 permitted and documented.** If strict is still wanted, the prerequisite is a first-class point-mass representation for the latent machinery — separate design prompt on request.

## API Changes

Behaviour changes on existing public symbols — nothing removed, one optional argument added.
`RelativeWidthModifier` gains `absolute_floor=`; its width is now `value * abs(mean)` (was `value * mean`, which went negative with the median). Default-path prior passing raises on non-positive computed widths instead of silently freezing the parameter. `NormalMessage`/`GaussianPrior` reject σ < 0 at construction (previously silent with sign-flipped `value_for`).
See full details below.

## Test Plan
- [x] Full `test_autofit/` suite: **1447 passed, 14 skipped**
- [x] New `test_autofit/mapper/prior/test_prior_width_safety.py` — 11 regression tests: `abs(mean)`, floor engagement + config round-trip, σ<0 rejection on both classes, σ=0 point-mass preserved, and the `mean=0` chained-parameter gate (clear error without floor / correct width with floor / positive width for negative medians)
- [x] Previously-failing clusters under the strict variant re-verified green after the permissive adjustment (latent variables, `from_mode`, `model_relative` — 67/67)
- [ ] Post-merge: downstream smoke — no workspace scripts touch the changed symbols directly (see impact note in #1346)

## Validation checklist (--auto run — plan on the issue; D2 scope adjusted mid-run, disclosed)
- Effective level: supervised (header: supervised, cap: bug → supervised); launched live in-session 2026-07-10 after Phase-1 merge
- Plan: on the issue (#1346), written at start; **one disclosed amendment** (Decision 2 strict → permissive on test evidence, full rationale on #1346)
- Gate: tests 1447 pass / 14 skip · smoke pending post-PR (no direct workspace consumers) · review CLEAN · Heart YELLOW within the live 6-reason ack recorded in active.md this session
- [ ] Human: plan sound in hindsight — **specifically the D2 permissive call**?
- [ ] Human: diff matches plan (no scope creep)?
- [ ] Human: merge, amend, or reject — then log the outcome

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- `RelativeWidthModifier(value, absolute_floor=None)` — optional minimum passed-prior width; engages when `value * abs(mean)` falls below it; round-trips through the `width_modifier` priors-config entry (`absolute_floor` key) and `WidthModifier.from_dict`/`.dict`

### Changed Behaviour
- `RelativeWidthModifier.__call__(mean)` — returns `value * abs(mean)` (was `value * mean`). Chained fits with **negative posterior medians** previously received a *negative* sigma that constructed silently and sign-flipped `value_for`/`sample`; they now receive the correct positive width. This changes sampling of affected chained fits — correctly.
- `AbstractPriorModel.mapper_from_prior_means` (default width-modifier path only) — a computed width ≤ 0 (posterior median 0, relative modifier, no floor) raises `exc.PriorException` naming the parameter path and pointing at `AbsoluteWidthModifier`/`absolute_floor` remediation. Previously the parameter was silently frozen behind a σ=0 delta prior. Explicit `a=`/`r=` widths are exempt and keep their historical point-mass semantics (pinned by `test_model_relative`).
- `NormalMessage.__init__` (⇒ `GaussianPrior`) — rejects σ < 0 with `exc.MessageException` (previously constructed silently with deceptive `variance = σ² > 0`). σ = 0 remains permitted as the documented point-mass idiom. The dead `assert_sigma_non_negative` `jax.lax.cond` branch (traced both branches, never raised under `jit`) is retired; the JAX path defers to NaN propagation.
- `TruncatedNormalMessage.__init__` — same σ < 0 rejection as before with a clearer message; the two classes now agree.
- `WidthModifier.__eq__` — compares full `.dict` (so modifiers differing only in `absolute_floor` are unequal).

### Migration
- None required for typical use. Pipelines that (knowingly or not) relied on a *negative* sigma from a relative width modifier will now sample a correct positive width. Pipelines with an unconfigured `mean=0` parameter on the default width path now fail loudly with guidance — set an `AbsoluteWidthModifier` or `absolute_floor` for that parameter.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)