### PR TITLE
fix: Aggregator.from_directory test-mode-aware (interpolate tutorial IndexError)

### DIFF
--- a/autofit/aggregator/aggregator.py
+++ b/autofit/aggregator/aggregator.py
@@ -19,6 +19,8 @@ from pathlib import Path
 from shutil import rmtree
 from typing import List, Union, Iterator, Optional
 
+from autonerves.test_mode import is_test_mode
+
 from .predicate import AttributePredicate
 from .search_output import SearchOutput, GridSearchOutput, GridSearch
 
@@ -168,42 +170,59 @@ class Aggregator:
         """
         print("Aggregator loading search_outputs... could take some time.")
 
-        search_outputs = []
-        grid_search_outputs = []
+        def scan(scan_directory):
+            search_outputs = []
+            grid_search_outputs = []
 
-        for root, dirs, filenames in os.walk(directory, topdown=True):
-            for filename in filenames:
-                if filename.endswith(".zip"):
-                    extracted = Path(root) / filename[:-4]
-                    if extracted.exists():
-                        continue
-                    try:
-                        with zipfile.ZipFile(Path(root) / filename, "r") as f:
-                            f.extractall(extracted)
-                    except zipfile.BadZipFile:
-                        raise zipfile.BadZipFile(
-                            f"File is not a zip file: \n " f"{root} \n" f"{filename}"
-                        )
-                    dirs.append(filename[:-4])
+            for root, dirs, filenames in os.walk(scan_directory, topdown=True):
+                for filename in filenames:
+                    if filename.endswith(".zip"):
+                        extracted = Path(root) / filename[:-4]
+                        if extracted.exists():
+                            continue
+                        try:
+                            with zipfile.ZipFile(Path(root) / filename, "r") as f:
+                                f.extractall(extracted)
+                        except zipfile.BadZipFile:
+                            raise zipfile.BadZipFile(
+                                f"File is not a zip file: \n " f"{root} \n" f"{filename}"
+                            )
+                        dirs.append(filename[:-4])
 
-            def should_add():
-                return not completed_only or ".completed" in filenames
+                def should_add():
+                    return not completed_only or ".completed" in filenames
 
-            if "metadata" in filenames:
-                if should_add():
-                    search_outputs.append(
-                        SearchOutput(
-                            Path(root),
-                            reference=reference,
+                if "metadata" in filenames:
+                    if should_add():
+                        search_outputs.append(
+                            SearchOutput(
+                                Path(root),
+                                reference=reference,
+                            )
                         )
-                    )
-            if ".is_grid_search" in filenames:
-                if should_add():
-                    grid_search_outputs.append(
-                        GridSearchOutput(
-                            Path(root),
+                if ".is_grid_search" in filenames:
+                    if should_add():
+                        grid_search_outputs.append(
+                            GridSearchOutput(
+                                Path(root),
+                            )
                         )
-                    )
+
+            return search_outputs, grid_search_outputs
+
+        search_outputs, grid_search_outputs = scan(directory)
+
+        # Under test mode the searches wrote their results beneath an inserted
+        # ``test_mode`` segment (``output/test_mode/<prefix>``) rather than the
+        # real-run location the caller points at (``output/<prefix>``); see
+        # ``_test_mode_segment`` in ``non_linear/paths/abstract.py``. If nothing
+        # was found there, retry once against that sibling so aggregator-based
+        # tutorials (e.g. features/interpolate) run cleanly under test mode.
+        if len(search_outputs) == 0 and is_test_mode():
+            directory = Path(directory)
+            test_mode_directory = directory.parent / "test_mode" / directory.name
+            if test_mode_directory.exists():
+                search_outputs, grid_search_outputs = scan(test_mode_directory)
 
         if len(search_outputs) == 0:
             print(f"\nNo search_outputs found in {directory}\n")

--- a/test_autofit/aggregator/test_from_directory.py
+++ b/test_autofit/aggregator/test_from_directory.py
@@ -68,3 +68,34 @@ def test_samples_summary_cached():
     search_output = SearchOutput(directory)
 
     assert search_output.samples_summary is search_output.samples_summary
+
+
+@pytest.fixture(name="test_mode_directory")
+def make_test_mode_directory(tmp_path):
+    """
+    Mirrors the on-disk layout a search produces under test mode: the results
+    live beneath an inserted ``test_mode`` segment (``output/test_mode/prefix``)
+    while the caller points ``from_directory`` at the real-run location
+    (``output/prefix``), which holds no metadata.
+    """
+    source = Path(__file__).parent / "search_output"
+    real_directory = tmp_path / "output" / "prefix"
+    real_directory.mkdir(parents=True)
+    shutil.copytree(source, real_directory.parent / "test_mode" / "prefix" / "search_output")
+    return real_directory
+
+
+def test_from_directory_test_mode_fallback(test_mode_directory, monkeypatch):
+    monkeypatch.setattr(
+        "autofit.aggregator.aggregator.is_test_mode", lambda: True
+    )
+    aggregator = Aggregator.from_directory(test_mode_directory)
+    assert len(aggregator) == 1
+
+
+def test_from_directory_no_fallback_when_not_test_mode(test_mode_directory, monkeypatch):
+    monkeypatch.setattr(
+        "autofit.aggregator.aggregator.is_test_mode", lambda: False
+    )
+    aggregator = Aggregator.from_directory(test_mode_directory)
+    assert len(aggregator) == 0


### PR DESCRIPTION
## Summary

`autofit_workspace`'s `features/interpolate.py` crashed with `IndexError: Cannot interpolate: no instances have been added to the interpolator` under test mode (and full-script sweeps). Root cause: under `PYAUTO_TEST_MODE` searches write results beneath an inserted `test_mode` segment (`output/test_mode/<prefix>`, via `_test_mode_segment()` in `non_linear/paths/abstract.py`), but `Aggregator.from_directory` walked only the real-run path the caller points at (`output/<prefix>`), found nothing, and returned an empty aggregator — the tutorial's database section then interpolated over zero instances.

The in-memory interpolation section already worked; only the aggregator/database section failed, and only under test mode (real user runs are unaffected). This restores the missing symmetry: the aggregator now resolves the `test_mode` sibling the way searches namespace their output.

Fixes #1401.

## API Changes

None affecting real runs — internal test-mode recovery only. The `from_directory` signature is unchanged and non-test-mode behaviour is byte-for-byte identical. In test mode only, an empty first scan now retries once against the `test_mode` sibling directory.
See full details below.

## Test Plan
- [x] `pytest test_autofit/aggregator/` — 58 pass (incl. 2 new `from_directory` test-mode tests)
- [x] `pytest test_autofit/aggregator/ test_autofit/interpolator/` — 93 pass, no regressions
- [x] `autofit_workspace/scripts/features/interpolate.py` under `PYAUTO_TEST_MODE=1` with this branch — exit 0, aggregator loads 3 outputs, interpolation succeeds

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- `autofit.aggregator.Aggregator.from_directory(directory, ...)` — when `is_test_mode()` is active **and** the first scan of `directory` yields zero search-outputs, it now retries once against `Path(directory).parent / "test_mode" / Path(directory).name` if that path exists. Outside test mode, and when the first scan is non-empty, behaviour is unchanged. No signature change; no migration required.

</details>

## Validation checklist (--auto run — plan was human-approved)
- Effective level: supervised; the two-level plan (incl. Option A) was **human-approved** before implementation, not merely written to the issue.
- Plan: on issue #1401, unmodified since.
- Gate: tests **58/58 aggregator (93 with interpolator)** · smoke **n/a** (interpolate.py not in the smoke set; validated directly under PYAUTO_TEST_MODE=1) · review **CLEAN** · Heart **RED human-waived** — sole RED reason was an unrelated dirty file (`PyAutoLens/paper_jax/paper.md` WIP), not this change; all YELLOW reasons pre-existing/unrelated.
- [ ] Human: plan sound in hindsight?
- [ ] Human: diff matches plan (no scope creep)?
- [ ] Human: merge, amend, or reject — then log the outcome

Generated by the PyAutoLabs agent workflow.