### PR TITLE
fix: don't register JAX-leaf types (int) as pytree nodes (shapelet vmap crash)

### DIFF
--- a/autofit/jax/pytrees.py
+++ b/autofit/jax/pytrees.py
@@ -15,6 +15,27 @@ _CLASS_FIELD_CLASSIFIERS: dict = {}
 _CLASS_CONSTRUCTOR_ARGS: dict = {}
 
 
+def _instances_carry_dict(cls) -> bool:
+    """Whether instances of ``cls`` have a ``__dict__``.
+
+    Only such classes may be registered as instance pytree nodes: the flatten
+    built by ``_build_instance_pytree_funcs`` reads ``vars(instance)``, which
+    raises ``TypeError`` on an instance without a ``__dict__``.
+
+    This excludes native JAX leaf types (``int``, ``float``, ``str``, ``bool``,
+    ``NoneType``, ``tuple``, ...) — which JAX already handles correctly as
+    opaque leaves — and any purely ``__slots__`` class. ``register_model``
+    reaches these via ``af.Model(int)`` sub-models (e.g. a ``ShapeletPolar``'s
+    integer ``n``/``m`` constructor args): without this guard ``int`` gets
+    registered, JAX then calls the instance-flatten on every ``int`` leaf, and
+    ``vars(5)`` crashes the whole ``jax.jit``/``jax.vmap`` flatten.
+
+    A class defines a ``__dict__`` for its instances iff some class in its MRO
+    carries the ``__dict__`` descriptor.
+    """
+    return any("__dict__" in vars(klass) for klass in cls.__mro__)
+
+
 def enable_pytrees() -> bool:
     """Register PyAutoFit model and prior classes as JAX pytree nodes.
 
@@ -92,7 +113,14 @@ def register_model(model) -> bool:
             _CLASS_CONSTRUCTOR_ARGS.setdefault(
                 cls, tuple(node.constructor_argument_names)
             )
-            if cls not in _REGISTERED_INSTANCE_CLASSES:
+            # Only register classes whose instances carry a ``__dict__`` — the
+            # instance flatten reads ``vars(instance)``. ``af.Model(int)``
+            # sub-models (e.g. a shapelet's integer ``n``/``m`` args) would
+            # otherwise register ``int`` and crash the flatten on every int leaf.
+            if (
+                cls not in _REGISTERED_INSTANCE_CLASSES
+                and _instances_carry_dict(cls)
+            ):
                 flatten, unflatten = _build_instance_pytree_funcs(cls)
                 try:
                     register_pytree_node(cls, flatten, unflatten)


### PR DESCRIPTION
## Summary
JAX-fitting a shapelet model crashed in `jax.vmap(jax.jit(self.call))` (`Fitness._vmap`) with `TypeError: vars() argument must have __dict__ attribute` (release-validation run `29266305445`).

## Root cause (differs from the issue's initial hypothesis)
Not a `__slots__`/array-like component. `af.Model(ShapeletPolar)` auto-wraps its `int`-typed `n`/`m` args as `af.Model(int)` sub-models, and `register_model._walk` registered **`builtins.int`** as a pytree node. JAX then ran the instance-flatten `_partition(5)` on every `int` leaf → `vars(5)` crash. Confirmed by walking the tree (`int ∈ _REGISTERED_INSTANCE_CLASSES`) and reproduced in pure autofit via `af.Model(int)`. `int` (like `float`/`str`) is a native JAX leaf and must never be registered.

## Fix
`autofit/jax/pytrees.py`: new helper `_instances_carry_dict(cls)` (`any("__dict__" in vars(k) for k in cls.__mro__)`); `register_model._walk` now gates the `register_pytree_node` block on it. Leaf types and purely `__slots__` classes are left as opaque JAX leaves; real model components (which have `__dict__`) register as before. Producer-side — no silent fallback inside `_partition` (per the no-silent-guards principle).

## Verification
- Shapelet repro now `tree_flatten`s cleanly (was crashing on `main`).
- New assertion (paired `autofit_workspace_test` PR): leaf types not registered, `tree_flatten`/`tree_unflatten` round-trip.
- Existing `jax_assertions/pytrees.py` + `enable_pytrees.py` still pass (no regression).
- `pytest test_autofit/` → **1473 passed, 1 skipped**.

## API Changes
None — one private helper added; public surface unchanged.

Fixes #1365

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TDCsgNCXacXqiWAPTswWCt
