### PR TITLE
fix: tolerate data-less HDUs in the database scrape

### DIFF
--- a/autofit/database/model/array.py
+++ b/autofit/database/model/array.py
@@ -170,13 +170,21 @@ class HDU(Array):
         self._header = header.tostring()
 
     @property
+    def has_data(self):
+        """
+        Whether this HDU carries an array payload. A data-less HDU stores no
+        shape, which is how it is distinguished from one holding an array.
+        """
+        return self._shape is not None
+
+    @property
     def hdu(self):
         from astropy.io import fits
 
         type_ = fits.PrimaryHDU if self.is_primary else fits.ImageHDU
 
         return type_(
-            self.array,
+            self.array if self.has_data else None,
             self.header,
         )
 
@@ -185,7 +193,18 @@ class HDU(Array):
         from astropy.io import fits
 
         self.is_primary = isinstance(hdu, fits.PrimaryHDU)
-        self.array = hdu.data
+
+        # A data-less HDU is legitimate and routine: the first HDU of a
+        # multi-extension FITS is conventionally an empty PrimaryHDU, and
+        # `AggregateFITS` emits exactly that. Leave the array columns null
+        # rather than dereferencing `hdu.data.dtype` on None.
+        if hdu.data is None:
+            self._dtype = None
+            self._shape = None
+            self.bytes = None
+        else:
+            self.array = hdu.data
+
         self.header = hdu.header
 
     @property

--- a/test_autofit/database/test_file_types.py
+++ b/test_autofit/database/test_file_types.py
@@ -54,3 +54,34 @@ def test_hdu(hdu, hdu_array):
     loaded = db_hdu.hdu
     assert (loaded.data == hdu_array).all()
     assert loaded.header == hdu.header
+
+
+def test_hdu_without_data():
+    """
+    A data-less HDU must round-trip. The first HDU of a multi-extension FITS is
+    conventionally an empty `PrimaryHDU` — `AggregateFITS` emits exactly that —
+    so dereferencing `hdu.data.dtype` here broke every such scrape.
+    """
+    db_hdu = db.HDU(name="test", hdu=fits.PrimaryHDU())
+
+    assert not db_hdu.has_data
+
+    loaded = db_hdu.hdu
+    assert isinstance(loaded, fits.PrimaryHDU)
+    assert loaded.data is None
+
+
+def test_set_fits_with_empty_primary_hdu(fit, hdu_array):
+    """
+    The shape the database scrape actually meets: an empty `PrimaryHDU`
+    followed by named image extensions.
+    """
+    image_hdu = fits.ImageHDU(hdu_array)
+    image_hdu.header["EXTNAME"] = "MODEL_IMAGE"
+
+    fit.set_fits("test", fits.HDUList([fits.PrimaryHDU(), image_hdu]))
+
+    loaded = fit.get_fits("test")
+    assert len(loaded) == 2
+    assert loaded[0].data is None
+    assert (loaded[1].data == hdu_array).all()


### PR DESCRIPTION
## Summary

The `HDU.hdu` setter assigned `hdu.data` straight into the inherited `Array.array` setter, which dereferences `array.dtype` without a null check. Any HDU carrying no data therefore raised `AttributeError: 'NoneType' object has no attribute 'dtype'` and aborted the whole sqlite scrape.

Data-less HDUs are routine rather than exotic. The first HDU of a multi-extension FITS is conventionally an empty `PrimaryHDU`, and `AggregateFITS` emits exactly that shape — `aggregate_fits.py:107`, whose own docstring at line 94 reads "The first HDU in each list is an empty PrimaryHDU". The database path could not ingest the library's own aggregated FITS output.

Such HDUs now store a null payload and are reconstructed with `data=None`, so an empty `PrimaryHDU` round-trips losslessly.

Found while reproducing a census report against `autofit_workspace_test` `scripts/profiling/aggregator/profile_database.py`, which was filed as a test-mode env-config gap. It is neither test-mode-specific nor env-dependent — the minimal repro is `db.HDU(hdu=fits.PrimaryHDU())`.

Closes #1413 (library half; the workspace half is queued behind a repo conflict).

## API Changes

Behaviour: `HDU` round-trips data-less HDUs instead of raising `AttributeError`. This only converts a hard crash into the correct result — no previously-working call changes its output.

Added: `HDU.has_data`, a read-only property distinguishing an HDU with an array payload from one without.

See full details below.

## Test Plan

- [x] `test_hdu_without_data` — a bare `fits.PrimaryHDU()` round-trips, returning `data is None` and preserving the `PrimaryHDU` type
- [x] `test_set_fits_with_empty_primary_hdu` — the shape the scrape actually meets (empty primary + named `ImageHDU` extension) survives `set_fits`/`get_fits`
- [x] Both new tests confirmed to **fail without the fix**, with exactly the reported `AttributeError` at `array.py:56`
- [x] `test_autofit/` full suite: 1527 passed, 1 skipped
- [x] `autofit_workspace_test` `profiling/aggregator/profile_database.py` runs end-to-end (exit 0); previously the reported crash
- [x] `black --check` clean

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- `autofit.database.model.array.HDU.has_data` — `bool` property; `True` when the HDU holds an array payload. A data-less HDU stores no shape, which is how the two are distinguished.

### Changed Behaviour
- `autofit.database.model.array.HDU.hdu` (setter) — an HDU whose `.data` is `None` now records a null payload (`_dtype`, `_shape`, `bytes` left unset) instead of raising `AttributeError` from the inherited `Array.array` setter.
- `autofit.database.model.array.HDU.hdu` (getter) — reconstructs with `data=None` when `has_data` is `False`, rather than calling `np.frombuffer` on a null buffer.
- Downstream, `Fit.set_fits` / `Aggregator.add_directory` now ingest multi-extension FITS beginning with an empty `PrimaryHDU`; previously any such file aborted the scrape.

### Migration
- None. No signature changed and no symbol was removed or renamed; code that worked before is unaffected.

</details>

Generated by the PyAutoLabs agent workflow.
