### PR TITLE
fix(graphical): EP hierarchical factor returns -inf for out-of-support scale (nightly crash)

### DIFF
--- a/autofit/graphical/declarative/factor/hierarchical.py
+++ b/autofit/graphical/declarative/factor/hierarchical.py
@@ -1,5 +1,8 @@
 from typing import Set, Optional, Type, List, Tuple, Dict
 
+import numpy as np
+
+from autofit import exc
 from autofit.mapper.model import ModelInstance
 from autofit.mapper.prior.abstract import Prior
 from autofit.mapper.prior_model.collection import Collection
@@ -140,9 +143,19 @@ class Factor:
             prior_id = int(name_.split("_")[1])
             prior = self.distribution_model.prior_with_id(prior_id)
             arguments[prior] = array
-        return self.distribution_model.instance_for_arguments(arguments).message(
-            argument
-        )
+        try:
+            return self.distribution_model.instance_for_arguments(arguments).message(
+                argument
+            )
+        except exc.MessageException:
+            # The distribution was parameterised outside its support — e.g. an EP
+            # factor optimiser proposing a (transiently) negative scale for a
+            # ``GaussianPrior`` distribution, just below a truncated hyper-prior's
+            # ``lower_limit=0``. Such a point has zero probability density, so the
+            # factor's log-value is ``-inf`` rather than a hard error. The strict
+            # ``NormalMessage`` sigma guard stays intact for genuine prior-passing
+            # misuse; here we translate it into the correct EP semantics.
+            return -np.inf
 
 
 class _HierarchicalFactor(AbstractModelFactor):

--- a/autofit/messages/normal.py
+++ b/autofit/messages/normal.py
@@ -46,9 +46,14 @@ def assert_sigma_non_negative(sigma, xp=np):
         if (np.asarray(sigma) < 0).any():
             raise exc.MessageException(
                 f"NormalMessage sigma cannot be negative, got sigma={sigma}. "
-                "Negative widths typically come from prior passing with a "
-                "parameter whose posterior median is negative — see "
-                "RelativeWidthModifier in the priors config."
+                "A negative width means a Gaussian was parameterised outside its "
+                "support. Two common sources: (1) prior passing with a parameter "
+                "whose posterior median is negative (though RelativeWidthModifier "
+                "now uses abs(mean), so this is rare); (2) a hierarchical / EP "
+                "factor whose optimiser proposes a negative scale for a "
+                "GaussianPrior distribution. Callers that can legitimately reach "
+                "such points (e.g. HierarchicalFactor) must treat them as "
+                "zero-density (-inf) rather than constructing the message."
             )
 
 class NormalMessage(AbstractMessage):

--- a/test_autofit/graphical/hierarchical/test_negative_scale.py
+++ b/test_autofit/graphical/hierarchical/test_negative_scale.py
@@ -1,0 +1,60 @@
+import numpy as np
+import pytest
+
+import autofit as af
+from autofit import exc
+from autofit import graphical as g
+from autofit.graphical.declarative.factor.hierarchical import Factor
+from autofit.messages.normal import NormalMessage
+
+
+def _factor():
+    """A HierarchicalFactor whose scale hyper-prior is truncated at zero, matching
+    the EP guide (`GaussianPrior` distribution drawn from truncated mean/sigma)."""
+    hf = g.HierarchicalFactor(
+        af.GaussianPrior,
+        mean=af.TruncatedGaussianPrior(
+            mean=2.0, sigma=1.0, lower_limit=0.0, upper_limit=100.0
+        ),
+        sigma=af.TruncatedGaussianPrior(
+            mean=0.5, sigma=0.5, lower_limit=0.0, upper_limit=100.0
+        ),
+    )
+    hf.add_drawn_variable(af.GaussianPrior(mean=2.0, sigma=1.0))
+    return hf
+
+
+def test_negative_scale_returns_neg_inf_not_raise():
+    """
+    Regression for the EP nightly crash: an EP factor optimiser proposing a
+    (transiently) negative scale for the `GaussianPrior` distribution — just below
+    the truncated scale hyper-prior's `lower_limit=0` — must yield a zero-density
+    (`-inf`) factor value rather than raising `MessageException` from the strict
+    `NormalMessage` sigma guard.
+    """
+    hf = _factor()
+    mean_p, scale_p = hf.mean, hf.sigma
+    factor = Factor(hf)
+
+    def call(scale):
+        return factor(
+            **{
+                f"prior_{mean_p.id}": 2.0,
+                f"prior_{scale_p.id}": scale,
+                "argument": 2.0,
+            }
+        )
+
+    # a valid scale gives a finite log-density
+    assert np.isfinite(call(0.5))
+
+    # negative scales are outside the distribution's support → zero density
+    assert call(-0.016) == -np.inf
+    assert call(-0.17) == -np.inf
+
+
+def test_normal_message_negative_sigma_guard_still_raises():
+    """The fix relies on the strict guard staying loud for genuine misuse (prior
+    passing); constructing a `NormalMessage` with a negative sigma must still raise."""
+    with pytest.raises(exc.MessageException):
+        NormalMessage(mean=1.0, sigma=-0.1)


### PR DESCRIPTION
## Summary

The EP guide (`scripts/guides/modeling/advanced/expectation_propagation.py`) crashed intermittently in the nightly `workspace-validation` with `NormalMessage sigma cannot be negative`. Root cause (pinned by deterministic reproduction): its `HierarchicalFactor` draws `mass.slope` from a `GaussianPrior(mean, sigma)` whose `sigma` is a truncated hyper-prior (`lower_limit=0`). The hierarchical factor's Laplace/Newton optimiser evaluates at proposed scales that dip just below `0` (the scale posterior sits at `mean≈0.0005`, hard against the boundary), so `Factor.__call__` built `GaussianPrior(sigma<0)` and tripped the strict `NormalMessage` sigma guard.

A distribution parameterised outside its support has zero probability density, so the factor's log-value is `-inf` — not a hard error. `Factor.__call__` now catches `exc.MessageException` and returns `-inf`. The strict guard is unchanged (still fires for genuine prior-passing misuse); its stale `RelativeWidthModifier`-only hint is corrected. Adds a deterministic regression test. The workspace guide is untouched (no autoimmunity — no seeding, no prior constraints).

Fixes #1363

## API Changes

None — internal changes only. Behavioural: a `HierarchicalFactor` whose optimiser proposes an out-of-support distribution scale now yields a zero-density (`-inf`) factor value instead of raising `MessageException`. No public symbols added/removed/renamed and no signatures changed.
See full details below.

## Test Plan

- [x] Full `test_autofit/` suite: **1473 passed, 1 skipped** (in-worktree).
- [x] New regression test `test_autofit/graphical/hierarchical/test_negative_scale.py`: the exact CI scales (−0.016, −0.17) return `-inf`; a valid scale returns finite; strict `NormalMessage(sigma<0)` still raises.
- [x] `test_autofit/graphical/` in-order: 218 passed (EP-optimisation locus green).
- [x] EP guide in the nightly's exact mode (`PYAUTO_TEST_MODE=1 PYAUTO_SMALL_DATASETS=1 PYAUTO_FAST_PLOTS=1`): base crashes (`sigma=-0.07…` via `graphical.laplace.newton`); with the fix the guide runs to completion (exit 0, full `MeanField` output).

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- `autofit.graphical.declarative.factor.hierarchical.Factor.__call__` — returns `-inf` (zero density) when the distribution is parameterised outside its support (raising `exc.MessageException`), instead of propagating the exception. Internal to the EP hierarchical-factor machinery.
- `autofit.messages.normal.assert_sigma_non_negative` — exception message text corrected (the `RelativeWidthModifier` path now uses `abs(mean)`, so it is no longer the likely source); the `sigma<0` rejection itself is unchanged.

### Migration
- None.

</details>

## Validation checklist (--auto run — plan was not pre-approved)
- Effective level: **supervised** (header: `safe`, cap: `bug` → `supervised`)
- Plan: on the issue (#1363), written at start, unmodified since
- Gate: tests **1473p / 1s** · smoke **base-crashes / fix-clean** in the nightly's exact test-mode · review **CLEAN** · Heart **YELLOW** (stale `test_run` 2026-07-09 + 58 stale parked scripts; human-acknowledged at the ship checkpoint as unrelated to this branch)
- [ ] Human: plan sound in hindsight?
- [ ] Human: diff matches plan (no scope creep)?
- [ ] Human: merge, amend, or reject — then log the outcome

Generated by the PyAutoLabs agent workflow.
