### PR TITLE
fix: invalidate stale factor-graph subsample instances

### DIFF
--- a/autofit/non_linear/samples/interface.py
+++ b/autofit/non_linear/samples/interface.py
@@ -53,6 +53,13 @@ class SamplesInterface(ABC):
         self._names = None
         self._instance = None
 
+    def _rebind_model(self, model: AbstractPriorModel) -> None:
+        """Rebind a copied samples object without retaining model-derived caches."""
+        self.model = model
+        self._paths = None
+        self._names = None
+        self._instance = None
+
     @property
     def instance(self):
         if self._instance is None:

--- a/autofit/non_linear/samples/samples.py
+++ b/autofit/non_linear/samples/samples.py
@@ -500,7 +500,7 @@ class Samples(SamplesInterface, ABC):
         A set of samples with a reduced set of attributes
         """
         with_paths = copy(self)
-        with_paths.model = self.model.with_paths(paths)
+        with_paths._rebind_model(model=self.model.with_paths(paths))
         with_paths.sample_list = [
             sample.with_paths(paths) for sample in self.sample_list
         ]
@@ -526,7 +526,7 @@ class Samples(SamplesInterface, ABC):
         A set of samples with a reduced set of attributes
         """
         with_paths = copy(self)
-        with_paths.model = self.model.without_paths(paths)
+        with_paths._rebind_model(model=self.model.without_paths(paths))
         with_paths.sample_list = [
             sample.without_paths(paths) for sample in self.sample_list
         ]
@@ -538,9 +538,7 @@ class Samples(SamplesInterface, ABC):
 
         path_map = self.path_map_for_model(model)
         copied = copy(self)
-        copied._paths = None
-        copied._names = None
-        copied.model = model
+        copied._rebind_model(model=model)
 
         copied.sample_list = [sample.subsample(path_map) for sample in self.sample_list]
         return copied

--- a/autofit/non_linear/samples/summary.py
+++ b/autofit/non_linear/samples/summary.py
@@ -77,9 +77,7 @@ class SamplesSummary(SamplesInterface):
             return None
 
         copied = copy(self)
-        copied._paths = None
-        copied._names = None
-        copied.model = model
+        copied._rebind_model(model=model)
 
         copied._max_log_likelihood_sample = self.max_log_likelihood_sample.subsample(
             self.path_map_for_model(model)

--- a/autofit/non_linear/search/abstract_search.py
+++ b/autofit/non_linear/search/abstract_search.py
@@ -756,7 +756,7 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
 
         if mode == 1:
             try:
-                samples_summary.instance
+                samples_summary.max_log_likelihood()
             except exc.FitException as error:
                 samples = self._test_mode_samples_after_rejected_fit(
                     samples=samples,

--- a/test_autofit/non_linear/samples/test_samples.py
+++ b/test_autofit/non_linear/samples/test_samples.py
@@ -29,6 +29,62 @@ def _guarded_samples(parameter_lists, log_likelihood_list, weight_list):
     )
 
 
+def _factor_graph_samples():
+    shared_value = af.UniformPrior(lower_limit=0.0, upper_limit=1.0)
+    factor_models = [
+        af.Collection(galaxies=af.Model(_RejectsLowStoredValue, value=shared_value))
+        for _ in range(2)
+    ]
+    factor_graph = af.FactorGraphModel(
+        *[
+            af.AnalysisFactor(
+                prior_model=factor_model,
+                analysis=af.m.MockAnalysis(),
+            )
+            for factor_model in factor_models
+        ]
+    )
+    model = factor_graph.global_prior_model
+    samples = af.SamplesPDF(
+        model=model,
+        sample_list=af.Sample.from_lists(
+            model=model,
+            parameter_lists=[[0.9]],
+            log_likelihood_list=[1.0],
+            log_prior_list=[0.0],
+            weight_list=[1.0],
+        ),
+    )
+    return samples, factor_models[0]
+
+
+@pytest.mark.parametrize("use_summary", [False, True])
+def test__subsamples__rebuilds_instance_after_model_rebind(use_summary):
+    samples, factor_model = _factor_graph_samples()
+    source = samples.summary() if use_summary else samples
+
+    global_instance = source.instance
+    child = source.subsamples(model=factor_model)
+
+    assert child._instance is None
+    assert child.instance is not global_instance
+    assert child.instance.galaxies.value == pytest.approx(0.9)
+
+
+@pytest.mark.parametrize("method_name", ["with_paths", "without_paths"])
+def test__path_filter__clears_model_derived_caches(samples_x5, method_name):
+    samples_x5.instance
+    samples_x5.paths
+    samples_x5.names
+
+    paths = [("mock_class_1", "one")]
+    filtered = getattr(samples_x5, method_name)(paths)
+
+    assert filtered._instance is None
+    assert filtered._paths is None
+    assert filtered._names is None
+
+
 def test__table__headers(samples_x5):
     assert samples_x5._headers == [
         "mock_class_1.one",

--- a/test_autofit/non_linear/search/test_abstract_search.py
+++ b/test_autofit/non_linear/search/test_abstract_search.py
@@ -596,6 +596,50 @@ class TestReducedModeRejectedFinalSample:
         assert len(result) == 2
         assert all(child.instance.galaxies.value >= 0.75 for child in result)
 
+    def test__test_mode_1__valid_factor_graph_children_keep_per_analysis_model(
+        self, monkeypatch
+    ):
+        """Validation must not leave child results bound to a cached global instance."""
+        monkeypatch.setenv("PYAUTO_TEST_MODE", "1")
+
+        shared_value = af.UniformPrior(lower_limit=0.0, upper_limit=1.0)
+        factor_models = [
+            af.Collection(galaxies=af.Model(_RejectsLowValue, value=shared_value))
+            for _ in range(2)
+        ]
+        factor_graph = af.FactorGraphModel(
+            *[
+                af.AnalysisFactor(
+                    prior_model=factor_model,
+                    analysis=af.m.MockAnalysis(),
+                )
+                for factor_model in factor_models
+            ]
+        )
+        model = factor_graph.global_prior_model
+        valid_samples = _TaggedSamplesPDF(
+            model=model,
+            sample_list=af.Sample.from_lists(
+                model=model,
+                parameter_lists=[[0.9]],
+                log_likelihood_list=[1.0],
+                log_prior_list=[0.0],
+                weight_list=[1.0],
+            ),
+            samples_info={"log_evidence": 1.0, "sampler_marker": "retained"},
+        )
+
+        result = _RejectedFinalSampleSearch(samples=valid_samples).fit(
+            model=model,
+            analysis=factor_graph,
+        )
+
+        assert type(result.samples) is _TaggedSamplesPDF
+        assert len(result) == 2
+        assert all(
+            child.instance.galaxies.value == pytest.approx(0.9) for child in result
+        )
+
     def test__normal_mode__fitexception_still_propagates(self, monkeypatch):
         monkeypatch.delenv("PYAUTO_TEST_MODE", raising=False)
         model, rejected_samples = _model_and_rejected_samples(_RejectsLowValue)


### PR DESCRIPTION
Closes #1467.

## What changed

- add a single model-rebinding helper that clears `paths`, `names`, and cached `instance`
- use it for `SamplesSummary.subsamples`, `Samples.subsamples`, `with_paths`, and `without_paths`
- validate a mode-1 final sample without warming the result-summary cache
- add direct cache-rebinding tests and a valid-factor-graph end-to-end regression

## Root cause

Stage 3 release rehearsal [31517075410](https://github.com/PyAutoLabs/PyAutoHeart/actions/runs/31517075410) exposed the valid-sample path missed by #1466. Test-mode validation warmed the global factor-graph `SamplesSummary.instance`. Per-analysis `subsamples` shallow-copied that cached instance while swapping to a child model, so child results retained the global structure and lacked attributes such as `.centre` or `.galaxies`.

This does not change or weaken PyAutoGalaxy's parameter guards. Recovery continues to catch only `FitException`; unexpected programming errors still propagate.

## Validation

- `python -m compileall`: pass
- `git diff --check`: pass
- focused/full pytest: delegated to the required Python 3.12/3.13 CI matrix because this cloud runtime does not contain pytest and its package-network installation was unavailable
- complete Stage 3 rehearsal will be rerun after merge