### PR TITLE
docs: pin Fitness's NaN guard contract — value-only, never gradient

### DIFF
--- a/autofit/non_linear/fitness.py
+++ b/autofit/non_linear/fitness.py
@@ -207,6 +207,27 @@ class Fitness:
         A private method that calls the fitness function with the given parameters and additional keyword arguments.
         This method is intended for internal use only.
 
+        The NaN/inf guard below protects the **value only, never the gradient**.
+
+        A model whose likelihood is NaN or inf is mapped to `resample_figure_of_merit`, so searches that read only
+        the figure of merit (nested samplers, MCMC) get the resample sentinel and never select the point. Gradient
+        consumers get no such protection: under `jax.grad`, reverse-mode differentiates *both* branches of an
+        `xp.where` and multiplies the unselected one by zero, so if the likelihood's derivative is also non-finite
+        the guard yields `0 * NaN = NaN` and the returned gradient is NaN even though the value looks handled.
+
+        This bites only when the masked branch's *derivative* is non-finite — not merely its value. `sqrt(x)` at
+        x < 0 and `cholesky(A)` for non-positive-definite `A` are NaN in both value and derivative, so they trigger
+        it; `log(x)` at x < 0 is NaN in value but its derivative `1/x` stays finite, so it does not.
+
+        A guard here **cannot** repair this. By the time this method receives `log_likelihood` the non-finite
+        derivative is already recorded on the autodiff tape, and no transformation of the output can remove it —
+        an output-side "double-where" does not work. Gradient-safety must be established at the site that creates
+        the NaN, by never *evaluating* the offending operation at the invalid input.
+
+        See autolens_workspace_developer#104, where this was diagnosed, and
+        `autofit_workspace_test/scripts/jax_assertions/fitness_nan_gradient_contract.py`, which pins the behaviour
+        described here.
+
         Parameters
         ----------
         parameters
@@ -235,7 +256,9 @@ class Fitness:
             except exc.FitException:
                 return self.resample_figure_of_merit
 
-        # Penalize NaNs in the log-likelihood
+        # Penalize NaNs in the log-likelihood. Value-only: under jax.grad these `where`s still differentiate the
+        # masked branch, so a non-finite derivative propagates as `0 * NaN = NaN`. See the contract in the
+        # docstring above -- gradient-safety belongs at the site that creates the NaN, not here.
         log_likelihood = self._xp.where(self._xp.isnan(log_likelihood), self.resample_figure_of_merit, log_likelihood)
         log_likelihood = self._xp.where(self._xp.isinf(log_likelihood), self.resample_figure_of_merit, log_likelihood)
 


### PR DESCRIPTION
Closes #1391.

Documents what `Fitness`'s NaN/inf resample guard actually promises. **Docstring and comment only — no behaviour change.**

## The problem

`Fitness.call` guards a bad likelihood with `xp.where(xp.isnan(ll), resample_figure_of_merit, ll)`. It repairs the **value**: searches that read only the figure of merit get the resample sentinel and never select the point. Gradient consumers get nothing — under `jax.grad`, reverse-mode differentiates *both* branches of a `where` and multiplies the unselected one by zero, so `0 * NaN = NaN`. The value looks handled; the gradient is poison.

This was diagnosed in autolens_workspace_developer#104 (the pixelized likelihood's NaN walls) and retroactively explains two #100/#101 mysteries: trajectories died with a *non-finite* objective rather than a NaN one, and `optax.apply_if_finite` *latched* at the cliff rather than stepping past it.

## Why this is a contract, not a fix

The obvious remedy does not work, and that is the point of this PR. Measured:

```
current (fitness.py:239-240)     x=-1.0  value=inf  grad=nan
output-side double-where         x=-1.0  value=inf  grad=nan   <-- does NOT help
input-side safe-x                x=-1.0  value=inf  grad=0.0   <-- works
```

By the time `call` receives `log_likelihood`, the non-finite derivative is **already on the autodiff tape**; no transformation of the output removes it. Only refusing to *evaluate* the offending operation at the invalid input works — and that requires knowing which input is invalid, which is knowable at the NaN's source, not at the `Fitness` boundary where the likelihood is an opaque already-computed scalar.

**So `Fitness.call` is structurally incapable of fixing this.** Rather than add a guard that cannot deliver, this PR documents the true contract and points at where gradient-safety must be established. The real fix for the pixelized case is the autoarray Cholesky (a separate issue).

## The trap is narrower than it first looked

It fires only when the masked branch's **derivative** is non-finite, not merely its value:

| primal at a bad point | value | derivative | trap fires? |
|---|---|---|---|
| `log(x)`, x<0 | NaN | `1/x` = finite | **no** — `0 * -1 = 0` |
| `sqrt(x)`, x<0 | NaN | NaN | **yes** |
| `cholesky(A)`, non-PD | NaN | NaN | **yes** |

An earlier write-up of this claimed the guard "does not protect gradient consumers at all". That was overreach and is corrected here and in the #104 findings doc.

## API Changes

**None.** Docstring and comment only; no signature, behaviour or public-surface change. Downstream workspaces need no migration.

<details>
<summary>Detail</summary>

- Removed: none
- Added: none
- Renamed: none
- Changed Signature: none
- Changed Behaviour: none — `Fitness.call` is byte-for-byte equivalent at runtime
- Migration: n/a

</details>

## Testing

- `pytest test_autofit/` → **1499 passed, 1 skipped** (no delta, as expected for a docstring-only change).
- The contract is pinned by `autofit_workspace_test/scripts/jax_assertions/fitness_nan_gradient_contract.py` (companion PR), which asserts: the value **is** guarded; `jax.grad` **is** NaN; the output-side double-`where` does **not** fix it; input-side safe-x **does**. JAX-only, so it lives there rather than in `test_autofit/` (unit tests are numpy-only per repo policy). Runs on CPU in seconds.

## Gate

- **Tests** — 1499 passed / 1 skipped, in the task worktree.
- **Smoke** — n/a: docstring-only, no runtime surface.
- **Heart** — **RED**, acknowledged contemporaneously by the human on 5 pre-existing unrelated reasons; RED reason verbatim: `PyAutoLens: 1 uncommitted source change(s)` (a stray `paper_jax/paper.md` edit in the main checkout, untouched by this branch).
