### PR TITLE
Use xp.stack in messages so JAX can trace fixed arrays

### DIFF
--- a/autofit/messages/beta.py
+++ b/autofit/messages/beta.py
@@ -223,7 +223,7 @@ class BetaMessage(AbstractMessage):
         -------
         Natural parameters [alpha - 1, beta - 1].
         """
-        return xp.array([alpha - 1, beta - 1])
+        return xp.stack([alpha - 1, beta - 1])
 
     @staticmethod
     def invert_natural_parameters(
@@ -276,7 +276,7 @@ class BetaMessage(AbstractMessage):
         -------
         Canonical sufficient statistics [log(x), log(1 - x)].
         """
-        return xp.array([xp.log(x), xp.log1p(-x)])
+        return xp.stack([xp.log(x), xp.log1p(-x)])
 
     @cached_property
     def mean(self) -> Union[np.ndarray, float]:

--- a/autofit/messages/gamma.py
+++ b/autofit/messages/gamma.py
@@ -41,7 +41,7 @@ class GammaMessage(AbstractMessage):
 
     @staticmethod
     def calc_natural_parameters(alpha, beta, xp=np):
-        return xp.array([alpha - 1, -beta])
+        return xp.stack([alpha - 1, -beta])
 
     @staticmethod
     def invert_natural_parameters(natural_parameters):
@@ -50,7 +50,7 @@ class GammaMessage(AbstractMessage):
 
     @staticmethod
     def to_canonical_form(x, xp=np):
-        return xp.array([np.log(x), x])
+        return xp.stack([xp.log(x), x])
 
     @classmethod
     def invert_sufficient_statistics(cls, suff_stats):

--- a/autofit/messages/normal.py
+++ b/autofit/messages/normal.py
@@ -196,7 +196,7 @@ class NormalMessage(AbstractMessage):
             η₂ = -1 / (2σ²)
         """
         precision = 1 / sigma**2
-        return xp.array([mu * precision, -precision / 2])
+        return xp.stack([mu * precision, -precision / 2])
 
     @staticmethod
     def invert_natural_parameters(natural_parameters : np.ndarray) -> Tuple[float, float]:
@@ -235,7 +235,7 @@ class NormalMessage(AbstractMessage):
         -------
         The sufficient statistics [x, x²].
         """
-        return xp.array([x, x**2])
+        return xp.stack([x, x**2])
 
     @classmethod
     def invert_sufficient_statistics(cls, suff_stats: Tuple[float, float]) -> np.ndarray:
@@ -591,7 +591,7 @@ class NaturalNormal(NormalMessage):
         eta2
             The second natural parameter.
         """
-        return xp.array([eta1, eta2])
+        return xp.stack([eta1, eta2])
 
     def natural_parameters(self, xp=np) -> np.ndarray:
         """

--- a/autofit/messages/truncated_normal.py
+++ b/autofit/messages/truncated_normal.py
@@ -204,7 +204,7 @@ class TruncatedNormalMessage(AbstractMessage):
             η₂ = -1 / (2σ²)
         """
         precision = 1 / sigma**2
-        return xp.array([mu * precision, -precision / 2])
+        return xp.stack([mu * precision, -precision / 2])
 
     @staticmethod
     def invert_natural_parameters(natural_parameters : np.ndarray) -> Tuple[float, float]:
@@ -248,7 +248,7 @@ class TruncatedNormalMessage(AbstractMessage):
         -------
         The sufficient statistics [x, x²].
         """
-        return xp.array([x, x**2])
+        return xp.stack([x, x**2])
 
     @classmethod
     def invert_sufficient_statistics(cls, suff_stats: Tuple[float, float]) -> np.ndarray:
@@ -722,7 +722,7 @@ class TruncatedNaturalNormal(TruncatedNormalMessage):
         eta2
             The second natural parameter.
         """
-        return xp.array([eta1, eta2])
+        return xp.stack([eta1, eta2])
 
     def natural_parameters(self, xp=np) -> np.ndarray:
         """

--- a/test_autofit/messages/test_jax_trace.py
+++ b/test_autofit/messages/test_jax_trace.py
@@ -1,0 +1,82 @@
+import numpy as np
+import pytest
+
+from autofit.messages.beta import BetaMessage
+from autofit.messages.gamma import GammaMessage
+from autofit.messages.normal import NaturalNormal, NormalMessage
+from autofit.messages.truncated_normal import (
+    TruncatedNaturalNormal,
+    TruncatedNormalMessage,
+)
+
+jax = pytest.importorskip("jax")
+jnp = pytest.importorskip("jax.numpy")
+
+
+MESSAGE_ARRAY_CASES = [
+    pytest.param(
+        lambda value, xp: NormalMessage.calc_natural_parameters(
+            value, value + 1.0, xp=xp
+        ),
+        id="normal-natural-parameters",
+    ),
+    pytest.param(
+        lambda value, xp: NormalMessage.to_canonical_form(value, xp=xp),
+        id="normal-canonical-form",
+    ),
+    pytest.param(
+        lambda value, xp: NaturalNormal.calc_natural_parameters(value, -value, xp=xp),
+        id="natural-normal-natural-parameters",
+    ),
+    pytest.param(
+        lambda value, xp: TruncatedNormalMessage.calc_natural_parameters(
+            value, value + 1.0, xp=xp
+        ),
+        id="truncated-normal-natural-parameters",
+    ),
+    pytest.param(
+        lambda value, xp: TruncatedNormalMessage.to_canonical_form(value, xp=xp),
+        id="truncated-normal-canonical-form",
+    ),
+    pytest.param(
+        lambda value, xp: TruncatedNaturalNormal.calc_natural_parameters(
+            value, -value, xp=xp
+        ),
+        id="truncated-natural-normal-natural-parameters",
+    ),
+    pytest.param(
+        lambda value, xp: BetaMessage.calc_natural_parameters(
+            value + 1.0, value + 2.0, xp=xp
+        ),
+        id="beta-natural-parameters",
+    ),
+    pytest.param(
+        lambda value, xp: BetaMessage.to_canonical_form(value, xp=xp),
+        id="beta-canonical-form",
+    ),
+    pytest.param(
+        lambda value, xp: GammaMessage.calc_natural_parameters(
+            value + 1.0, value + 2.0, xp=xp
+        ),
+        id="gamma-natural-parameters",
+    ),
+    pytest.param(
+        lambda value, xp: GammaMessage.to_canonical_form(value, xp=xp),
+        id="gamma-canonical-form",
+    ),
+]
+
+
+@pytest.mark.parametrize("message_array", MESSAGE_ARRAY_CASES)
+@pytest.mark.parametrize(
+    "value",
+    [pytest.param(0.25, id="scalar"), pytest.param([0.25, 0.5], id="batched")],
+)
+def test_message_array_construction_is_jittable_and_matches_numpy(message_array, value):
+    numpy_value = np.asarray(value)
+    expected = message_array(numpy_value, np)
+
+    actual = jax.jit(lambda traced: message_array(traced, jnp))(jnp.asarray(value))
+
+    assert actual.shape == expected.shape
+    np.testing.assert_allclose(np.asarray(actual), expected)


### PR DESCRIPTION
## Summary

- replace ten fixed-shape `xp.array([...])` message constructors with `xp.stack([...])`
- dispatch `GammaMessage.to_canonical_form` through `xp.log` instead of NumPy
- add direct scalar and batched `jax.jit` coverage for every changed constructor, with NumPy shape/value parity

## Why

The Gamma canonical-form path currently sends a traced value through `np.log`, raising `TracerArrayConversionError`. Using the selected array namespace throughout keeps message sufficient-statistic construction traceable and makes the fixed-array construction consistent across NumPy and JAX.

The same regression test was run against untouched `main`: the scalar and batched Gamma canonical-form cases fail there and pass on this branch. The other array constructors already pass with current supported JAX, so their `xp.stack` conversion is cross-backend hardening with unchanged shapes and values.

## Verification

- `test_autofit/messages`: **32 passed**
- full `test_autofit`: **1689 passed, 4 skipped**
- baseline proof: **2 expected failures** on untouched `main`, both `GammaMessage.to_canonical_form`; **20 passed** on this branch

The private `z_projects/concr` integration reproducer was not available in this environment.

## Prior/message audit

The adjacent audit found four separate JIT backend leaks in Gamma/Beta `log_partition` and compound-prior `log`/`log10`. They are independently reproduced and tracked in #1459 rather than widening this PR.

Closes #1458