### PR TITLE
Rename PyAutoBuild to PyAutoHands

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![PyPI Version](https://img.shields.io/pypi/v/autofit.svg)](https://pypi.org/project/autofit/)
 [![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.7.15.1/notebooks/overview/overview_1_the_basics.ipynb)
 [![Tests](https://github.com/PyAutoLabs/PyAutoFit/actions/workflows/main.yml/badge.svg)](https://github.com/PyAutoLabs/PyAutoFit/actions)
-[![Build](https://github.com/PyAutoLabs/PyAutoBuild/actions/workflows/release.yml/badge.svg)](https://github.com/PyAutoLabs/PyAutoBuild/actions)
+[![Build](https://github.com/PyAutoLabs/PyAutoHands/actions/workflows/release.yml/badge.svg)](https://github.com/PyAutoLabs/PyAutoHands/actions)
 [![Documentation Status](https://readthedocs.org/projects/pyautofit/badge/?version=latest)](https://pyautofit.readthedocs.io/en/latest/?badge=latest)
 [![JOSS](https://joss.theoj.org/papers/10.21105/joss.02550/status.svg)](https://doi.org/10.21105/joss.02550)
 


### PR DESCRIPTION
Part of the coordinated **PyAutoBuild → PyAutoHands** repository rename (the Hands organ). Repoints the release-pipeline **Build badge** in `README.md` to `PyAutoLabs/PyAutoHands`.

**Preserved:** the `autobuild` package/CLI names.

See PyAutoHands/MIGRATION.md for the full rename guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JsYpZBw74w5g1kAqpWEAiE)_