### PR TITLE
Make remaining message and prior xp paths JAX-traceable

### DIFF
--- a/autofit/mapper/prior/abstract.py
+++ b/autofit/mapper/prior/abstract.py
@@ -185,6 +185,7 @@ class Prior(Variable, ABC, ArithmeticMixin):
         self,
         arguments,
         ignore_assertions=False,
+        xp=np,
     ):
         """Look up this prior's value in an arguments dictionary.
 
@@ -194,8 +195,11 @@ class Prior(Variable, ABC, ArithmeticMixin):
             A dictionary mapping Prior objects to physical values.
         ignore_assertions
             Unused for priors (present for interface compatibility).
+        xp
+            Unused for direct prior lookup. Accepted so compound prior models can
+            propagate their selected NumPy/JAX backend recursively.
         """
-        _ = ignore_assertions
+        _ = ignore_assertions, xp
         return arguments[self]
 
     def project(self, samples, log_weight_list):

--- a/autofit/mapper/prior/arithmetic/compound.py
+++ b/autofit/mapper/prior/arithmetic/compound.py
@@ -149,6 +149,7 @@ class CompoundPrior(AbstractPriorModel, ArithmeticMixin, Compound, ABC):
         self,
         arguments: dict,
         ignore_assertions=False,
+        xp=np,
     ):
         """
         Instantiate the left object.
@@ -168,6 +169,7 @@ class CompoundPrior(AbstractPriorModel, ArithmeticMixin, Compound, ABC):
             return self._left.instance_for_arguments(
                 arguments,
                 ignore_assertions=ignore_assertions,
+                xp=xp,
             )
         except AttributeError:
             return self._left
@@ -176,6 +178,7 @@ class CompoundPrior(AbstractPriorModel, ArithmeticMixin, Compound, ABC):
         self,
         arguments: dict,
         ignore_assertions=False,
+        xp=np,
     ):
         """
         Instantiate the right object.
@@ -195,6 +198,7 @@ class CompoundPrior(AbstractPriorModel, ArithmeticMixin, Compound, ABC):
             return self._right.instance_for_arguments(
                 arguments,
                 ignore_assertions=ignore_assertions,
+                xp=xp,
             )
         except AttributeError:
             return self._right
@@ -217,9 +221,11 @@ class SumPrior(CompoundPrior):
         return self.left_for_arguments(
             arguments,
             ignore_assertions=ignore_assertions,
+            xp=xp,
         ) + self.right_for_arguments(
             arguments,
             ignore_assertions=ignore_assertions,
+            xp=xp,
         )
 
     def __str__(self):
@@ -243,9 +249,11 @@ class MultiplePrior(CompoundPrior):
         return self.left_for_arguments(
             arguments,
             ignore_assertions=ignore_assertions,
+            xp=xp,
         ) * self.right_for_arguments(
             arguments,
             ignore_assertions=ignore_assertions,
+            xp=xp,
         )
 
 
@@ -263,9 +271,11 @@ class DivisionPrior(CompoundPrior):
         return self.left_for_arguments(
             arguments,
             ignore_assertions=ignore_assertions,
+            xp=xp,
         ) / self.right_for_arguments(
             arguments,
             ignore_assertions=ignore_assertions,
+            xp=xp,
         )
 
 
@@ -283,9 +293,11 @@ class FloorDivPrior(CompoundPrior):
         return self.left_for_arguments(
             arguments,
             ignore_assertions=ignore_assertions,
+            xp=xp,
         ) // self.right_for_arguments(
             arguments,
             ignore_assertions=ignore_assertions,
+            xp=xp,
         )
 
 
@@ -303,9 +315,11 @@ class ModPrior(CompoundPrior):
         return self.left_for_arguments(
             arguments,
             ignore_assertions=ignore_assertions,
+            xp=xp,
         ) % self.right_for_arguments(
             arguments,
             ignore_assertions=ignore_assertions,
+            xp=xp,
         )
 
 
@@ -323,9 +337,11 @@ class PowerPrior(CompoundPrior):
         return self.left_for_arguments(
             arguments,
             ignore_assertions=ignore_assertions,
+            xp=xp,
         ) ** self.right_for_arguments(
             arguments,
             ignore_assertions=ignore_assertions,
+            xp=xp,
         )
 
 
@@ -407,6 +423,7 @@ class NegativePrior(ModifiedPrior):
         return -self.prior.instance_for_arguments(
             arguments,
             ignore_assertions=ignore_assertions,
+            xp=xp,
         )
 
 
@@ -425,6 +442,7 @@ class AbsolutePrior(ModifiedPrior):
             self.prior.instance_for_arguments(
                 arguments,
                 ignore_assertions=ignore_assertions,
+                xp=xp,
             )
         )
 
@@ -440,10 +458,11 @@ class Log(ModifiedPrior):
         ignore_assertions=False,
         xp=np,
     ):
-        return np.log(
+        return xp.log(
             self.prior.instance_for_arguments(
                 arguments,
                 ignore_assertions=ignore_assertions,
+                xp=xp,
             )
         )
 
@@ -459,9 +478,10 @@ class Log10(ModifiedPrior):
         ignore_assertions=False,
         xp=np,
     ):
-        return np.log10(
+        return xp.log10(
             self.prior.instance_for_arguments(
                 arguments,
                 ignore_assertions=ignore_assertions,
+                xp=xp,
             )
         )

--- a/autofit/messages/beta.py
+++ b/autofit/messages/beta.py
@@ -146,14 +146,21 @@ class BetaMessage(AbstractMessage):
         id_
             Identifier for the message. Default is None.
         """
-        self.alpha = alpha
-        self.beta = beta
+        if isinstance(alpha, (np.ndarray, float, int, list)):
+            xp = np
+        else:
+            import jax.numpy as jnp
+
+            xp = jnp
+
         super().__init__(
             alpha,
             beta,
             log_norm=log_norm,
-            id_=id_
+            id_=id_,
+            _xp=xp,
         )
+        self.alpha, self.beta = self.parameters
 
     def value_for(self, unit: float) -> float:
         """
@@ -184,7 +191,10 @@ class BetaMessage(AbstractMessage):
         -------
         The value of the log Beta function, i.e. betaln(alpha, beta).
         """
-        from scipy.special import betaln
+        if xp is np:
+            from scipy.special import betaln
+        else:
+            from jax.scipy.special import betaln
 
         return betaln(*self.parameters)
 

--- a/autofit/messages/gamma.py
+++ b/autofit/messages/gamma.py
@@ -8,10 +8,15 @@ from autofit.messages.utils import invpsilog
 class GammaMessage(AbstractMessage):
 
     def log_partition(self, xp=np):
-        from scipy import special
+        if xp is np:
+            from scipy.special import gammaln
+        else:
+            from jax.scipy.special import gammaln
 
-        alpha, beta = GammaMessage.invert_natural_parameters(self.natural_parameters(xp=xp))
-        return special.gammaln(alpha) - alpha * np.log(beta)
+        alpha, beta = GammaMessage.invert_natural_parameters(
+            self.natural_parameters(xp=xp)
+        )
+        return gammaln(alpha) - alpha * xp.log(beta)
 
     log_base_measure = 0.0
     _support = ((0, np.inf),)
@@ -24,14 +29,21 @@ class GammaMessage(AbstractMessage):
             log_norm=0.0,
             id_=None
     ):
-        self.alpha = alpha
-        self.beta = beta
+        if isinstance(alpha, (np.ndarray, float, int, list)):
+            xp = np
+        else:
+            import jax.numpy as jnp
+
+            xp = jnp
+
         super().__init__(
             alpha,
             beta,
             log_norm=log_norm,
-            id_=id_
+            id_=id_,
+            _xp=xp,
         )
+        self.alpha, self.beta = self.parameters
 
     def value_for(self, unit: float) -> float:
         raise NotImplemented()

--- a/test_autofit/mapper/prior/test_arithmetic_jax_trace.py
+++ b/test_autofit/mapper/prior/test_arithmetic_jax_trace.py
@@ -1,0 +1,42 @@
+import numpy as np
+import pytest
+
+import autofit as af
+
+jax = pytest.importorskip("jax")
+jnp = pytest.importorskip("jax.numpy")
+
+
+COMPOUND_PRIOR_CASES = [
+    pytest.param(lambda prior: af.Log(prior), id="log"),
+    pytest.param(lambda prior: af.Log10(prior), id="log10"),
+    pytest.param(
+        lambda prior: af.Log(prior) + af.Log10(prior),
+        id="compound-children",
+    ),
+    pytest.param(lambda prior: af.Log(af.Log(prior)), id="nested-modifier"),
+]
+
+
+@pytest.mark.parametrize("compound_prior_from", COMPOUND_PRIOR_CASES)
+@pytest.mark.parametrize(
+    "value",
+    [pytest.param(4.0, id="scalar"), pytest.param([4.0, 10.0], id="batched")],
+)
+def test_compound_prior_is_jittable_and_matches_numpy(compound_prior_from, value):
+    prior = af.GaussianPrior(mean=0.0, sigma=1.0)
+    compound_prior = compound_prior_from(prior)
+
+    def evaluate(prior_value, xp):
+        return compound_prior.instance_for_arguments(
+            {prior: prior_value},
+            ignore_assertions=True,
+            xp=xp,
+        )
+
+    numpy_value = np.asarray(value)
+    expected = evaluate(numpy_value, np)
+    actual = jax.jit(lambda traced: evaluate(traced, jnp))(jnp.asarray(value))
+
+    assert actual.shape == np.shape(expected)
+    np.testing.assert_allclose(np.asarray(actual), expected, rtol=1e-6)

--- a/test_autofit/messages/test_jax_trace.py
+++ b/test_autofit/messages/test_jax_trace.py
@@ -80,3 +80,34 @@ def test_message_array_construction_is_jittable_and_matches_numpy(message_array,
 
     assert actual.shape == expected.shape
     np.testing.assert_allclose(np.asarray(actual), expected)
+
+
+MESSAGE_LOG_PARTITION_CASES = [
+    pytest.param(
+        lambda value, xp: GammaMessage(value + 1.0, value + 2.0).log_partition(xp=xp),
+        id="gamma",
+    ),
+    pytest.param(
+        lambda value, xp: BetaMessage(value + 1.0, value + 2.0).log_partition(xp=xp),
+        id="beta",
+    ),
+]
+
+
+@pytest.mark.parametrize("message_log_partition", MESSAGE_LOG_PARTITION_CASES)
+@pytest.mark.parametrize(
+    "value",
+    [pytest.param(2.0, id="scalar"), pytest.param([2.0, 3.0], id="batched")],
+)
+def test_message_log_partition_is_jittable_and_matches_numpy(
+    message_log_partition, value
+):
+    numpy_value = np.asarray(value)
+    expected = message_log_partition(numpy_value, np)
+
+    actual = jax.jit(lambda traced: message_log_partition(traced, jnp))(
+        jnp.asarray(value)
+    )
+
+    assert actual.shape == np.shape(expected)
+    np.testing.assert_allclose(np.asarray(actual), expected, rtol=1e-6)


### PR DESCRIPTION
## Summary

Make the remaining message and compound-prior array-namespace paths genuinely JAX-traceable.

- select the JAX backend while constructing traced Beta/Gamma messages
- dispatch Beta/Gamma log-partition special functions through SciPy or `jax.scipy`
- propagate `xp` recursively through arithmetic and modified priors
- use `xp.log` / `xp.log10` for compound-prior modifiers
- add scalar, batched, nested-prior, and NumPy-parity JIT regressions

## API Changes

`Prior.instance_for_arguments` gains an optional `xp=np` keyword, aligning direct priors with `AbstractPriorModel.instance_for_arguments`. Beta/Gamma message construction and compound-prior evaluation now honor JAX inputs instead of coercing them through NumPy. Existing NumPy calls and defaults are unchanged.

See full details below.

## Test Plan

- [x] Direct tests against untouched post-#1460 `main`: 12 expected JAX failures, 20 passes
- [x] Direct branch tests on JAX 0.10.2: 32 passed
- [x] Direct branch tests on supported-minimum JAX 0.7.0: 32 passed
- [x] Focused message/prior suites: 317 passed
- [x] Full PyAutoFit suite: 1701 passed, 4 skipped

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Signature
- `Prior.instance_for_arguments(arguments, ignore_assertions=False, xp=np)` — adds an optional backend argument used by recursive compound-prior evaluation.

### Changed Behaviour
- `BetaMessage` and `GammaMessage` constructors select JAX broadcasting for traced parameters.
- `BetaMessage.log_partition(xp=jnp)` uses `jax.scipy.special.betaln`.
- `GammaMessage.log_partition(xp=jnp)` uses `jax.scipy.special.gammaln` and `xp.log`.
- Arithmetic and modified priors propagate `xp` to nested children.
- `Log` and `Log10` dispatch through `xp.log` and `xp.log10`.

### Migration
- None. Existing callers remain valid; `xp` is optional and defaults to NumPy.

</details>

Closes #1459

Generated by the PyAutoLabs agent workflow.