### PR TITLE
docs: drop stale [nss] gotcha reference from copilot-instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,6 +5,6 @@ composition and non-linear search / Bayesian inference (package `autofit`).
 
 The canonical, agent-agnostic instructions for this repo live in **`AGENTS.md`** at
 the repository root — build and test commands, architecture, the model/search
-subsystems, and conventions (including the `[nss]` / blackjax install gotcha). Read
+subsystems, and conventions. Read
 it directly (Copilot does not process `@`-imports) and treat it as the single source
 of truth.


### PR DESCRIPTION
Straggler from the `af.NSS` removal (#1357): the `[nss]`/blackjax install gotcha is gone from AGENTS.md, so the `copilot-instructions.md` parenthetical pointing at it is stale. One-line doc fix. Part of #1356.%s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9eyGoEAUHGSqcmJpzzjsi