### PR TITLE
feat: require Python 3.12

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ NUMBA_CACHE_DIR=/tmp/numba_cache MPLCONFIGDIR=/tmp/matplotlib python -m pytest t
 
 PRs must pass `pytest --cov` on the CI matrix (Python 3.12 **and** 3.13). There
 is no black/ruff/flake8 gate — formatting is advisory. (`requires-python` in
-`pyproject.toml` is `>=3.9`.)
+`pyproject.toml` is `>=3.12`.)
 
 ## Configuration & defaults
 

--- a/autofit/graphical/factor_graphs/abstract.py
+++ b/autofit/graphical/factor_graphs/abstract.py
@@ -8,6 +8,7 @@ from typing import (
     Optional,
     Collection,
     Any,
+    Protocol,
     TYPE_CHECKING, 
 )
 
@@ -35,8 +36,6 @@ from autofit.mapper.variable import (
 if TYPE_CHECKING:
     from autofit.graphical.mean_field import MeanField
     from autofit.graphical.expectation_propagation import EPMeanField
-
-Protocol = ABC  # for python 3.7 compat
 
 Value = Dict[Variable, np.ndarray]
 

--- a/autofit/graphical/factor_graphs/jacobians.py
+++ b/autofit/graphical/factor_graphs/jacobians.py
@@ -16,15 +16,13 @@ from autofit.mapper.variable import (
 from autofit.mapper.variable_operator import (
     RectVariableOperator,
 )
-from abc import ABC
 from typing import (
     Tuple,
     Dict,
     Union,
     Callable,
+    Protocol,
 )
-
-Protocol = ABC  # for python 3.7 compat
 
 Value = Dict[Variable, np.ndarray]
 GradientValue = VariableData

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Classy Probabilistic Programming"
 readme = { file = "README.md", content-type = "text/markdown" }
 license = { text = "MIT" }
-requires-python = ">=3.9"
+requires-python = ">=3.12"
 authors = [
     { name = "James Nightingale", email = "James.Nightingale@newcastle.ac.uk" },
     { name = "Richard Hayes", email = "richard@rghsoftware.co.uk" },
@@ -18,9 +18,6 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Physics",
   "Natural Language :: English",
   "Operating System :: OS Independent",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13"
 ]
@@ -66,13 +63,7 @@ local_scheme = "no-local-version"
 
 
 [project.optional-dependencies]
-# optax carries the same `python_version >= '3.11'` marker every entry in
-# autonerves[jax] does. Without it, resolving this extra on 3.9/3.10 sends pip
-# backtracking through the whole optax/jax release history looking for a version
-# with wheels for that interpreter — which ends in `resolution-too-deep`, taking
-# every 3.9 leg of python_matrix red. optax is only useful where jax is
-# installed, and jax is gated to 3.11+, so gating optax to match loses nothing.
-jax = ["autonerves[jax]", "optax>=0.2.5; python_version >= '3.11'"]
+jax = ["autonerves[jax]", "optax>=0.2.5"]
 mcp = ["mcp"]
 optional = [
     "autofit[jax]",


### PR DESCRIPTION
## Summary
Raise PyAutoFit's minimum supported Python version to 3.12 and advertise only Python 3.12 and 3.13.

Remove the now-tautological Optax interpreter marker while preserving its existing lower bound, and replace two Python-3.7-era ABC aliases with direct typing.Protocol definitions.

Refs #1428.

## API Changes
Public PyAutoFit symbols and signatures are unchanged. Installation now requires Python 3.12 or newer; internal graphical interface annotations are real typing.Protocol classes rather than ABC aliases.
See full details below.

## Test Plan
- [x] Graphical subsystem on Python 3.12: 219 passed
- [x] Full Python 3.12 suite: 1559 passed, 1 skipped
- [x] Full Python 3.13 suite: 1559 passed, 1 skipped
- [x] Wheel metadata: Requires-Python >=3.12; classifiers 3.12/3.13 only; optax>=0.2.5 preserved without a Python marker
- [x] Curated ecosystem smoke: 57 passed, 5 parallel failures, 3 intentional skips; sequential retry passed 4/5, with only the exact previously accepted 300-second imaging/subhalo_recovery.py timeout remaining
- [x] Independent Claude Opus 5 review: CLEAN
- [x] Heart: YELLOW score 65, exact previously acknowledged campaign reason set, no RED

## Validation checklist (--auto run — plan was not pre-approved)
- Effective level: safe (header: supervised, cap: feature medium → safe)
- Plan: on issue #1428, written at start, unmodified since
- Gate: tests 3.12 1559 passed/1 skipped + 3.13 1559 passed/1 skipped · smoke accepted identical non-causal timeout after 4/5 sequential retries passed · review CLEAN · Heart YELLOW within launch acknowledgement
- [ ] Human: plan sound in hindsight?
- [ ] Human: diff matches plan (no scope creep)?
- [x] Human: campaign merges authorized contingent on exact reviewed head and green CI

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- Package installation now requires Python 3.12 or newer.
- autofit.graphical.factor_graphs abstract and jacobian interface classes are genuine typing.Protocol objects. They are annotation-only, not publicly re-exported, and have no runtime consumer in PyAutoFit or downstream repositories.
- The jax extra installs optax>=0.2.5 without an interpreter marker; this is equivalent on every supported interpreter.

### Migration
- Recreate environments on Python 3.12 or newer before installing the next PyAutoFit release.
- External code importing the internal FactorInterface classes should use them as static protocols, not instantiate them or apply isinstance checks.

</details>

Generated by the PyAutoLabs agent workflow.
