### PR TITLE
fix: from_dict dropped dict entries with falsy values (0.0 parameters vanish on load)

### DIFF
--- a/autofit/mapper/model_object.py
+++ b/autofit/mapper/model_object.py
@@ -213,7 +213,7 @@ class ModelObject:
                     loaded_ids=loaded_ids,
                 )
                 for key, value in d["arguments"].items()
-                if value
+                if value is not None
             }
         elif type_ == "instance":
             class_path = get_class_path()

--- a/test_autofit/serialise/test_samples.py
+++ b/test_autofit/serialise/test_samples.py
@@ -157,3 +157,19 @@ def test_generic_from_dict(summary_dict):
     summary = from_dict(summary_dict)
     assert isinstance(summary, SamplesSummary)
     assert isinstance(summary.max_log_likelihood_sample, af.Sample)
+
+
+def test_sample_zero_valued_kwargs_round_trip():
+    """
+    Sample kwargs whose value is exactly 0.0 (e.g. a prior-median centre) must
+    survive to_dict -> from_dict — the dict branch previously filtered falsy
+    values, silently dropping them.
+    """
+    sample = af.Sample(
+        log_likelihood=1.0,
+        log_prior=0.0,
+        weight=1.0,
+        kwargs={"centre.centre_0": 0.0, "sigma": 6.0},
+    )
+    loaded = from_dict(to_dict(sample))
+    assert loaded.kwargs == {("centre", "centre_0"): 0.0, ("sigma",): 6.0}


### PR DESCRIPTION
## Summary

`from_dict`'s dict branch (`autofit/mapper/model_object.py`) filtered entries with `if value`, silently dropping any dictionary entry whose deserialized value is falsy — including parameters whose value is exactly `0.0`. Exposed by the `PYAUTO_TEST_MODE_SAMPLES` bypass (#1381), which writes exact prior-median sample values: lens-model centres and ell_comps have zero medians, so a bypass-written `samples_summary.json` loaded back with 8 of 15 parameters missing and `TracerAgg`/`FitImagingAgg` reconstruction crashed with `KeyError` on the missing paths. Any stored dict with a legitimately-zero value (sample kwargs, info dicts) was affected — this predates #1381, which merely made it deterministic.

## API Changes

None — bug fix only: `from_dict` on a serialized dict now keeps entries whose value is `0.0`/`False`/`""` and drops only `None` (the original intent of the filter).
See full details below.

## Test Plan

- [x] `pytest test_autofit/` — 1494 passed, 1 skipped
- [x] New regression test `test_autofit/serialise/test_samples.py::test_sample_zero_valued_kwargs_round_trip`
- [x] End-to-end: a `PYAUTO_TEST_MODE=2` bypass fit of a lens model (zero-median centre priors) round-trips its summary and reconstructs tracers/fits through `al.agg` (aggregator-lens-profiling harness, autolens_workspace_test PR)

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- `ModelObject.from_dict` (`type == "dict"` branch) — entries with falsy non-None values (`0.0`, `False`, `""`) are no longer silently dropped on deserialization; only `None` values are skipped.

</details>

Generated by the PyAutoLabs agent workflow.
