### PR TITLE
fix: MultiStart gradient step loop crashes on a real iterations_per_full_update cadence

### DIFF
--- a/autofit/non_linear/search/mle/multi_start_gradient/search.py
+++ b/autofit/non_linear/search/mle/multi_start_gradient/search.py
@@ -174,12 +174,22 @@ class AbstractMultiStartGradient(AbstractMLE):
         reach it, and raises ``TypeError: 'float' object cannot be interpreted
         as an integer``.
 
+        The chunk is floored at 1 step because ``int`` truncates towards zero: a
+        fractional cadence below 1 would otherwise give ``range(0)``, so
+        ``total_steps`` would never advance and the enclosing ``while`` loop
+        would spin forever re-running ``perform_update``. One step per chunk is
+        the slowest *progressing* cadence, and it can never overshoot
+        ``steps_remaining``, which is at least 1 whenever the loop is entered.
+
         Parameters
         ----------
         steps_remaining
             The number of steps left in the ``n_steps`` budget.
         """
-        return int(min(self.iterations_per_full_update or self.n_steps, steps_remaining))
+        return max(
+            1,
+            int(min(self.iterations_per_full_update or self.n_steps, steps_remaining)),
+        )
 
     def _fit(
         self,

--- a/autofit/non_linear/search/mle/multi_start_gradient/search.py
+++ b/autofit/non_linear/search/mle/multi_start_gradient/search.py
@@ -156,6 +156,31 @@ class AbstractMultiStartGradient(AbstractMLE):
 
         self.logger.debug(f"Creating {self.optax_method} MultiStartGradient Search")
 
+    def _steps_in_chunk(self, steps_remaining: int) -> int:
+        """
+        The number of gradient steps to run before the next ``perform_update``
+        checkpoint boundary, given how much of the ``n_steps`` budget is left.
+
+        ``AbstractSearch.__init__`` stores ``iterations_per_full_update`` as a
+        **float**, because the packaged default is the inf-like ``1e99`` (a
+        single chunk, i.e. checkpoint only at the end). ``range`` requires an
+        ``int``, so the chunk size is cast here at the consumer rather than in
+        the shared float coercion, which every other search relies on.
+
+        Without the cast the loop only survives on the default: ``min(1e99,
+        steps_remaining)`` returns the ``int`` operand, so the float never
+        reaches ``range``. A user-supplied cadence *below* the remaining budget
+        (e.g. ``iterations_per_full_update=50`` with ``n_steps=3000``) does
+        reach it, and raises ``TypeError: 'float' object cannot be interpreted
+        as an integer``.
+
+        Parameters
+        ----------
+        steps_remaining
+            The number of steps left in the ``n_steps`` budget.
+        """
+        return int(min(self.iterations_per_full_update or self.n_steps, steps_remaining))
+
     def _fit(
         self,
         model: AbstractPriorModel,
@@ -281,9 +306,7 @@ class AbstractMultiStartGradient(AbstractMLE):
         while total_steps < self.n_steps and stop_reason != "converged":
 
             steps_remaining = self.n_steps - total_steps
-            iterations = min(
-                self.iterations_per_full_update or self.n_steps, steps_remaining
-            )
+            iterations = self._steps_in_chunk(steps_remaining)
 
             # Convergence is assessed every step (``fom_history`` updates every
             # step) rather than only at the ``iterations_per_full_update`` boundary,

--- a/autofit/non_linear/search/mle/multi_start_gradient/search.py
+++ b/autofit/non_linear/search/mle/multi_start_gradient/search.py
@@ -174,22 +174,60 @@ class AbstractMultiStartGradient(AbstractMLE):
         reach it, and raises ``TypeError: 'float' object cannot be interpreted
         as an integer``.
 
-        The chunk is floored at 1 step because ``int`` truncates towards zero: a
-        fractional cadence below 1 would otherwise give ``range(0)``, so
-        ``total_steps`` would never advance and the enclosing ``while`` loop
-        would spin forever re-running ``perform_update``. One step per chunk is
-        the slowest *progressing* cadence, and it can never overshoot
-        ``steps_remaining``, which is at least 1 whenever the loop is entered.
+        Both the cadence and ``n_steps`` are validated as whole numbers of at
+        least one step, rather than being coerced into something plausible. A
+        value below 1 (or a fractional one) truncates to ``range(0)``: no step
+        runs, ``total_steps`` never advances, and the enclosing ``while`` loop
+        spins forever re-running ``perform_update`` — a silent hang that on a
+        cluster burns the whole allocation. Clamping such a value to 1 would
+        hide the mistake instead of reporting it, so it raises here. Once both
+        are validated, ``steps_remaining`` is an ``int`` of at least 1 whenever
+        the loop is entered, so the returned chunk is at least 1 and never
+        overshoots the remaining budget.
 
         Parameters
         ----------
         steps_remaining
             The number of steps left in the ``n_steps`` budget.
+
+        Raises
+        ------
+        ValueError
+            If ``n_steps``, or an explicitly supplied
+            ``iterations_per_full_update``, is not a whole number of at least 1.
         """
-        return max(
-            1,
-            int(min(self.iterations_per_full_update or self.n_steps, steps_remaining)),
-        )
+        self._check_step_count(self.n_steps, "n_steps")
+
+        # A falsy cadence means "no intermediate checkpoint": one chunk covering
+        # the whole budget. Only a value the user actually supplied is validated.
+        if self.iterations_per_full_update:
+            self._check_step_count(
+                self.iterations_per_full_update, "iterations_per_full_update"
+            )
+            cadence = self.iterations_per_full_update
+        else:
+            cadence = self.n_steps
+
+        return int(min(cadence, steps_remaining))
+
+    def _check_step_count(self, value, name: str):
+        """
+        Reject a step count that cannot describe a whole number of gradient
+        steps. ``float`` values are allowed — the packaged config default
+        ``1e99`` is one — provided they are integral.
+        """
+        try:
+            is_whole = value == int(value)
+        except (TypeError, ValueError, OverflowError):
+            is_whole = False
+
+        if not is_whole or value < 1:
+            raise ValueError(
+                f"{type(self).__name__}: `{name}` must be a whole number of "
+                f"gradient steps and at least 1, but was {value!r}. A fractional "
+                "or sub-1 value gives a zero-length step chunk, which never "
+                "advances the search and would hang it rather than fail."
+            )
 
     def _fit(
         self,

--- a/test_autofit/non_linear/search/mle/test_multi_start_gradient.py
+++ b/test_autofit/non_linear/search/mle/test_multi_start_gradient.py
@@ -181,6 +181,18 @@ def test__steps_in_chunk__default_cadence_is_a_single_chunk():
     assert isinstance(iterations, int)
 
 
+def test__steps_in_chunk__fractional_cadence_never_yields_a_zero_length_chunk():
+    """``int`` truncates towards zero, so a cadence below 1 would give
+    ``range(0)``: no steps run, ``total_steps`` never advances, and the step
+    loop's enclosing ``while`` spins forever. The chunk is floored at 1."""
+    search = af.MultiStartAdam(n_steps=300, iterations_per_full_update=0.5)
+
+    iterations = search._steps_in_chunk(steps_remaining=300)
+
+    assert iterations == 1
+    assert isinstance(iterations, int)
+
+
 def test__steps_in_chunk__falsy_cadence_falls_back_to_n_steps():
     # A falsy cadence means "no checkpoint boundary": fall back to the full
     # ``n_steps`` budget rather than a zero-length chunk that would spin the

--- a/test_autofit/non_linear/search/mle/test_multi_start_gradient.py
+++ b/test_autofit/non_linear/search/mle/test_multi_start_gradient.py
@@ -136,6 +136,64 @@ def test__convergence_default_is_on_and_carried():
         assert cls(convergence=custom).convergence is custom
 
 
+def test__steps_in_chunk__real_cadence_is_an_int_range_can_consume():
+    """The step loop does ``for _ in range(...)`` over the chunk size, but
+    ``iterations_per_full_update`` is stored as a float by ``AbstractSearch``.
+
+    A cadence *below* the remaining budget is the case that reaches ``range``
+    (with the ``1e99`` default, ``min`` returns the int ``steps_remaining``
+    instead), and it used to raise ``TypeError: 'float' object cannot be
+    interpreted as an integer`` on step-loop entry.
+    """
+    search = af.MultiStartAdam(n_steps=3000, iterations_per_full_update=50)
+
+    # The knob really is stored as a float — this is what made the crash latent.
+    assert isinstance(search.iterations_per_full_update, float)
+
+    iterations = search._steps_in_chunk(steps_remaining=3000)
+
+    assert iterations == 50
+    assert isinstance(iterations, int)
+    # The actual failing operation in ``_fit``.
+    assert len(list(range(iterations))) == 50
+
+
+def test__steps_in_chunk__clamps_to_the_remaining_budget():
+    # Near the end of the budget the chunk shrinks to what is left, so the loop
+    # never overshoots ``n_steps``.
+    search = af.MultiStartAdam(n_steps=3000, iterations_per_full_update=50)
+
+    assert search._steps_in_chunk(steps_remaining=20) == 20
+    assert isinstance(search._steps_in_chunk(steps_remaining=20), int)
+
+
+def test__steps_in_chunk__default_cadence_is_a_single_chunk():
+    # The packaged default is the inf-like 1e99: one chunk covering the whole
+    # budget (checkpoint only at the end), which is why the crash never fired
+    # on a default run.
+    search = af.MultiStartAdam(n_steps=300)
+
+    assert search.iterations_per_full_update == pytest.approx(1e99)
+
+    iterations = search._steps_in_chunk(steps_remaining=300)
+
+    assert iterations == 300
+    assert isinstance(iterations, int)
+
+
+def test__steps_in_chunk__falsy_cadence_falls_back_to_n_steps():
+    # A falsy cadence means "no checkpoint boundary": fall back to the full
+    # ``n_steps`` budget rather than a zero-length chunk that would spin the
+    # while-loop forever. ``__init__`` cannot produce this (a falsy argument
+    # resolves from config to 1e99), so it is set directly — which is exactly
+    # what a caller overwriting the attribute post-construction does.
+    search = af.MultiStartAdam(n_steps=120)
+    search.iterations_per_full_update = 0.0
+
+    assert search._steps_in_chunk(steps_remaining=120) == 120
+    assert isinstance(search._steps_in_chunk(steps_remaining=120), int)
+
+
 def test__check_if_converged__plateau_stops_climbing_does_not():
     # rtol/atol both zero: converges only on an exactly-flat window.
     convergence = af.MultiStartGradientConvergence(

--- a/test_autofit/non_linear/search/mle/test_multi_start_gradient.py
+++ b/test_autofit/non_linear/search/mle/test_multi_start_gradient.py
@@ -1,3 +1,5 @@
+import inspect
+
 import numpy as np
 import pytest
 
@@ -181,16 +183,48 @@ def test__steps_in_chunk__default_cadence_is_a_single_chunk():
     assert isinstance(iterations, int)
 
 
-def test__steps_in_chunk__fractional_cadence_never_yields_a_zero_length_chunk():
-    """``int`` truncates towards zero, so a cadence below 1 would give
-    ``range(0)``: no steps run, ``total_steps`` never advances, and the step
-    loop's enclosing ``while`` spins forever. The chunk is floored at 1."""
-    search = af.MultiStartAdam(n_steps=300, iterations_per_full_update=0.5)
+def test__fit_step_loop_takes_its_chunk_size_from_the_helper():
+    """Wiring guard: every other test here exercises ``_steps_in_chunk``
+    directly, so all of them would still pass if ``_fit`` went back to computing
+    the chunk inline — which is the exact regression this fix is about.
 
-    iterations = search._steps_in_chunk(steps_remaining=300)
+    ``_fit`` cannot be executed from this suite (it needs jax, optax and a
+    JAX-traceable ``Analysis``, and the library suite is NumPy-only), so the
+    call site is asserted at the source level instead.
+    """
+    source = inspect.getsource(af.MultiStartAdam._fit)
 
-    assert iterations == 1
-    assert isinstance(iterations, int)
+    assert "self._steps_in_chunk(" in source
+    # the un-cast inline form the crash came from must not come back
+    assert "self.iterations_per_full_update or self.n_steps" not in source
+
+
+@pytest.mark.parametrize("cadence", [0.5, 50.9, -5])
+def test__steps_in_chunk__unusable_cadence_raises_rather_than_being_clamped(cadence):
+    """A cadence below 1 (or a fractional one) truncates to ``range(0)``: no
+    step runs, ``total_steps`` never advances, and the step loop's enclosing
+    ``while`` spins forever re-running ``perform_update``.
+
+    Clamping such a value to 1 would hide the mistake and silently run a
+    cadence the user did not ask for, so it is rejected instead — a hang on a
+    cluster is far more expensive than an error at the first chunk boundary.
+    """
+    search = af.MultiStartAdam(n_steps=300, iterations_per_full_update=cadence)
+
+    with pytest.raises(ValueError, match="iterations_per_full_update"):
+        search._steps_in_chunk(steps_remaining=300)
+
+
+@pytest.mark.parametrize("n_steps", [2.5, 0, -10])
+def test__steps_in_chunk__unusable_n_steps_raises(n_steps):
+    """``steps_remaining`` is only guaranteed to be an ``int`` of at least 1
+    because ``n_steps`` is one. A fractional ``n_steps`` leaves a fractional
+    remainder (e.g. 0.5) that truncates to a zero-length chunk, so the budget
+    is validated too rather than assumed from its type annotation."""
+    search = af.MultiStartAdam(n_steps=n_steps)
+
+    with pytest.raises(ValueError, match="n_steps"):
+        search._steps_in_chunk(steps_remaining=1)
 
 
 def test__steps_in_chunk__falsy_cadence_falls_back_to_n_steps():


### PR DESCRIPTION
Closes #1420.

## Summary

The MultiStart gradient step loop does `for _ in range(iterations)`, but
`AbstractSearch.__init__` stores `iterations_per_full_update` as a **float**
(`abstract_search.py:219`) so the inf-like `1e99` config default is
representable. The crash was latent because `min(1e99, steps_remaining)` returns
the `int` operand — only a user-supplied cadence *below* the remaining budget
reaches `range` and raises:

```
TypeError: 'float' object cannot be interpreted as an integer
```

Six RAL chain jobs (331182–331190) died on this back-to-back during the wsdev#117
Pix-Prodigy CPU campaign, using `iterations_per_full_update=50` with
`n_steps=3000`.

The cast is applied **at the consumer**, via a new
`AbstractMultiStartGradient._steps_in_chunk`, rather than in the shared `float()`
coercion — that coercion exists to accept `1e99` and is used by every other
search, so changing it there is the regression-prone option. The helper also
makes the defect testable without JAX: `_fit` requires `jax`, `optax` and a
JAX-traceable `Analysis`, and the library unit suite is NumPy-only.

Commits 2 and 3 come from review, and are the interesting part of this PR.

**Commit 2** fixed a defect in commit 1: `int` truncates towards zero, so a
fractional cadence below 1 gives `range(0)` — no steps run, `total_steps` never
advances, and the enclosing `while` spins forever re-running `perform_update`.
Commit 1 alone would have traded a loud `TypeError` for a silent hang, which on
a cluster burns the whole allocation. It floored the chunk at 1.

**Commit 3** replaced that floor, after an independent adversarial review (Codex
`gpt-5.6-sol`) made two points that hold up:

- `max(1, int(...))` **silently launders invalid input** — `-5`, `0.5` and `50.9`
  all became a plausible-looking cadence, so a typo would quietly run a schedule
  the user never asked for. That is the silent-guard pattern this codebase
  removes rather than adds. It now raises a `ValueError` naming the value.
- The "chunk can never overshoot `steps_remaining`" claim held **only because
  `n_steps` is an integer**. The loop guard proves `steps_remaining > 0`, not
  `>= 1`, so a float `n_steps=2.5` leaves a `0.5` remainder that truncates to a
  zero-length chunk and hangs. `n_steps` is annotated `int` but never validated,
  so it is validated too. The two checks together restore the invariant the
  floor was papering over, which is why the floor could be removed rather than
  kept alongside them.

## API Changes

**None.** The only new symbol is the private
`AbstractMultiStartGradient._steps_in_chunk`; no public class, method, signature,
argument, default or config key changed. Behaviour on the default path is
bit-identical — with the packaged `1e99` cadence the expression already returned
the `int` `steps_remaining`, and `int()`/`max(1, ...)` leave that untouched.
Downstream workspaces and notebooks need no migration.

The change is purely corrective: inputs that previously **crashed** now work.
Nothing that previously ran behaves differently.

## Testing

- `pytest test_autofit/ -x` in the task worktree → **1541 passed, 1 skipped**.
- New NumPy-only tests in
  `test_autofit/non_linear/search/mle/test_multi_start_gradient.py`: a real
  cadence below the budget returns an `int` that `range()` consumes; the chunk
  clamps to `steps_remaining`; the `1e99` default still gives a single
  whole-budget chunk; a falsy cadence falls back to `n_steps`; an unusable
  cadence (`0.5`, `50.9`, `-5`) and an unusable `n_steps` (`2.5`, `0`, `-10`)
  each raise `ValueError`.
- A **wiring guard**, also from the review: every other test drives
  `_steps_in_chunk` directly, so all of them would still pass if `_fit` went
  back to computing the chunk inline — the exact regression this PR is about.
  `_fit` can't be executed from this suite (jax + optax + a JAX-traceable
  `Analysis`; the library suite is NumPy-only), so the call site is asserted at
  the source level.
- **Regression pinned:** removing the `int()` cast fails exactly one new test
  (`test__steps_in_chunk__real_cadence_is_an_int_range_can_consume`).
- Reproduced on `main` first: `range(min(50.0, 3000))` raises the reported
  `TypeError`.

## Validation checklist

- [x] **Tests** — `pytest test_autofit/ -x`: 1541 passed, 1 skipped. No public API
      change, so downstream dependent suites are n/a.
- [x] **Smoke** — curated `smoke_tests.txt` across all six workspaces with the task
      worktree's `activate.sh` sourced: 50 passed, 7 failed, 3 skipped/missing.
      All 7 failures are **pre-existing** — re-running each against `main` under
      identical conditions reproduces exactly the same 7 (they are the
      `jax_likelihood` parity scripts, which the smoke profile runs with
      `PYAUTO_DISABLE_JAX=1`). A further 5 scripts failed only in the parallel
      sweep and pass on the branch when re-run sequentially, matching `main` —
      contention over shared `output/`/`dataset/` state in the runner, not a
      regression.
- [x] **Review** — two reviewers. The Brain review faculty returned FINDINGS on
      pass 1 (the truncation-to-zero hang → commit 2) and **CLEAN** on pass 2. An
      independent adversarial review (Codex `gpt-5.6-sol`, xhigh) then produced
      commit 3, corrected the follow-up list below, and surfaced two pre-existing
      bugs now filed separately.
- [x] **Heart** — **YELLOW**, score 65, `2026-07-27T12:11:07Z`, no RED reasons.
      The reason set was acknowledged by the human at this launch, verbatim:
      `workspace validation not passing (13 failed, 2026-07-21T19-05-22Z)`;
      `33 stale parked script(s)`;
      `manifest drift: tenant firewall (organ code) — 5 mismatch(es) vs PyAutoMind/repos.yaml`;
      and the stale-tier `release validation stale: source moved since rehearsal
      (PyAutoNerves, PyAutoFit, PyAutoArray, PyAutoGalaxy, PyAutoLens)`.
      None touches `autofit/non_linear/search/mle/`.

## Follow-ups (deliberately not in this PR)

1. **Two sibling searches carry the same defect, both confirmed reproducible** —
   `mcmc/emcee/search.py:206` (`EnsembleSampler.sample` does `range(iterations)`
   with no cast) and `mcmc/blackjax/nuts/search.py:291` (`jax.random.split(key,
   50.0)` raises the same `TypeError`). An independent adversarial review
   (Codex `gpt-5.6-sol`) checked every consumer empirically and corrected an
   earlier, wider claim of mine: `mcmc/zeus/search.py:242` is **safe** (zeus casts
   internally via `self.nsteps = int(iterations)`), and `mle/bfgs/search.py:171`,
   `nest/dynesty/.../abstract.py:365` and `nest/nautilus/search.py:477` are
   tolerated (comparison limits / arithmetic only). See issue #1420 for the
   verified table.
2. **Two pre-existing MultiStart bugs**, both confirmed by reading the call
   sites and filed as PyAutoMind drafts:
   - the final `perform_update` runs **twice** — `_fit` emits one with
     `during_analysis=False` at `search.py:432`, then `start_resume_fit` emits
     the same at `abstract_search.py:704`. Every other search
     (`emcee:238`, `bfgs:219`, `nautilus:438`) passes `during_analysis=True`
     unconditionally inside `_fit`, so MultiStart is the outlier and doubles
     the cost of final output, latents, visualization and profiling.
   - a completed `stop_reason="max_steps"` search resumed with a larger
     `n_steps` keeps the stale stop reason in every intermediate checkpoint
     (`search.py:413-416` only reassigns on convergence or the new ceiling).
3. **The workspace hotfix should be removed once this merges** — the
   post-construction int overwrite in
   `autolens_workspace_developer/searches_minimal/pix_prodigy.py` (branch
   `feature/pix-prodigy-cpu`), which belongs to the live `pix-prodigy-cpu` task
   (wsdev#117).

🤖 Generated with [Claude Code](https://claude.com/claude-code)