### PR TITLE
fix: test-mode bypass tolerates a single-eval FitException (resample-equivalent)

### DIFF
--- a/autofit/non_linear/search/abstract_search.py
+++ b/autofit/non_linear/search/abstract_search.py
@@ -872,9 +872,24 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
         log_likelihood = -1.0e99
         if call_likelihood:
             instance = model.instance_from_vector(vector=parameter_vector)
-            log_likelihood = float(
-                analysis.log_likelihood_function(instance)
-            )
+            try:
+                log_likelihood = float(
+                    analysis.log_likelihood_function(instance)
+                )
+            except exc.FitException as e:
+                # A `FitException` means this particular instance is pathological
+                # (e.g. a non-positive-definite inversion, or a degenerate mesh
+                # that yields NaN vertices). In a real search the sampler absorbs
+                # this by resampling; test mode has no sampler, so a single
+                # unlucky verification eval must not hard-fail the run. Keep the
+                # `-1.0e99` sentinel — the same effect a resample-to-reject has —
+                # and log the cause so a genuinely broken likelihood stays visible.
+                # Only `FitException` is caught: real code errors still propagate.
+                logger.warning(
+                    "TEST MODE 2: likelihood verification raised FitException "
+                    f"({e.__cause__ or e!r}); treating as a resample-rejected "
+                    "instance and continuing with the sentinel log likelihood."
+                )
 
         sample_list = self._build_fake_samples(
             model=model,

--- a/test_autofit/non_linear/search/test_abstract_search.py
+++ b/test_autofit/non_linear/search/test_abstract_search.py
@@ -420,3 +420,56 @@ class TestBypassWritesCompleted:
         )
 
         assert result is not None
+
+
+class _FitExceptionAnalysis(af.m.MockAnalysis):
+    """Analysis whose likelihood always raises `FitException`, mimicking a
+    pathological instance (non-PD inversion / NaN Delaunay mesh) that a real
+    sampler would resample away."""
+
+    def log_likelihood_function(self, instance):
+        raise af.exc.FitException("pathological instance (test)")
+
+
+class TestBypassToleratesFitException:
+    """
+    In test mode 2 the bypass calls the likelihood once to verify it works. A
+    single unlucky instance raising `FitException` (a resample signal a real
+    sampler absorbs) must NOT hard-fail the run — otherwise flaky pixelization
+    scripts intermittently break CI smoke (autolens_workspace#307, PyAutoLens#640).
+    Only `FitException` is tolerated; genuine errors still propagate.
+    """
+
+    def test__test_mode_2__fitexception_tolerated__fit_completes_with_sentinel(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("PYAUTO_TEST_MODE", "2")
+
+        search = af.DynestyStatic(
+            name="bypass_fitexception", unique_tag="bypass_fitexception_test"
+        )
+
+        result = search.fit(
+            model=af.Model(af.m.MockClassx2), analysis=_FitExceptionAnalysis()
+        )
+
+        assert result is not None
+        # The failed verification eval falls back to the -1.0e99 sentinel, the
+        # same effect as a resample-to-reject.
+        assert float(result.samples.max_log_likelihood_sample.log_likelihood) == pytest.approx(
+            -1.0e99
+        )
+
+    def test__test_mode_2__non_fitexception_still_propagates(self, monkeypatch):
+        monkeypatch.setenv("PYAUTO_TEST_MODE", "2")
+
+        class _BrokenAnalysis(af.m.MockAnalysis):
+            def log_likelihood_function(self, instance):
+                raise ValueError("a genuine bug, not a resample signal")
+
+        search = af.DynestyStatic(
+            name="bypass_broken", unique_tag="bypass_broken_test"
+        )
+
+        with pytest.raises(ValueError):
+            search.fit(model=af.Model(af.m.MockClassx2), analysis=_BrokenAnalysis())


### PR DESCRIPTION
## Summary

`TEST_MODE=2`'s `_fit_bypass_test_mode` (`autofit/non_linear/search/abstract_search.py`) calls the likelihood **once** to verify the analysis runs. If that single prior-median instance is pathological — a non-positive-definite inversion, or a degenerate Delaunay mesh that yields NaN vertices — the analysis raises `af.exc.FitException`. That is exactly the signal a real non-linear search absorbs by **resampling**. In test mode there is no sampler, so the exception hard-failed the whole run.

This made flaky pixelization scripts intermittently break CI smoke. Concretely, `autolens_workspace/scripts/interferometer/features/pixelization/delaunay.py` fails ~50% on CI py3.12 with `ValueError: Points cannot contain NaN` from the Delaunay/qhull triangulation, via `source_pix_2` → `_fit_bypass_test_mode` → `log_likelihood_function` → inversion → `scipy_delaunay` (autolens_workspace#307, PyAutoLens#640). The same workspace commit passed on a parallel run — a true nondeterministic (CI-thread/BLAS-dependent) flake.

## Change

Wrap the single verification eval: on `FitException`, log the cause and keep the existing `-1.0e99` sentinel (the same effect as a resample-to-reject). **Only `FitException` is caught** — genuine code errors (e.g. `ValueError`, `AttributeError`) still propagate and fail test mode, so a truly broken likelihood stays loud. Central fix: benefits every analysis (imaging, interferometer, galaxy), not just this one script. Complements PyAutoLens#639 (`raise_fit_exception` preserves the cause behind the FitException).

## Tests

- `TestBypassToleratesFitException::test__test_mode_2__fitexception_tolerated__fit_completes_with_sentinel` — fit completes, sentinel log-likelihood retained.
- `...::test__test_mode_2__non_fitexception_still_propagates` — a `ValueError` still raises.
- 108 `non_linear/{search,result,samples}` tests pass; no regressions.

## API Changes

None. Behaviour change is confined to the `TEST_MODE=2` bypass path; public API, signatures, and normal-search behaviour are unchanged. No downstream workspace migration required.

## Follow-ups

- autolens_workspace: un-park the interferometer Delaunay `no_run.yaml` entry + add to smoke (library-first: merge this PR first).
- Phase 2 (PyAutoArray): fix the actual NaN/non-PD producer (candidate: `fnnls.py:134` divide-by-zero; degenerate Hilbert-mesh vertices) so the fit is not merely tolerated but correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)