### PR TITLE
fix: AggregateFITS leaked one file handle per HDU per result (crash at ~500 results)

### DIFF
--- a/autofit/aggregator/summary/aggregate_fits.py
+++ b/autofit/aggregator/summary/aggregate_fits.py
@@ -44,6 +44,12 @@ class AggregateFITS:
         """
         Extract the HDUs from a given fits for a given search.
 
+        Each source fits file is opened once (not once per requested HDU) and closed
+        deterministically — the extracted data is copied out of the memmap, so no
+        file handle stays open per result. Previously each HDU leaked one handle,
+        which exhausted the default open-file limit when aggregating many hundreds
+        of results.
+
         Parameters
         ----------
         result
@@ -58,19 +64,27 @@ class AggregateFITS:
         from astropy.io import fits
 
         row = []
-        for hdu in hdus:
-            source = result.value(subplot_filename(hdu))
-            source_hdu = source[source.index_of(hdu.value)]
+        sources = {}
+        try:
+            for hdu in hdus:
+                source_name = subplot_filename(hdu)
+                if source_name not in sources:
+                    sources[source_name] = result.value(source_name)
+                source = sources[source_name]
+                source_hdu = source[source.index_of(hdu.value)]
 
-            if extname_prefix is not None:
-                source_hdu.header["EXTNAME"] = f"{extname_prefix.upper()}_{source_hdu.header['EXTNAME']}"
+                if extname_prefix is not None:
+                    source_hdu.header["EXTNAME"] = f"{extname_prefix.upper()}_{source_hdu.header['EXTNAME']}"
 
-            row.append(
-                fits.ImageHDU(
-                    data=source_hdu.data,
-                    header=source_hdu.header,
+                row.append(
+                    fits.ImageHDU(
+                        data=source_hdu.data.copy(),
+                        header=source_hdu.header,
+                    )
                 )
-            )
+        finally:
+            for source in sources.values():
+                source.close()
         return row
 
     def extract_fits(self, hdus: List[Enum], extname_prefix_list = None) -> "fits.HDUList":
@@ -119,7 +133,11 @@ class AggregateFITS:
 
         output = []
         for result in self.aggregator:
-            output.append(Table.read(result.value(filename), format="fits"))
+            source = result.value(filename)
+            try:
+                output.append(Table.read(source, format="fits").copy())
+            finally:
+                source.close()
 
         return output
 

--- a/test_autofit/aggregator/summary_files/test_aggregate_fits.py
+++ b/test_autofit/aggregator/summary_files/test_aggregate_fits.py
@@ -57,3 +57,21 @@ def test_list_of_names(summary, output_directory):
         "one.fits",
         "two.fits",
     ])
+
+
+def test_extract_fits_closes_files(summary):
+    """
+    Each source fits file is opened once per result and closed deterministically —
+    previously one handle leaked per requested HDU, exhausting the open-file limit
+    when aggregating many hundreds of results.
+    """
+    import os
+
+    if not os.path.isdir("/proc/self/fd"):
+        pytest.skip("file-descriptor counting requires /proc")
+
+    before = len(os.listdir("/proc/self/fd"))
+    summary.extract_fits([FITSFit.ModelData, FITSFit.ResidualMap])
+    after = len(os.listdir("/proc/self/fd"))
+
+    assert after <= before + 1


### PR DESCRIPTION
## Summary

`AggregateFITS` (the fits_make catalogue workflow) leaked **one file handle per requested HDU per result**: `_hdus` called `result.value(...)` — a fresh `fits.open` — for every HDU, and the returned `ImageHDU`s kept the memmaps (and so the handles) alive. Measured: 200 leaked fds for 100 results × 2 HDUs. At the default `ulimit` of 1024, `extract_fits`/`output_to_folder` crashes with "Too many open files" around ~500 results — the Euclid use case is 3000. `extract_csv` had the same one-leak-per-result pattern.

Fix: each source fits file is opened **once per result** (not once per HDU), extracted data is copied out of the memmap, and the source is closed deterministically. Verified: 0 leaked fds at 100 results, byte-identical output (201 HDUs), and 19% faster per result at 2 HDUs in an interleaved A/B (the win grows with HDU count — the workflow guide uses 4).

Found by the new `aggregate_images`/`aggregate_fits` profiling stages (autofit_workspace_test PR) — the last uncovered leg of the #1375 catalogue workflow (csv was profiled and sped up in #1376; png/fits never were). `AggregateImages` profiled clean: ~1.5 ms/result, already caches one open per subplot type per result — no fruit taken there.

## API Changes

None — bug fix only: no behaviour change other than handles being closed (and `extract_csv` tables being materialised rather than possibly memmap-backed).
See full details below.

## Test Plan

- [x] `pytest test_autofit/` — 1495 passed, 1 skipped
- [x] New regression test `test_aggregate_fits.py::test_extract_fits_closes_files` (fd counting, /proc-guarded)
- [x] Empirical: 100-result extract_fits leaks 0 fds (was 200); output identical

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- `AggregateFITS._hdus` — one `fits.open` per unique source file per result; data copied out of the memmap; sources closed in a `finally`.
- `AggregateFITS.extract_csv` — source fits closed per result; returned `Table`s are materialised copies.

</details>

Generated by the PyAutoLabs agent workflow.
