### PR TITLE
fix: sqlite database slicing + direct-write samples_summary (aggregator Phase D)

### DIFF
--- a/autofit/database/aggregator/aggregator.py
+++ b/autofit/database/aggregator/aggregator.py
@@ -343,16 +343,15 @@ class Aggregator(AbstractAggregator):
         if isinstance(item, int):
             return self.fits[item]
         elif isinstance(item, slice):
+            start_index = 0
             if item.start is not None:
-                if item.start >= 0:
-                    offset += item.start
-                else:
-                    offset = len(self) + item.start
+                start_index = (
+                    item.start if item.start >= 0 else len(self) + item.start
+                )
+                offset += start_index
             if item.stop is not None:
-                if item.stop >= 0:
-                    limit = len(self) - item.stop - offset
-                else:
-                    limit = len(self) + item.stop
+                stop_index = item.stop if item.stop >= 0 else len(self) + item.stop
+                limit = max(stop_index - start_index, 0)
         return self._new_with(offset=offset, limit=limit)
 
     def _fits_for_query(self, query: str) -> List[m.Fit]:

--- a/autofit/non_linear/paths/database.py
+++ b/autofit/non_linear/paths/database.py
@@ -1,14 +1,15 @@
 import shutil
 from typing import Optional, Union
 
-from autoconf.output import conditional_output
+from autoconf.output import conditional_output, should_output
 from autofit.database.sqlalchemy_ import sa
 from .abstract import AbstractPaths
 import numpy as np
 
 from autofit.database.model import Fit
-from autoconf.dictable import to_dict
+from autoconf.dictable import to_dict, from_dict
 from autofit.database.aggregator.info import Info
+from autofit.non_linear.samples.summary import SamplesSummary
 
 
 class DatabasePaths(AbstractPaths):
@@ -275,6 +276,43 @@ class DatabasePaths(AbstractPaths):
 
         self.fit.samples = samples
         self.fit.set_json("samples_info", samples.samples_info)
+
+    def save_samples_summary(
+        self, samples_summary: SamplesSummary, name="samples_summary"
+    ):
+        model = samples_summary.model
+
+        filter_args = tuple(
+            arg_name
+            for arg_name in (
+                "errors_at_sigma_1",
+                "errors_at_sigma_3",
+                "values_at_sigma_1",
+                "values_at_sigma_3",
+                "max_log_likelihood_sample",
+                "median_pdf_sample",
+            )
+            if not should_output(arg_name)
+        )
+
+        samples_summary.model = None
+        self.fit.set_json(
+            name or "samples_summary",
+            to_dict(samples_summary, filter_args=filter_args),
+        )
+        samples_summary.model = model
+
+    def load_samples_summary(self) -> SamplesSummary:
+        try:
+            summary_dict = self.fit.get_json("samples_summary")
+        except KeyError:
+            raise FileNotFoundError(
+                f"No samples_summary saved for fit {self.identifier}"
+            )
+        samples_summary = from_dict(summary_dict)
+        samples_summary.model = self.model
+
+        return samples_summary
 
     def save_latent_samples(self, latent_samples):
         if not self.save_all_samples:

--- a/test_autofit/aggregator/test_aggregator.py
+++ b/test_autofit/aggregator/test_aggregator.py
@@ -1,3 +1,24 @@
+import pytest
+
+import autofit as af
+
+
+@pytest.fixture(name="aggregator_x3")
+def make_aggregator_x3(session):
+    fits = [af.db.Fit(id=f"fit_{i}", is_complete=True) for i in range(3)]
+    session.add_all(fits)
+    session.flush()
+    return af.Aggregator(session)
+
+
+def test_slicing(aggregator_x3):
+    assert len(aggregator_x3[:2]) == 2
+    assert len(aggregator_x3[1:3]) == 2
+    assert len(aggregator_x3[:-1]) == 2
+    assert len(aggregator_x3[-2:]) == 2
+    assert len(aggregator_x3[2:]) == 1
+
+
 def test_completed_aggregator(
         aggregator
 ):


### PR DESCRIPTION
## Summary

Phase D of the aggregator work (#1377, follow-up to #1375/#1376): the sqlite results database was exercised at scale with the merged mock-results harness and assessed. Two genuine bugs found and fixed; the full where-it's-at assessment (including database-vs-directory performance, which shows the sqlite path currently offers no loading-speed advantage) is posted on #1377.

## API Changes

None — bug fixes only.

1. **Database aggregator slicing was inverted**: `agg[:5]` on 26 fits returned 21 (`len − stop − offset` items instead of `stop − start`); `agg[3:8]` returned 15. The pre-existing unit test passed only by coincidence (2 fits, stop=1, where `len − stop == stop`). Fixed in `database/aggregator/aggregator.py::__getitem__` with a 3-fit regression test.
2. **Direct-write (session) fits never stored `samples_summary`**: `DatabasePaths` fell through to the abstract no-op, so `values("samples_summary")` raised `AttributeError` on any session-written database — the summary-only workflows sped up in #1376 were unusable there. Implemented `save_samples_summary` / `load_samples_summary` on `DatabasePaths` (mirrors the directory filter semantics; a missing summary maps to the `FileNotFoundError` the `Fitness` resume check expects). Verified end-to-end: a session-written fit's database now serves summaries.

See full details below.

## Test Plan

- [x] `pytest test_autofit/` — 1486 passed, 1 skipped
- [x] New regression test: `test_autofit/aggregator/test_aggregator.py::test_slicing` (3 fits, breaks the old coincidence)
- [x] End-to-end: `scripts/database/session/general.py` fit → `values("samples_summary")` loads from the session-written database
- [x] Scrape at scale: 25/25 mock results ingested and queryable (was 1/25 before the workspace-side harness fix)

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- `database/aggregator/Aggregator.__getitem__` — positive-stop slices now return `stop − start` fits (previously `len − stop − offset`); negative indices normalised consistently.
- `DatabasePaths.save_samples_summary` / `load_samples_summary` — implemented (previously silent no-op / `None`); session-written fits now store the summary json exactly as scraped fits do; `load_samples_summary` raises `FileNotFoundError` when absent (matching directory semantics).

</details>

Generated by the PyAutoLabs agent workflow.
