### PR TITLE
fix: preserve_in_zip replaces a stale archive member (#1414)

### DIFF
--- a/autofit/non_linear/paths/abstract.py
+++ b/autofit/non_linear/paths/abstract.py
@@ -3,6 +3,7 @@ import os
 import re
 import shutil
 import zipfile
+import zlib
 from abc import ABC, abstractmethod
 from configparser import NoSectionError
 from pathlib import Path
@@ -34,6 +35,72 @@ def _test_mode_segment() -> Optional[str]:
     a later real run at the same paths ("Fit Already Completed").
     """
     return "test_mode" if is_test_mode() else None
+
+
+def _matches_archived(info: zipfile.ZipInfo, file_path) -> bool:
+    """
+    Returns whether the archived member described by ``info`` has the same
+    content as the file at ``file_path``.
+
+    Compared via the size and CRC already held in the zip's central directory,
+    so the archived bytes are never decompressed and the file on disk is read
+    once in chunks — a cache artifact can be a large ``.fits`` image.
+    """
+    if info.file_size != os.path.getsize(file_path):
+        return False
+
+    crc = 0
+    with open(file_path, "rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            crc = zlib.crc32(chunk, crc)
+
+    return crc == info.CRC
+
+
+def _replace_zip_member(zip_path, arcname: str, file_path):
+    """
+    Replace the member ``arcname`` of the zip at ``zip_path`` with the file at
+    ``file_path``.
+
+    ``zipfile`` cannot overwrite a member in place, so every other member is
+    streamed into a new archive alongside the replacement. The new archive is
+    written next to the original (same directory, so the final ``os.replace``
+    is atomic on one filesystem) and only swapped in once complete: an error
+    part-way leaves the original archive untouched.
+
+    Rebuilding the archive from the output directory instead (as the search
+    itself does at completion) is not an option here, because with
+    ``remove_files`` the directory holds only the file just written.
+    """
+    zip_path = Path(zip_path)
+    temporary_path = zip_path.with_name(f"{zip_path.name}.replace.tmp")
+
+    try:
+        with zipfile.ZipFile(zip_path, "r") as source:
+            replaced = source.getinfo(arcname)
+
+            with zipfile.ZipFile(temporary_path, "w") as destination:
+                for info in source.infolist():
+                    if info.filename == arcname:
+                        continue
+
+                    with source.open(info) as member:
+                        with destination.open(info, "w") as target:
+                            shutil.copyfileobj(member, target)
+
+                destination.write(
+                    file_path,
+                    arcname,
+                    compress_type=replaced.compress_type,
+                )
+
+        os.replace(temporary_path, zip_path)
+    except BaseException:
+        try:
+            os.remove(temporary_path)
+        except FileNotFoundError:
+            pass
+        raise
 
 
 class AbstractPaths(ABC):
@@ -325,7 +392,10 @@ class AbstractPaths(ABC):
 
         No-op when the zip does not exist (e.g. the search is still running,
         so the file will be zipped with everything else at completion) and
-        when the member is already present.
+        when the archived member is already byte-identical to the file on
+        disk. When the member exists but its content has changed — a cache
+        that was invalidated and recomputed — it is replaced, otherwise the
+        stale copy would come back at the next ``restore()``.
 
         Parameters
         ----------
@@ -339,8 +409,20 @@ class AbstractPaths(ABC):
         arcname = str(Path(file_path).relative_to(self.output_path))
 
         with zipfile.ZipFile(self._zip_path, "a") as f:
-            if arcname not in f.namelist():
+            try:
+                info = f.getinfo(arcname)
+            except KeyError:
                 f.write(file_path, arcname)
+                return
+
+            if _matches_archived(info, file_path):
+                return
+
+        _replace_zip_member(
+            zip_path=self._zip_path,
+            arcname=arcname,
+            file_path=file_path,
+        )
 
     def restore(self):
         """

--- a/test_autofit/non_linear/paths/test_paths.py
+++ b/test_autofit/non_linear/paths/test_paths.py
@@ -149,6 +149,59 @@ def test__preserve_in_zip__file_survives_restore(tmp_path):
     assert cache_file.exists()
 
 
+def test__preserve_in_zip__replaces_stale_member(tmp_path):
+    import zipfile
+
+    paths = af.DirectoryPaths(name="preserve_replace_test", path_prefix=str(tmp_path))
+
+    files_path = Path(paths._files_path)
+    files_path.mkdir(parents=True, exist_ok=True)
+    (files_path / "samples_summary.json").write_text("{}")
+
+    cache_file = files_path / "cache_artifact.json"
+    cache_file.write_text('{"cached": "stale"}')
+
+    paths.zip_remove()
+    assert Path(paths._zip_path).exists()
+
+    # The cache was invalidated and recomputed: the member is already in the
+    # zip, but its content has changed.
+    files_path.mkdir(parents=True, exist_ok=True)
+    cache_file.write_text('{"cached": "recomputed"}')
+    paths.preserve_in_zip(cache_file)
+
+    with zipfile.ZipFile(paths._zip_path) as f:
+        assert f.namelist().count("files/cache_artifact.json") == 1
+        assert f.read("files/cache_artifact.json") == b'{"cached": "recomputed"}'
+        # The rewrite must not lose the members it copied across.
+        assert f.read("files/samples_summary.json") == b"{}"
+
+    # The restore cycle yields the recomputed bytes, not the stale ones.
+    paths.restore()
+    assert cache_file.read_text() == '{"cached": "recomputed"}'
+
+
+def test__preserve_in_zip__identical_content_does_not_rewrite(tmp_path):
+    paths = af.DirectoryPaths(name="preserve_identical_test", path_prefix=str(tmp_path))
+
+    files_path = Path(paths._files_path)
+    files_path.mkdir(parents=True, exist_ok=True)
+    cache_file = files_path / "cache_artifact.json"
+    cache_file.write_text('{"cached": true}')
+
+    paths.zip_remove()
+    before = Path(paths._zip_path).read_bytes()
+
+    # Re-preserving a file whose content is unchanged leaves the archive
+    # untouched, so the common resume path never pays for a rewrite.
+    files_path.mkdir(parents=True, exist_ok=True)
+    cache_file.write_text('{"cached": true}')
+
+    paths.preserve_in_zip(cache_file)
+
+    assert Path(paths._zip_path).read_bytes() == before
+
+
 def test__preserve_in_zip__no_zip_is_a_no_op(tmp_path):
     paths = af.DirectoryPaths(name="preserve_noop_test", path_prefix=str(tmp_path))
 


### PR DESCRIPTION
## Summary

Closes #1414.

`AbstractPaths.preserve_in_zip` added a file to a completed search's `.zip` only when that member was **absent**, so a post-completion artifact rewritten on disk left the stale bytes in the archive. Because `restore()` deletes the output directory and re-extracts the zip, the stale copy came back on the next resume — the case PyAutoGalaxy#516 creates, where a changed dataset mask invalidates `files/galaxy_images_snr.fits` and the images are recomputed. Correctness was never at risk (the stale cache is rejected on load), but such a search missed its cache on *every* run instead of once, repaying the max-log-likelihood-fit rebuild each time.

An existing member is now compared against the file on disk and replaced when it differs:

- **Comparison** uses the `file_size` and `CRC` already in the zip's central directory, with a chunk-streamed `zlib.crc32` over the file — the archived bytes are never decompressed and a large `.fits` cache is never read fully into memory.
- **Replacement** streams every other member into a temporary archive beside the original (same directory, so the final `os.replace` is atomic) and swaps it in only once complete; a failure part-way leaves the original archive untouched. The replaced member's `compress_type` is carried over.
- **Byte-identical content stays a no-op**, so the common resume path — re-preserving an unchanged cache — never pays for a rewrite. The no-zip and member-absent paths are unchanged.

Rebuilding the whole archive from the output directory (what the search itself does at completion via `zip_directory`) is not usable here: with `remove_files: true` the completed search's directory is deleted after zipping, so a later post-completion write recreates only `files/<cache>` and a full re-zip would truncate the archive to that one file.

The issue's other-callers check: `autolens/analysis/result.py` writes its multiple-image-positions cache only when the loose file is absent, so it never depended on replacement — no change needed. The related config knobs `force_pickle_overwrite` / `force_visualize_overwrite` do not overlap: they act on the search whose `fit()` is re-invoked, which always brackets the run with `paths.restore()` (which deletes the zip) and `post_fit_output` → `zip_remove()` (which rebuilds it wholesale). `preserve_in_zip` exists for the opposite seam — a write into an upstream completed search that is not fitted this run, whose zip is never rebuilt.

## API Changes

None — no signature changes. `AbstractPaths.preserve_in_zip` gains behaviour: it now replaces an archived member whose content differs from the file on disk, where it previously left the archive untouched. Callers that write a changed artifact into a completed search's `files/` folder get the refreshed copy after `restore()`.
See full details below.

## Test Plan

- [x] `pytest test_autofit/non_linear/paths/test_paths.py` — 18 passed
- [x] `pytest test_autofit` — 1559 passed, 1 skipped
- [x] New `test__preserve_in_zip__replaces_stale_member` fails on the pre-fix source (regression pinned), passes after
- [x] PyAutoGalaxy suite unaffected — 1009 passed (docstring follow-up on the same branch)

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- `autofit.non_linear.paths.abstract.AbstractPaths.preserve_in_zip(file_path)` — an existing archive member whose content differs from `file_path` is now replaced (archive rewritten atomically) instead of being silently skipped. Unchanged: no-op when the zip does not exist, plain append when the member is absent, and no-op when the member is byte-identical.

### Added (private)
- `autofit.non_linear.paths.abstract._matches_archived(info, file_path)` — size + CRC comparison against the central directory.
- `autofit.non_linear.paths.abstract._replace_zip_member(zip_path, arcname, file_path)` — atomic member replacement via a temporary archive.

### Migration
- None — no caller changes required.

</details>

Generated by the PyAutoLabs agent workflow.