### PR TITLE
feat: per-step progress logging for the multi-start gradient searches

### DIFF
--- a/autofit/non_linear/search/mle/multi_start_gradient/search.py
+++ b/autofit/non_linear/search/mle/multi_start_gradient/search.py
@@ -42,6 +42,7 @@ class AbstractMultiStartGradient(AbstractMLE):
         start_upper_limit: float = 0.85,
         resurrect: bool = False,
         convergence: Optional[MultiStartGradientConvergence] = None,
+        iterations_per_log: int = 10,
         initializer: Optional[AbstractInitializer] = None,
         iterations_per_full_update: int = None,
         iterations_per_quick_update: int = None,
@@ -134,6 +135,29 @@ class AbstractMultiStartGradient(AbstractMLE):
             when ``resurrect=True`` (the pixelized regime, whose best-fom climbs in
             breakthrough jumps that a plateau check would false-stop on); there the
             search leans on the ``n_steps`` ceiling.
+        iterations_per_log
+            How many steps pass between progress lines on the search log. The
+            step loop is otherwise entirely silent between "Starting new ..." and
+            "... sampling complete", which on a long fit leaves a user unable to
+            tell a live search from a hung one.
+
+            Neither of the framework's usual progress channels reaches this
+            search, which is why it needs its own: ``iterations_per_full_update``
+            defaults to the never-sentinel, so the whole run is a single chunk
+            whose lone ``perform_update`` is (correctly) suppressed as duplicated
+            work; and ``Fitness``'s quick-update counter is Python state mutated
+            inside ``fitness.call``, which is traced under ``jax.jit(jax.vmap(…))``
+            here — it runs once at trace time and never again. The samplers dodge
+            the problem entirely by delegating to their own library's progress bar
+            (emcee ``progress=True``, dynesty ``print_progress``); a search that
+            owns its step loop has to report for itself.
+
+            The first step always logs regardless of this cadence, because that
+            line is what tells the user the XLA compile finished and stepping has
+            begun — the longest unexplained wait in a real run. A log line rather
+            than a progress bar: ``n_steps`` is a ceiling that auto-convergence
+            routinely stops short of, so a bar's ETA would mislead, and lines
+            survive SLURM/HPC log capture where bars do not.
         """
 
         super().__init__(
@@ -161,6 +185,15 @@ class AbstractMultiStartGradient(AbstractMLE):
         self.convergence = (
             convergence if convergence is not None else MultiStartGradientConvergence()
         )
+
+        # Rejected here rather than clamped, and at construction rather than at
+        # the first step: a sub-1 cadence makes ``total_steps % cadence`` either
+        # raise (0) or log every step (negative, since the modulo is never 0),
+        # and a user who mistyped the knob is better served by an immediate error
+        # than by a schedule they never asked for. Mirrors the reasoning on
+        # ``AbstractSearch._check_step_count``, which it reuses.
+        self._check_step_count(iterations_per_log, "iterations_per_log")
+        self.iterations_per_log = int(iterations_per_log)
 
         self.logger.debug(f"Creating {self.optax_method} MultiStartGradient Search")
 
@@ -197,6 +230,128 @@ class AbstractMultiStartGradient(AbstractMLE):
         boundary, so it starts clear.
         """
         return stop_reason if stop_reason == "converged" else None
+
+    def _should_log_progress(self, total_steps: int, converged: bool) -> bool:
+        """
+        Whether the step just completed should emit a progress line.
+
+        Three ways to qualify: the first step (the compile is over and the search
+        is genuinely moving — the single most useful line in the run), every
+        ``iterations_per_log``-th step thereafter, and the step that converged
+        (which lands off-cadence far more often than not, and is the one step a
+        user most wants to see).
+
+        ``silence`` suppresses all of them, matching how the samplers gate their
+        own progress output (e.g. Dynesty's ``print_progress=not self.silence``).
+
+        A named predicate rather than an inline condition so the cadence rule can
+        be tested directly; ``_fit`` needs jax + optax + a JAX-traceable
+        ``Analysis`` and cannot be driven from the NumPy-only library suite.
+        """
+        if self.silence:
+            return False
+
+        return (
+            bool(converged)
+            or total_steps <= 1
+            or total_steps % self.iterations_per_log == 0
+        )
+
+    def _compile_message(self, batched: bool) -> str:
+        """
+        The notice logged immediately before a step that will trigger an XLA
+        compile, so the ensuing wait is explained rather than silent.
+
+        Two distinct compiles block a fresh run, hence the ``batched`` switch:
+        the single-point ``value_and_grad`` that ``_broad_starts`` calls per draw,
+        and the vmapped (or ``batch_size``-chunked) one the step loop calls. Both
+        can run to minutes on a multi-band objective, and neither is reachable by
+        the ``Fitness._jit`` / ``_vmap`` / ``_grad`` compile notices — this search
+        builds its transforms straight off ``fitness.call``.
+
+        Phrased to match the sampler-wide compile message rather than inventing a
+        second dialect for the same event.
+        """
+        if not batched:
+            return (
+                "JAX: jit compiling the single-point objective used to draw "
+                f"{self.n_starts} broad starts, could take seconds or minutes..."
+            )
+
+        over = (
+            f"batches of {self.batch_size} starts"
+            if self.batch_size is not None
+            else f"all {self.n_starts} starts at once"
+        )
+
+        return (
+            f"JAX: jit compiling the vmapped objective over {over}, "
+            "could take seconds or minutes..."
+        )
+
+    def _progress_message(
+        self,
+        total_steps: int,
+        best_fom: float,
+        previous_fom: Optional[float],
+        n_alive: int,
+        estim_lr=None,
+    ) -> str:
+        """
+        The one-line progress report for a single step.
+
+        Compact and pipe-delimited rather than prose: unlike the one-shot notices
+        this line repeats tens of times per run, and sentences would bury the
+        numbers that carry the signal.
+
+        Reports the log posterior, not the raw figure of merit. ``best_fom`` is
+        ``-2 * log_posterior`` (what the search minimises), so the sign-and-halve
+        conversion here is the same one ``samples_via_internal_from`` applies —
+        a user comparing the log to their results should not have to do it in
+        their head.
+
+        Parameters
+        ----------
+        total_steps
+            Steps completed, reported against the ``n_steps`` ceiling.
+        best_fom
+            The global best figure-of-merit. Non-finite until some start finds a
+            finite basin, which is reported plainly rather than as ``inf``.
+        previous_fom
+            The global best at the previous progress line, used for the gain
+            since. ``None`` on the first line, and skipped while either end of
+            the comparison is non-finite (a first finite basin is an arrival, not
+            an improvement, and ``inf - x`` would print as ``inf``).
+        n_alive
+            Starts whose objective is currently finite, against ``n_starts`` —
+            the population-health signal that a falling best-fom alone hides.
+        estim_lr
+            Per-start self-estimated step scale, for the learning-rate-free rules
+            that carry one (Prodigy's ``d``). ``None`` for the fixed-rate Adam
+            family, whose optimizer state has no such field; the field is then
+            omitted rather than rendered empty.
+        """
+        parts = [f"{self.optax_method} step {total_steps}/{self.n_steps}"]
+
+        if np.isfinite(best_fom):
+            parts.append(f"best log_post {-0.5 * best_fom:.4f}")
+
+            if previous_fom is not None and np.isfinite(previous_fom):
+                # fom is -2*log_posterior, so a fom drop of d is a log-posterior
+                # gain of d/2.
+                parts.append(f"gained {0.5 * (previous_fom - best_fom):.4f}")
+        else:
+            parts.append("best log_post — (no finite basin yet)")
+
+        parts.append(f"alive {n_alive}/{self.n_starts}")
+
+        if estim_lr is not None:
+            lr = np.asarray(estim_lr, dtype=float)
+            parts.append(
+                f"d {np.nanmin(lr):.2e} / {np.nanmedian(lr):.2e} / {np.nanmax(lr):.2e}"
+            )
+
+        return " | ".join(parts)
 
     def _fit(
         self,
@@ -309,6 +464,9 @@ class AbstractMultiStartGradient(AbstractMLE):
 
         except (FileNotFoundError, TypeError, KeyError):
 
+            if not self.silence:
+                self.logger.info(self._compile_message(batched=False))
+
             params = self._broad_starts(
                 model=model,
                 value_and_grad_single=jax.jit(_value_and_grad),
@@ -337,6 +495,18 @@ class AbstractMultiStartGradient(AbstractMLE):
 
         stop_reason = self._stop_reason_on_resume(stop_reason)
 
+        # The vmapped objective compiles on its first call below, not here, so
+        # the notice is emitted at the call site the first time round. Resumed
+        # runs pay it too (a fresh process has no live trace cache), which is why
+        # the flag is set here rather than only on the fresh path.
+        awaiting_compile = True
+
+        # The global best at the previous progress line, so each line can report
+        # the gain since the last one rather than since the previous *step* —
+        # over a cadence of ``iterations_per_log`` steps that is the number a
+        # user can actually act on.
+        previous_logged_fom = None
+
         # ``n_steps`` is the hard ceiling / max budget; ``stop_reason`` becomes
         # ``"converged"`` if the auto-convergence check stops the search early
         # (this also short-circuits the loop on a resumed, already-converged run).
@@ -356,6 +526,11 @@ class AbstractMultiStartGradient(AbstractMLE):
             converged = False
 
             for _ in range(iterations):
+                if awaiting_compile:
+                    if not self.silence:
+                        self.logger.info(self._compile_message(batched=True))
+                    awaiting_compile = False
+
                 foms, grads = batched_value_and_grad(params)
 
                 alive = np.isfinite(np.asarray(foms))
@@ -397,6 +572,33 @@ class AbstractMultiStartGradient(AbstractMLE):
                     fom_history
                 ):
                     converged = True
+
+                # Logged before the ``converged`` break so the terminating step
+                # reports itself; it is the one step a user most wants to see and
+                # it lands off-cadence more often than not.
+                if self._should_log_progress(
+                    total_steps=total_steps, converged=converged
+                ):
+                    # Prodigy et al. carry a self-estimated step scale; the Adam
+                    # family's state has no such field and ``tree_get`` returns
+                    # None, which the message renders by omission. Read only on a
+                    # logging step: it is an (n_starts,) device->host copy, which
+                    # merely pulls forward the sync the next iteration's
+                    # ``np.asarray(foms)`` would force anyway.
+                    estim_lr = optax.tree_utils.tree_get(opt_state, "estim_lr")
+
+                    self.logger.info(
+                        self._progress_message(
+                            total_steps=total_steps,
+                            best_fom=best_fom,
+                            previous_fom=previous_logged_fom,
+                            n_alive=int(alive.sum()),
+                            estim_lr=estim_lr,
+                        )
+                    )
+                    previous_logged_fom = best_fom
+
+                if converged:
                     break
 
             if converged:

--- a/test_autofit/non_linear/search/mle/test_multi_start_gradient.py
+++ b/test_autofit/non_linear/search/mle/test_multi_start_gradient.py
@@ -469,6 +469,177 @@ def test__stop_reason_on_resume(restored, expected):
     assert af.MultiStartAdam._stop_reason_on_resume(restored) == expected
 
 
+@pytest.mark.parametrize(
+    "total_steps, converged, silence, should_log",
+    [
+        (1, False, False, True),  # first step: the compile is over, we are moving
+        (2, False, False, False),  # off-cadence
+        (10, False, False, True),  # on-cadence
+        (20, False, False, True),
+        (23, False, False, False),
+        (23, True, False, True),  # converged off-cadence still reports
+        (10, False, True, False),  # silence suppresses a cadence hit
+        (1, False, True, False),  # ...and the first step
+        (23, True, True, False),  # ...and convergence
+    ],
+)
+def test__should_log_progress(total_steps, converged, silence, should_log):
+    """The cadence rule. The first step always logs because that line is what
+    tells a user the XLA compile finished and stepping has begun — the longest
+    unexplained wait in a real run. The converged step always logs because it
+    lands off-cadence more often than not."""
+    search = af.MultiStartAdam(n_steps=300, iterations_per_log=10, silence=silence)
+
+    assert (
+        search._should_log_progress(total_steps=total_steps, converged=converged)
+        is should_log
+    )
+
+
+@pytest.mark.parametrize("bad", [0, -1, 2.5])
+def test__iterations_per_log__rejects_a_cadence_that_cannot_schedule(bad):
+    """Rejected at construction, not clamped: ``total_steps % 0`` raises and a
+    negative cadence is never 0, so it would log every step. A user who mistyped
+    the knob is better served by an error than by a schedule they never asked
+    for."""
+    with pytest.raises(ValueError, match="iterations_per_log"):
+        af.MultiStartAdam(iterations_per_log=bad)
+
+
+def test__progress_message__reports_log_posterior_not_the_raw_fom():
+    """``best_fom`` is ``-2 * log_posterior`` (what the search minimises), so the
+    line must apply the same sign-and-halve conversion as
+    ``samples_via_internal_from`` — otherwise the number in the log cannot be
+    compared with the number in the results."""
+    search = af.MultiStartAdam(n_starts=48, n_steps=300)
+
+    message = search._progress_message(
+        total_steps=30,
+        best_fom=-63575.6876,
+        previous_fom=-63571.4676,
+        n_alive=46,
+    )
+
+    assert "adam step 30/300" in message
+    assert "best log_post 31787.8438" in message
+    # a fom drop of 4.22 is a log-posterior gain of 2.11
+    assert "gained 2.1100" in message
+    assert "alive 46/48" in message
+    # no learning-rate-free state was supplied, so the field is omitted entirely
+    assert " d " not in message
+
+
+def test__progress_message__includes_the_prodigy_step_scale_when_present():
+    """Prodigy's per-start ``estim_lr`` (its ``d``) is the one genuinely
+    learning-rate-free diagnostic, and is otherwise invisible: min/median/max
+    across starts says whether it has finished ramping or is still climbing."""
+    search = af.MultiStartProdigy(n_starts=4, n_steps=300)
+
+    message = search._progress_message(
+        total_steps=10,
+        best_fom=-100.0,
+        previous_fom=-90.0,
+        n_alive=4,
+        estim_lr=np.array([1.0e-2, 2.0e-2, 4.0e-2, 8.0e-2]),
+    )
+
+    assert "prodigy step 10/300" in message
+    assert "d 1.00e-02 / 3.00e-02 / 8.00e-02" in message
+
+
+@pytest.mark.parametrize(
+    "best_fom, previous_fom, expect_gain",
+    [
+        (np.inf, None, False),  # nothing has found a finite basin yet
+        (-100.0, None, False),  # first line: no previous to compare against
+        (-100.0, np.inf, False),  # arrival at a first basin is not a "gain"
+        (-100.0, -90.0, True),
+    ],
+)
+def test__progress_message__non_finite_and_first_line_edges(
+    best_fom, previous_fom, expect_gain
+):
+    """``inf - x`` would print as ``inf`` and a bare ``inf`` best-fom would print
+    as a figure of merit the user cannot act on, so both are reported plainly
+    instead."""
+    search = af.MultiStartAdam(n_starts=8, n_steps=300)
+
+    message = search._progress_message(
+        total_steps=10,
+        best_fom=best_fom,
+        previous_fom=previous_fom,
+        n_alive=8,
+    )
+
+    assert ("gained" in message) is expect_gain
+    assert "inf" not in message
+
+    if not np.isfinite(best_fom):
+        assert "no finite basin yet" in message
+
+
+@pytest.mark.parametrize(
+    "batch_size, expected",
+    [
+        (None, "all 16 starts at once"),
+        (4, "batches of 4 starts"),
+    ],
+)
+def test__compile_message__names_what_is_being_compiled(batch_size, expected):
+    """Two distinct compiles block a fresh run — the single-point objective
+    ``_broad_starts`` calls per draw, and the vmapped/chunked one the step loop
+    calls. Neither is reachable by the ``Fitness._jit`` / ``_vmap`` / ``_grad``
+    notices, because this search builds its transforms straight off
+    ``fitness.call``."""
+    search = af.MultiStartProdigy(n_starts=16, batch_size=batch_size)
+
+    single = search._compile_message(batched=False)
+    assert "single-point objective" in single
+    assert "16 broad starts" in single
+    assert "could take seconds or minutes" in single
+
+    batched = search._compile_message(batched=True)
+    assert "vmapped objective" in batched
+    assert expected in batched
+    assert "could take seconds or minutes" in batched
+
+
+def test__dict_round_trip__iterations_per_log():
+    """The cadence must survive serialisation so a resumed search keeps
+    reporting at the rate the user chose."""
+    restored = from_dict(to_dict(af.MultiStartProdigy(iterations_per_log=25)))
+
+    assert isinstance(restored, af.MultiStartProdigy)
+    assert restored.iterations_per_log == 25
+
+
+def test__fit_wires_the_progress_and_compile_seams():
+    """Wiring guard for the three progress seams, which are otherwise tested in
+    isolation and would keep passing if ``_fit`` stopped calling them.
+
+    Necessarily a source-level check — ``_fit`` cannot run from this suite.
+    """
+    source = " ".join(inspect.getsource(af.MultiStartAdam._fit).split())
+
+    # the cadence gate and the line it guards
+    assert (
+        "if self._should_log_progress( total_steps=total_steps, converged=converged )"
+        in source
+    )
+    assert "self._progress_message(" in source
+
+    # both compile notices, each emitted before the call that triggers its compile
+    assert "self._compile_message(batched=False)" in source
+    assert "self._compile_message(batched=True)" in source
+
+    # the step scale is read from the optimizer state, not recomputed
+    assert 'optax.tree_utils.tree_get(opt_state, "estim_lr")' in source
+
+    # the converged step must still be able to report before the loop breaks:
+    # setting `converged` and breaking must not be fused back together.
+    assert "converged = True break" not in source
+
+
 def test__fit_uses_both_seams_and_keeps_the_converged_loop_guard():
     """Wiring guard for the two seams above, which are otherwise tested in
     isolation and would keep passing if ``_fit`` stopped calling them.


### PR DESCRIPTION
## Summary

Closes #1433.

`af.MultiStartProdigy` / `MultiStartAdam` / `MultiStartADABelief` / `MultiStartLion` emitted exactly two log lines for an entire run — `"Starting new <rule> MultiStartGradient search (N starts, ...)"` and, however many hours later, `"<rule> MultiStartGradient sampling complete."` Nothing in between, so a user could not tell a live 300-step fit from a hung one.

Neither of the framework's usual progress channels reaches this search, which is why it needs its own:

- `iterations_per_full_update` defaults to the never-sentinel, so the whole run is a single chunk whose lone `perform_update` is (correctly) suppressed by `_is_final_boundary` as duplicated work.
- `Fitness`'s quick-update counter is Python state mutated inside `fitness.call`, which this search traces under `jax.jit(jax.vmap(…))` — it runs once at trace time and never again.

The samplers dodge the problem by delegating to their own library's progress bar (emcee `progress=True`, dynesty `print_progress`); a search that owns its step loop has to report for itself.

This adds a cadence-controlled progress line plus two JAX-compile notices, all gated on the existing `silence` flag.

**Why a log line and not a progress bar:** `tqdm` is only a transitive dependency, auto-convergence makes `n_steps` a ceiling the search routinely stops short of (so a bar's ETA would mislead), and lines survive SLURM/HPC log capture where bars do not.

**Why the compile notices live here:** the compile-message work in #1434 targets `Fitness._jit` / `_vmap` / `_grad`, which these searches never use — they build their transforms straight off `fitness.call` (`search.py:260-261`). Without this, that fix would ship and these searches would still sit through their compile in silence. Two distinct compiles block a fresh run and both are covered: the single-point objective `_broad_starts` calls per draw, and the vmapped/chunked one the step loop calls. Wording is matched to #1434 rather than inventing a second dialect.

## API Changes

One additive, default-preserving constructor argument on `AbstractMultiStartGradient`, inherited by all four concrete searches: `iterations_per_log: int = 10`. No existing signature, default or behaviour changes, and no symbol is removed or renamed — a caller that ignores it sees identical results, only new log output.

See full details below.

## Test Plan

- [x] Full library suite: `python -m pytest test_autofit/` → **1614 passed, 1 skipped**
- [x] New NumPy-only unit tests (22) for the cadence rule, the message formatting, the sign convention, the non-finite edges, the compile notices, dict round-trip, and a source-level wiring guard
- [x] Real JAX `MultiStartProdigy` fit on the 1D Gaussian, confirming the lines fire in a live run (output below)
- [x] Diff is **pure additions** — 373 insertions, 0 deletions

Real run (`n_starts=16`, `n_steps=120`, `iterations_per_log=10`):

```
21:39:32,209 - INFO - JAX: jit compiling the single-point objective used to draw 16 broad starts, could take seconds or minutes...
21:39:34,390 - INFO - Starting new prodigy MultiStartGradient search (16 starts, no previous samples found).
21:39:34,390 - INFO - JAX: jit compiling the vmapped objective over all 16 starts at once, could take seconds or minutes...
21:39:36,614 - INFO - prodigy step 1/120 | best log_post -3335.7342 | alive 16/16 | d 1.00e-06 / 1.00e-06 / 1.00e-06
21:39:36,641 - INFO - prodigy step 10/120 | best log_post -3335.7291 | gained 0.0051 | alive 16/16 | d 1.73e-05 / 1.73e-05 / 1.73e-05
21:39:36,679 - INFO - prodigy step 20/120 | best log_post -3335.4641 | gained 0.2649 | alive 16/16 | d 8.99e-04 / 8.99e-04 / 8.99e-04
21:39:36,706 - INFO - prodigy step 30/120 | best log_post -3318.1027 | gained 17.3614 | alive 16/16 | d 5.91e-02 / 5.92e-02 / 5.93e-02
21:39:36,735 - INFO - prodigy step 40/120 | best log_post -1743.4656 | gained 1574.6372 | alive 15/16 | d 2.56e+00 / 4.86e+00 / 5.07e+00
21:39:36,760 - INFO - prodigy step 50/120 | best log_post -171.4357 | gained 1572.0299 | alive 14/16 | d 2.56e+00 / 7.70e+00 / 1.19e+01
...
21:39:36,911 - INFO - prodigy step 120/120 | best log_post -58.8587 | gained 0.0647 | alive 16/16 | d 2.56e+00 / 7.70e+00 / 1.19e+01
21:39:36,916 - INFO - prodigy MultiStartGradient sampling complete.
```

Note the two compiles account for ~4.4s while all 120 steps take 0.3s — on this toy problem the compile *is* the wait, which is exactly why it needed a notice. The `d` (Prodigy's `estim_lr`) column ramps `1e-06 → 1.19e+01` while the fit is still finding its basin, then plateaus: previously invisible, and the one genuinely learning-rate-free diagnostic.

## Notes for review

- The knob lands on `AbstractMultiStartGradient`, so all four subclasses get the line — the silence was a base-class problem, not a Prodigy-only one.
- **No new packaged config key.** A key added to the shared `updates:` block would imply every search honours it (they don't) and would `KeyError` in any workspace whose config shadows that section — the trap hit in #1409. A plain constructor kwarg avoids both.
- **No XLA recompile and no new sync.** The step loop already forces a device sync every step at `search.py:361` (`np.isfinite(np.asarray(foms))`), so the step/fom/alive fields are free. `estim_lr` is an `(n_starts,)` device→host copy taken only on a logging step, which merely pulls forward the sync the next iteration would force anyway. Nothing traced is added.
- Ships alongside #1434, which is concurrently claimed on PyAutoFit but touches disjoint files (`abstract_search.py` / `fitness.py`). Branched off the same `a50ba95b0`; `origin/main` had not moved at PR-open.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added

- `AbstractMultiStartGradient.__init__(..., iterations_per_log: int = 10)` — steps between progress lines on the search log. Inherited by `MultiStartAdam`, `MultiStartADABelief`, `MultiStartLion` and `MultiStartProdigy`. Serialised through `to_dict`/`from_dict`, so a resumed search keeps the chosen cadence. Rejected at construction (via `AbstractSearch._check_step_count`) if not a whole number ≥ 1, since a sub-1 cadence either raises on the modulo or logs every step.

### Changed Behaviour

- The four multi-start gradient searches now emit progress output during `_fit`, where previously they were silent between start and completion. Emitted at `logging.INFO` on the search's own logger and fully suppressed by the existing `silence=True`; numerical results are unchanged.

### Migration

None required — the argument is optional and defaults to the new behaviour. Pass `silence=True` for the previous, fully-silent output.

</details>

Generated by the PyAutoLabs agent workflow.
