### PR TITLE
fix: respect disabled test mode in output paths

### DIFF
--- a/autofit/non_linear/paths/abstract.py
+++ b/autofit/non_linear/paths/abstract.py
@@ -11,6 +11,7 @@ from typing import Optional
 import numpy as np
 
 from autoconf import conf
+from autoconf.test_mode import is_test_mode
 from autofit.mapper.identifier import Identifier, IdentifierField
 from autofit.non_linear.samples.summary import SamplesSummary
 
@@ -24,15 +25,15 @@ pattern = re.compile(r"(?<!^)(?=[A-Z])")
 
 def _test_mode_segment() -> Optional[str]:
     """
-    Returns ``"test_mode"`` when ``PYAUTO_TEST_MODE`` is set in the
-    environment, else ``None``.
+    Returns ``"test_mode"`` when ``PYAUTO_TEST_MODE`` has an active
+    test-mode level, else ``None``.
 
     Inserted into the output-path composition so that smoke runs land
     under ``output/test_mode/...`` instead of sharing a directory with
     real runs. Without this, a cached test-mode result short-circuits
     a later real run at the same paths ("Fit Already Completed").
     """
-    return "test_mode" if os.environ.get("PYAUTO_TEST_MODE") else None
+    return "test_mode" if is_test_mode() else None
 
 
 class AbstractPaths(ABC):
@@ -66,9 +67,8 @@ class AbstractPaths(ABC):
 
         /path/to/output/folder_0/folder_1/name
 
-        If the ``PYAUTO_TEST_MODE`` environment variable is set, a
-        ``test_mode`` segment is inserted directly after the output
-        root:
+        If ``PYAUTO_TEST_MODE`` has an active level greater than zero, a
+        ``test_mode`` segment is inserted directly after the output root:
 
         /path/to/output/test_mode/folder_0/folder_1/name
 

--- a/test_autofit/non_linear/paths/test_paths.py
+++ b/test_autofit/non_linear/paths/test_paths.py
@@ -96,6 +96,11 @@ class TestTestModeOutputPath:
         paths = af.DirectoryPaths(name="name", path_prefix="prefix")
         assert "test_mode" not in paths.output_path.parts
 
+    def test_output_path_excludes_segment_when_level_zero(self, monkeypatch):
+        monkeypatch.setenv("PYAUTO_TEST_MODE", "0")
+        paths = af.DirectoryPaths(name="name", path_prefix="prefix")
+        assert "test_mode" not in paths.output_path.parts
+
     def test_make_path_contains_segment_when_env_set(self, monkeypatch):
         monkeypatch.setenv("PYAUTO_TEST_MODE", "2")
         paths = af.DirectoryPaths(name="name", path_prefix="prefix")
@@ -103,5 +108,10 @@ class TestTestModeOutputPath:
 
     def test_make_path_excludes_segment_when_env_unset(self, monkeypatch):
         monkeypatch.delenv("PYAUTO_TEST_MODE", raising=False)
+        paths = af.DirectoryPaths(name="name", path_prefix="prefix")
+        assert "test_mode" not in paths._make_path().parts
+
+    def test_make_path_excludes_segment_when_level_zero(self, monkeypatch):
+        monkeypatch.setenv("PYAUTO_TEST_MODE", "0")
         paths = af.DirectoryPaths(name="name", path_prefix="prefix")
         assert "test_mode" not in paths._make_path().parts


### PR DESCRIPTION
## Summary

Use PyAutoConf's canonical numeric test-mode state when selecting AutoFit's output namespace. This prevents the release profile's `PYAUTO_TEST_MODE=0` from writing real-search results under `output/test_mode/`, where database scripts cannot find them, while preserving isolation for active test-mode levels.

Addresses #1367.

## Corrective Heart RED authorization

- Exact Heart RED reason: `release validation FAILED (stage integrate)`
- Human authorization: https://github.com/PyAutoLabs/PyAutoFit/issues/1367#issuecomment-4967751375
- Corrective issue: PyAutoFit#1367
- Authorized scope: this existing two-file producer fix and regression tests, delivered as one `pending-release` PR
- Review verdict: CLEAN — one causal commit, no mixed or unrelated scope
- Sibling RED reasons: none; existing YELLOW and STALE findings remain and are not claimed fixed

### Causal mapping

The release integration profile sets `PYAUTO_TEST_MODE=0`. AutoFit used raw environment-string truthiness, so the non-empty string `"0"` incorrectly enabled the `test_mode` path segment. Fits were written below `output/test_mode/database/...`, while the database scrapers read `output/database/...`; the aggregator therefore contained zero searches and raised `AssertionError`. This change delegates path selection to PyAutoConf's numeric `is_test_mode()` API, so level 0 uses the normal output root and active levels remain isolated.

The reported `Failed to load latent variables` warning is incidental: the failing run did not reach latent-variable scraping. SQLAlchemy 2.0.51, dill 0.4.1, and NumPy 2.4.6 do not flip the result.

## API Changes

Changed behavior only: `DirectoryPaths.output_path` now treats `PYAUTO_TEST_MODE=0` as disabled, consistently with the rest of the test-mode API. Active levels continue to use `output/test_mode/`. No symbols or signatures changed.

## Test Plan

- [x] Focused path tests — 14 passed
- [x] `python -m pytest test_autofit/ -x` — 1475 passed, 1 skipped
- [x] Exact Python 3.12 branch-source + release-wheel dependency stack (`SQLAlchemy 2.0.51`, `dill 0.4.1`, `numpy 2.4.6`) — all 6 database scripts passed with `PYAUTO_TEST_MODE=0`
- [x] Dependency controls — SQLAlchemy 2.0.32, NumPy 2.2.6, and dill 0.4.0 each retained the pre-fix assertion; none is causal
- [x] `git diff --check`

## Post-merge validation

Merge remains a separate human decision. After merge, build fresh wheels, rerun release integration validation, and obtain a new Heart verdict before any release decision.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
- None.

### Added
- None.

### Renamed
- None.

### Changed Signature
- None.

### Changed Behaviour
- `autofit.non_linear.paths.directory.DirectoryPaths.output_path` — `PYAUTO_TEST_MODE=0` now writes to the normal output root; values greater than zero continue to write under `output/test_mode/`.

### Migration
- None required. Release-profile callers already set the documented value `PYAUTO_TEST_MODE=0`.

</details>

Generated by the PyAutoLabs agent workflow.
