### PR TITLE
docs(search): state the opt-in rule for _test_mode_samples_info

### DIFF
--- a/autofit/non_linear/search/abstract_search.py
+++ b/autofit/non_linear/search/abstract_search.py
@@ -981,11 +981,34 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
         Sampler-specific keys to merge into ``samples_info`` when the
         sampler is bypassed via ``PYAUTO_TEST_MODE=2`` or ``=3``.
 
-        Override in subclasses to add the diagnostic keys that the real
-        run would populate (e.g. NUTS ESS, MCMC autocorrelations) so that
-        tutorial scripts and downstream code can access those keys
-        without ``KeyError``. Use NaN/0 placeholders — the bypass did not
-        actually sample.
+        **Opt-in, not a per-sampler obligation.** Most searches do not
+        override this, and that is correct — no library code reads these
+        diagnostic keys under bypass. The properties that read them
+        (``SamplesMCMC.total_steps``, ``SamplesNest.total_samples``, …)
+        live on ``Samples`` subclasses the bypass never constructs;
+        ``_fit_bypass_test_mode`` always builds a ``SamplesPDF``. The only
+        consumers are workspace scripts reading ``samples_info[...]``
+        directly, so override this only when such a script exists.
+
+        Which fix applies depends on what that script does with the keys:
+
+        - It **prints** them (a tutorial, whose point is the prose, so it
+          may legitimately run bypassed) → override here, returning NaN/0
+          placeholders. The bypass did not sample; honest empties.
+        - It **asserts** on them (a test) → the script must not run
+          bypassed at all. Give it an ``ENV: real_search`` declaration
+          instead. Do **not** add placeholders for an asserting reader:
+          the assert then silently passes on a stub value, which is worse
+          than the ``KeyError`` it replaced.
+
+        Both live cases follow that split. ``BlackJAXNUTS`` overrides this
+        because ``autofit_workspace/scripts/searches/mcmc.py`` prints
+        ``ess_min`` / ``n_divergent``, carries no ``__Env__`` declaration
+        and is in that workspace's ``smoke_tests.txt``, so it runs
+        bypassed on every PR (PyAutoFit #1260).
+        ``AbstractMultiStartGradient`` deliberately does not: its only
+        reader asserts on ``total_steps``, so that script declares
+        ``ENV: real_search jax`` instead (autofit_workspace_test #83).
         """
         return {}
 


### PR DESCRIPTION
## Summary

`NonLinearSearch._test_mode_samples_info()` told subclasses to override it "so
that tutorial scripts and downstream code can access those keys without
`KeyError`" — which reads as a per-sampler obligation. Nine search modules write
`samples_info` in their real path (nautilus, dynesty, emcee, zeus, bfgs, drawer,
blackjax nuts, multi_start_gradient, abstract) and **exactly one overrides the
hook**, so the other eight look like they are missing one.

They aren't. This PR documents the rule the existing decisions actually follow.

**Reachability.** No library path reads these diagnostic keys under bypass. The
properties that read them — `SamplesMCMC.total_steps` (`samples/mcmc.py:200`),
`SamplesNest.number_live_points` / `total_samples` / `log_evidence`
(`samples/nest.py:77-92`) — live on `Samples` subclasses the bypass never
constructs; `_fit_bypass_test_mode` always builds a `SamplesPDF`. The only
consumers are workspace scripts reading `samples_info[...]` directly.

**Consumer sweep** across all eleven workspace/tutorial repos finds exactly two:

| Site | Keys | Runs bypassed? |
|---|---|---|
| `autofit_workspace/scripts/searches/mcmc.py:335` | `ess_min`, `num_samples`, `mean_acceptance`, `n_divergent`, `n_logl_evals` | **yes** — no `__Env__`, and it is line 2 of that workspace's `smoke_tests.txt`, so it runs bypassed on every PR |
| `autofit_workspace_test/.../multi_start_gradient_auto_convergence.py:130` | `total_steps` | no — declares `ENV: real_search jax` |

The first is why the NUTS override exists (#1260). The second was fixed on the
workspace side (autofit_workspace_test#83 / PR#84, merged `f4c45c1`). Nautilus,
Dynesty, Emcee and Zeus have no bypassed consumer either — hence no override.
`autofit_workspace/scripts/searches/mle.py` uses `MultiStartAdam` but never
touches `samples_info`, so MultiStartGradient has no bypassed consumer at all.

**The rule, now in the docstring:** prints → placeholders; asserts → real search.
A tutorial that only *displays* diagnostics may legitimately run bypassed, so its
search needs the override with honest empties. A script that *asserts* on them
must not run bypassed at all — it declares `ENV: real_search`. Adding
placeholders for an asserting reader is worse than the `KeyError` it replaces,
because the assert then silently passes on a stub value.

## API Changes

None. Docstring-only — no signature, behaviour or output change.

## Rejected alternatives

- **Add an `AbstractMultiStartGradient` override** for surface consistency with
  NUTS: it serves no existing consumer, and a placeholder `total_steps` would let
  a future `assert total_steps < n_steps` silently pass on a stub `0` — the exact
  failure mode avoided in autofit_workspace_test#83.
- **A unit test pinning the bypass keys**: a test can pin `BlackJAXNUTS`'s keys
  but cannot express "and the others deliberately have none" without freezing the
  sampler roster.

## Test Plan

- [x] `pytest test_autofit/non_linear/search` — **172 passed, 1 skipped**
- [x] Docstring renders and is reachable at runtime
      (`NonLinearSearch._test_mode_samples_info.__doc__`)
- [x] Diff is one file, docstring only

Closes #1448

Generated by the PyAutoLabs agent workflow.
