### PR TITLE
chore: rename PyAutoConf → PyAutoNerves in docs/prose

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Shared utilities (e.g. `test_mode`, `jax_wrapper`) belong in autonerves.
 
 ## Related repos
 
-- **Source siblings:** PyAutoConf (upstream). PyAutoGalaxy / PyAutoLens are
+- **Source siblings:** PyAutoNerves (upstream). PyAutoGalaxy / PyAutoLens are
   downstream consumers (they build `Analysis` subclasses on autofit).
 - **autofit_workspace** — runnable tutorials/examples (`../autofit_workspace`).
 - **autofit_workspace_test** — integration + JAX/likelihood parity scripts.

--- a/autofit/non_linear/paths/abstract.py
+++ b/autofit/non_linear/paths/abstract.py
@@ -52,7 +52,7 @@ class AbstractPaths(ABC):
         API. Use via non-linear searches requires manual input of paths, whereas the search API manages this using the
         search attributes.
 
-        The output path within which the *Paths* objects path structure is contained is set via PyAutoConf, using the
+        The output path within which the *Paths* objects path structure is contained is set via PyAutoNerves, using the
         command:
 
         from autonerves import conf

--- a/docs/cookbooks/result.md
+++ b/docs/cookbooks/result.md
@@ -487,7 +487,7 @@ By extending an `Analysis` class with the methods `save_attributes` and `save_re
 custom files can be written to the `files` folder and become accessible via the database.
 
 To save the objects in a human readable and loaded .json format, the `data` and `noise_map`, which are natively stored
-as 1D numpy arrays, are converted to a suitable dictionary output format. This uses the **PyAutoConf** method
+as 1D numpy arrays, are converted to a suitable dictionary output format. This uses the **PyAutoNerves** method
 `to_dict`.
 
 ```python

--- a/docs/features/interpolate.md
+++ b/docs/features/interpolate.md
@@ -166,7 +166,7 @@ print(f"Gaussian centre interpolated at t = 1.5 {instance.gaussian.centre}")
 
 ## Serialisation
 
-The interpolator and model can be serialized to a .json file using **PyAutoConf**'s dedicated serialization methods.
+The interpolator and model can be serialized to a .json file using **PyAutoNerves**'s dedicated serialization methods.
 
 This means an interpolator can easily be loaded into other scripts.
 

--- a/docs/general/configs.md
+++ b/docs/general/configs.md
@@ -11,7 +11,7 @@ the [config directory of the workspace](https://github.com/PyAutoLabs/autofit_wo
 By default, **PyAutoFit** looks for the config files in a `config` folder in the current working directory, which is
 why we run autofit scripts from the `autofit_workspace` directory.
 
-The configuration path can also be set manually in a script using the project **PyAutoConf** and the following
+The configuration path can also be set manually in a script using the project **PyAutoNerves** and the following
 command (the path to the `output` folder where the results of a non-linear search are stored is also set below):
 
 ```bash

--- a/docs/installation/overview.md
+++ b/docs/installation/overview.md
@@ -24,7 +24,7 @@ There are currently no known issues with installing **PyAutoFit**.
 
 ## Dependencies
 
-**PyAutoConf** <https://github.com/PyAutoLabs/PyAutoConf>
+**PyAutoNerves** <https://github.com/PyAutoLabs/PyAutoNerves>
 
 **dynesty** <https://github.com/joshspeagle/dynesty>
 

--- a/llms.txt
+++ b/llms.txt
@@ -17,4 +17,4 @@
 
 ## Ecosystem
 
-- Built on PyAutoConf (config); used by PyAutoGalaxy and PyAutoLens, which build `Analysis` subclasses on it.
+- Built on PyAutoNerves (config); used by PyAutoGalaxy and PyAutoLens, which build `Analysis` subclasses on it.


### PR DESCRIPTION
## What

Update the "source siblings / related repos" references from PyAutoConf to PyAutoNerves following the GitHub repo rename (the package `autonerves` was already renamed in the prior PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ciVftxvYpefh59wSkR7jN

---
_Generated by [Claude Code](https://claude.ai/code/session_013ciVftxvYpefh59wSkR7jN)_