### PR TITLE
fix(graphical): seed inherently-stochastic test_full_hierachical (#1352)

### DIFF
--- a/test_autofit/graphical/hierarchical/test_hierarchical.py
+++ b/test_autofit/graphical/hierarchical/test_hierarchical.py
@@ -298,6 +298,14 @@ def test_full_hierachical(data):
         },
     )
 
+    # This fits a *marginal* hierarchical EP model whose Laplace refinement draws
+    # stochastic samples from the global np.random state (n_refine=3 via
+    # NormalMessage.sample). The fit sits near a convergence boundary, so its
+    # recovered fixed point (good vs sigma-collapse) depends on the ambient RNG
+    # state left by whatever ran before — an inherently stochastic test. Seed here
+    # so the fit is reproducible; this is the pragmatic fix (see PyAutoFit #1352).
+    np.random.seed(0)
+
     laplace = graph.LaplaceOptimiser()
     ep_opt = graph.EPOptimiser(model, default_optimiser=laplace)
     new_approx = ep_opt.run(model_approx, max_steps=10)


### PR DESCRIPTION
## Summary

Fixes the red **Tests** workflow on PyAutoFit `main`. `test_autofit/graphical/hierarchical/test_hierarchical.py::test_full_hierachical` is an **inherently stochastic** test that was failing deterministically at HEAD.

The test fits a *marginal* hierarchical EP model. The Laplace optimiser refines each factor with `n_refine=3` stochastic samples drawn from the **global** `np.random` state (`NormalMessage.sample` → `np.random.randn`), so the recovered `mu_logt` hyperparameter converges to a good value or a **sigma-collapsed** one depending on the ambient RNG state left by whatever ran before the test. The test seeded `np.random` only before *data generation*, never before the fit.

When #1351 added `test_autofit/graphical/functionality/test_ep_statistics_fixes.py` (Monte-Carlo KL-direction tests that consume `np.random`), the ambient state going into the hierarchical fit shifted into a failing region — flipping the full-suite result from green (`#1347`, `2e33b175`) to red (`#1351`/`#1354`). #1351's F1/F2/F4/F8 math is not implicated.

## Fix

Seed `np.random` immediately before the fit so the test is reproducible. One line (+ explanatory comment); no library or API change.

## API Changes

None — test-only change.

## Validation

- `test_autofit/graphical/` — **216 passed, 0 failed**
- Full `test_autofit/` — **1475 passed, 14 skipped, 0 failed** (was 1474 passed / 1 failed at HEAD)

## Notes

The underlying observation — EP/Laplace fits draw from global `np.random`, so results aren't fully reproducible across arbitrary process states (the fit also depends on variable-id ordering) — is documented on #1352. A controlled-RNG design was prototyped and reverted as out of proportion for a marginal stochastic test; seeding is the pragmatic fix per maintainer steer. Flagged there if reproducibility becomes a first-class requirement.

Closes #1352.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgCFQoGUbVkspbCjRuKnHJ
