### PR TITLE
fix: gate optax to python>=3.11 in the jax extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,13 @@ local_scheme = "no-local-version"
 
 
 [project.optional-dependencies]
-jax = ["autonerves[jax]", "optax>=0.2.5"]
+# optax carries the same `python_version >= '3.11'` marker every entry in
+# autonerves[jax] does. Without it, resolving this extra on 3.9/3.10 sends pip
+# backtracking through the whole optax/jax release history looking for a version
+# with wheels for that interpreter — which ends in `resolution-too-deep`, taking
+# every 3.9 leg of python_matrix red. optax is only useful where jax is
+# installed, and jax is gated to 3.11+, so gating optax to match loses nothing.
+jax = ["autonerves[jax]", "optax>=0.2.5; python_version >= '3.11'"]
 mcp = ["mcp"]
 optional = [
     "autofit[jax]",


### PR DESCRIPTION
**Hotfix for a regression I introduced in PyAutoGalaxy#530.**

## What broke

#530 pointed `autogalaxy[jax]` at `autofit[jax]` so `optax` follows the jax chain — correct for 3.11+, and it closed a real user-facing gap (`pip install autolens[jax]` previously did not get optax, so `af.MultiStartAdam` / `af.MultiStartProdigy` raised `ImportError`).

But `autofit[jax]` declared optax with **no Python marker**, while every entry in `autonerves[jax]` carries `python_version >= '3.11'`. So on 3.9/3.10 the extra suddenly asked pip to find an optax for an interpreter recent optax has no wheels for, and pip backtracked through the optax/jax release history until:

```
error: resolution-too-deep
× Dependency resolution exceeded maximum depth
```

That took **every 3.9 leg** of `python_matrix` red — PyAutoNerves, PyAutoArray, PyAutoGalaxy and PyAutoLens — legs that were green in the pre-merge run.

## Fix

Give optax the same marker the rest of the jax family already has:

```diff
-jax = ["autonerves[jax]", "optax>=0.2.5"]
+jax = ["autonerves[jax]", "optax>=0.2.5; python_version >= '3.11'"]
```

optax is only useful where jax is installed, and jax is already gated to 3.11+, so gating optax to match loses nothing on 3.9/3.10 and keeps #530's intended fix fully intact on 3.11+.

## API Changes

**None.** Packaging metadata only, and strictly narrowing: the `jax` extra resolves exactly as it did before #530 on 3.9/3.10, and exactly as #530 intended on 3.11+.

## Verification

Built wheel metadata from this branch:

```
Requires-Dist: autonerves[jax]; extra == "jax"
Requires-Dist: optax>=0.2.5; python_version >= "3.11" and extra == "jax"
```

Marker evaluation across the matrix:

```
py3.9  -> False      py3.11 -> True
py3.10 -> False      py3.12 -> True
                     py3.13 -> True
```

## Lesson

An unmarked dependency added to an extra whose every other member is version-gated does not just fail to install — it can make the whole resolution unsolvable on the excluded interpreters. Marker parity within an extra is load-bearing.
