### PR TITLE
feat: live display resolves fit.png only — fit_quick.png removed

### DIFF
--- a/autofit/non_linear/quick_update.py
+++ b/autofit/non_linear/quick_update.py
@@ -32,10 +32,9 @@ def _convert_jax_to_numpy(instance):
 
 
 # Filenames the worker looks for under `paths.image_path` when refreshing
-# a live quick-update display. The first existing file wins. Quick updates
-# write `fit_quick.png` (6-panel subplot); full updates write `fit.png`
-# (12-panel). The quick variant is preferred when both exist.
-_DISPLAY_CANDIDATES = ("fit_quick.png", "fit.png")
+# a live quick-update display. The first existing file wins. Quick and full
+# updates both write the normal `fit.png` fit subplot.
+_DISPLAY_CANDIDATES = ("fit.png",)
 
 
 def _is_ipython_kernel() -> bool:


### PR DESCRIPTION
## Summary

Companion to PyAutoLabs/PyAutoLens#680: the special lighter-weight `fit_quick.png` quick-update figures are removed — quick updates now write the normal `fit.png` fit subplot. The live-display filename candidate list in `autofit/non_linear/quick_update.py` (`_DISPLAY_CANDIDATES`) therefore reduces from `("fit_quick.png", "fit.png")` to `("fit.png",)`, with comments updated to match.

## API Changes

None — internal changes only (`_DISPLAY_CANDIDATES` is a module-private constant; no public signature or behaviour of the autofit API changes).

## Test Plan
- [x] `test_autofit/` full suite: 1637 passed, 2 skipped (existing quick-update display tests already assert against `fit.png`)

Shipped under human-authorized Heart-RED override; RED reason (verbatim, unrelated nightly): `release validation FAILED (stage integrate)`.

Generated by the PyAutoLabs agent workflow.