### PR TITLE
fix: stop a crashed run poisoning every later run of the same search

### DIFF
--- a/autofit/non_linear/fitness.py
+++ b/autofit/non_linear/fitness.py
@@ -633,6 +633,34 @@ class Fitness:
             samples_summary = self.paths.load_samples_summary()
         except FileNotFoundError:
             return
+        except ValueError as e:
+            # A CORRUPT previous summary means the same thing as an ABSENT one
+            # for this check: there is no trustworthy old likelihood to compare
+            # against. Returning early is what the FileNotFoundError branch
+            # above already does for the no-previous-run case.
+            #
+            # `ValueError` is the catch because `json.JSONDecodeError`
+            # subclasses it -- which is exactly why this was missed by both the
+            # `FileNotFoundError` above and the `(FileNotFoundError, TypeError,
+            # KeyError)` guard on the multi-start resume path. A half-written
+            # file therefore aborted the whole run from inside an OPTIONAL
+            # sanity check -- and it stayed aborted on every subsequent run of
+            # the same search name, since nothing rewrites the file until a run
+            # gets far enough to finish.
+            #
+            # Warned rather than passed over in silence: an unreadable file is
+            # a real event, unlike a missing one, and the user is the only one
+            # who can decide whether the old results mattered.
+            logger.warning(
+                f"Could not read the previous samples summary while resuming "
+                f"({type(e).__name__}: {e}). It is missing or corrupt, most "
+                f"likely because an earlier run of this search was interrupted "
+                f"while writing its output. The likelihood-function sanity "
+                f"check is being SKIPPED for this run, and results are being "
+                f"recomputed. Delete the search's output directory if you want "
+                f"a guaranteed-clean start."
+            )
+            return
 
         try:
             max_log_likelihood_sample = samples_summary.max_log_likelihood_sample

--- a/autofit/non_linear/paths/directory.py
+++ b/autofit/non_linear/paths/directory.py
@@ -13,7 +13,7 @@ from autonerves.class_path import get_class
 from autonerves.dictable import to_dict, from_dict
 from autonerves.output import conditional_output, should_output
 from autofit.text import formatter
-from autofit.tools.util import open_
+from autofit.tools.util import open_, open_atomic
 from autofit.non_linear.samples.samples import Samples
 
 from .abstract import AbstractPaths, _test_mode_segment
@@ -76,7 +76,13 @@ class DirectoryPaths(AbstractPaths):
         prefix
             A prefix to add to the path which is the name of the folder the file is saved in.
         """
-        with open_(self._path_for_json(name, prefix), "w+") as f:
+        # ``open_atomic``, not ``open_``: a plain "w+" truncates before it
+        # writes, so a serialisation failure here leaves a HALF-WRITTEN file
+        # where a valid one was -- and the next run of this search reads that
+        # while resuming and dies on it. Written to a sibling temp file and
+        # ``os.replace``d into place, a failed write leaves the previous file
+        # whole instead.
+        with open_atomic(self._path_for_json(name, prefix)) as f:
             json.dump(object_dict, f, indent=4)
 
     def load_json(self, name, prefix: str = ""):
@@ -192,7 +198,11 @@ class DirectoryPaths(AbstractPaths):
         """
         filename = self.search_internal_path / "search_internal.dill"
 
-        with open_(filename, "wb") as f:
+        # Atomic for the same reason as ``save_json``, and it matters more
+        # here: ``search_internal`` is what a resumed run restores its step
+        # count and counters from, so a truncated dill does not merely fail to
+        # load -- it is the file the resume path most depends on.
+        with open_atomic(filename, "wb") as f:
             dill.dump(obj, f)
 
     def load_search_internal(self):

--- a/autofit/non_linear/search/mle/multi_start_gradient/search.py
+++ b/autofit/non_linear/search/mle/multi_start_gradient/search.py
@@ -1,4 +1,5 @@
 import inspect
+import pickle
 from typing import Optional
 
 import numpy as np
@@ -717,7 +718,32 @@ class AbstractMultiStartGradient(AbstractMLE):
                 "Resuming MultiStartGradient search (previous samples found)."
             )
 
-        except (FileNotFoundError, TypeError, KeyError):
+        # ``EOFError``/``UnpicklingError``/``ValueError`` join the original
+        # three so that a CORRUPT ``search_internal`` starts a fresh run rather
+        # than killing this one. A dill truncated by an interrupted write is
+        # the same situation as an absent one -- there is no state to resume
+        # from -- but it raised out of this guard instead of falling into the
+        # fresh-start branch below, and it kept doing so on every rerun of the
+        # same search name, because nothing rewrites the file until a run
+        # finishes. ``save_search_internal`` is atomic now, so this is the
+        # belt to that braces: it also covers files left by older versions,
+        # killed processes and full disks.
+        except (
+            FileNotFoundError,
+            TypeError,
+            KeyError,
+            EOFError,
+            ValueError,
+            pickle.UnpicklingError,
+        ) as e:
+
+            if not isinstance(e, FileNotFoundError):
+                self.logger.warning(
+                    f"Could not restore the previous MultiStartGradient state "
+                    f"({type(e).__name__}: {e}); starting a fresh run. This "
+                    f"usually means an earlier run was interrupted while "
+                    f"writing its output."
+                )
 
             if not self.silence:
                 self.logger.info(self._compile_message(batched=False))

--- a/autofit/tools/util.py
+++ b/autofit/tools/util.py
@@ -58,6 +58,42 @@ def open_(filename, *flags):
 
 
 @contextmanager
+def open_atomic(filename, mode: str = "w+"):
+    """
+    Write ``filename`` so that it is either fully replaced or left untouched.
+
+    A plain ``open(path, "w+")`` **truncates first and writes second**. If the
+    write then fails partway -- a serialisation ``TypeError``, a full disk, a
+    killed process -- what is left on disk is a half-written file where a valid
+    one used to be. That truncated file is not inert: the next run of the same
+    search reads it while resuming and fails on it, so one crash propagates
+    into every subsequent run of that search until the output directory is
+    deleted by hand.
+
+    Writing to a temporary file in the *same directory* and then ``os.replace``
+    -ing it into place removes the window. ``os.replace`` is atomic on POSIX
+    and on Windows, and staying in one directory keeps it a rename within a
+    single filesystem, which is where that guarantee holds. On failure the
+    temporary file is removed and the original is still whole.
+    """
+    path = Path(filename)
+    os.makedirs(path.parent, exist_ok=True)
+
+    tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+
+    try:
+        with open(tmp, mode) as f:
+            yield f
+    except BaseException:
+        # BaseException, not Exception: a KeyboardInterrupt mid-write leaves
+        # exactly the same debris and must not leak a .tmp file either.
+        tmp.unlink(missing_ok=True)
+        raise
+
+    os.replace(tmp, path)
+
+
+@contextmanager
 def suppress_stdout():
     with open(os.devnull, "w") as devnull:
         old_stdout = sys.stdout

--- a/test_autofit/tools/test_atomic_write.py
+++ b/test_autofit/tools/test_atomic_write.py
@@ -1,0 +1,176 @@
+import json
+
+import numpy as np
+import pytest
+
+import autofit as af
+from autofit.tools.util import open_atomic
+
+
+class TestOpenAtomic:
+    def test__successful_write_replaces_the_file(self, tmp_path):
+        path = tmp_path / "f.json"
+        path.write_text('{"old": 1}')
+
+        with open_atomic(path) as f:
+            json.dump({"new": 2}, f)
+
+        assert json.loads(path.read_text()) == {"new": 2}
+
+    def test__failed_write_leaves_the_original_intact(self, tmp_path):
+        """
+        The whole point. A plain ``open(path, "w+")`` truncates first, so a
+        failure partway through destroys the previous file.
+        """
+        path = tmp_path / "f.json"
+        path.write_text('{"old": 1}')
+
+        with pytest.raises(TypeError):
+            with open_atomic(path) as f:
+                f.write('{"partial": ')
+                raise TypeError("Object of type float32 is not JSON serializable")
+
+        assert json.loads(path.read_text()) == {"old": 1}
+
+    def test__failed_write_leaves_no_temp_file_behind(self, tmp_path):
+        path = tmp_path / "f.json"
+        path.write_text('{"old": 1}')
+
+        with pytest.raises(TypeError):
+            with open_atomic(path) as f:
+                f.write("junk")
+                raise TypeError
+
+        assert [p.name for p in tmp_path.iterdir()] == ["f.json"]
+
+    def test__keyboard_interrupt_also_cleans_up(self, tmp_path):
+        """
+        ``BaseException``, not ``Exception``: an interrupt mid-write leaves the
+        same debris and must not leak a .tmp file either.
+        """
+        path = tmp_path / "f.json"
+        path.write_text('{"old": 1}')
+
+        with pytest.raises(KeyboardInterrupt):
+            with open_atomic(path) as f:
+                f.write("junk")
+                raise KeyboardInterrupt
+
+        assert json.loads(path.read_text()) == {"old": 1}
+        assert [p.name for p in tmp_path.iterdir()] == ["f.json"]
+
+    def test__creates_a_file_that_did_not_exist(self, tmp_path):
+        path = tmp_path / "sub" / "f.json"
+
+        with open_atomic(path) as f:
+            json.dump({"a": 1}, f)
+
+        assert json.loads(path.read_text()) == {"a": 1}
+
+    def test__binary_mode(self, tmp_path):
+        """``save_search_internal`` writes dill, so binary must work too."""
+        path = tmp_path / "f.bin"
+
+        with open_atomic(path, "wb") as f:
+            f.write(b"\x00\x01")
+
+        assert path.read_bytes() == b"\x00\x01"
+
+
+class TestSaveJsonIsAtomic:
+    def test__a_failed_save_json_does_not_destroy_the_previous_file(
+        self, output_directory
+    ):
+        """
+        The field sequence: a run writes a good summary, a later run dies while
+        rewriting it, and the half-written file poisons every run after that.
+        """
+        paths = af.DirectoryPaths(name="atomic_save_json")
+        paths._identifier = "id"
+
+        paths.save_json(name="counters", object_dict={"clipped": 4})
+        assert paths.load_json(name="counters") == {"clipped": 4}
+
+        class Unserialisable:
+            pass
+
+        with pytest.raises(TypeError):
+            paths.save_json(
+                name="counters", object_dict={"clipped": Unserialisable()}
+            )
+
+        # Still readable, and still the OLD value -- not truncated.
+        assert paths.load_json(name="counters") == {"clipped": 4}
+
+
+class TestCorruptOutputDoesNotPoisonTheNextRun:
+    def test__truncated_summary_lets_the_next_run_proceed(
+        self, output_directory
+    ):
+        """
+        End-to-end, because this bug is only visible across two runs.
+
+        Before the fix the second run died with an opaque
+        ``JSONDecodeError: Expecting value: line 1 column 13`` raised from
+        inside an OPTIONAL likelihood sanity check, and kept dying on every
+        rerun of the same name.
+        """
+        from autofit import example
+
+        xvalues = np.arange(60)
+        truth = example.Gaussian(centre=30.0, normalization=25.0, sigma=8.0)
+        data = np.asarray(truth.model_data_from(xvalues=xvalues))
+        noise_map = np.full(60, 1.0)
+
+        def analysis():
+            instance = example.Analysis(data=data, noise_map=noise_map)
+            instance._use_jax = False
+            return instance
+
+        def model():
+            built = af.Model(example.Gaussian)
+            built.centre = af.UniformPrior(lower_limit=5.0, upper_limit=35.0)
+            built.normalization = af.UniformPrior(
+                lower_limit=10.0, upper_limit=40.0
+            )
+            built.sigma = af.UniformPrior(lower_limit=1.0, upper_limit=20.0)
+            return built
+
+        name = "corrupt_resume"
+
+        search = af.LBFGS(name=name, maxiter=10)
+        search.fit(model=model(), analysis=analysis())
+
+        out = search.paths.output_path
+
+        # The test config prunes output files after a run, so write the
+        # corrupt state directly rather than depending on what survived. This
+        # is the same half-written file a truncating "w+" leaves behind.
+        summary = out / "files" / "samples_summary.json"
+        summary.parent.mkdir(parents=True, exist_ok=True)
+        summary.write_text('{"partial": ')
+
+        # Not `.completed` by rglob -- the marker's location is the paths
+        # object's business, and an interrupted run never wrote it anyway.
+        search.paths._has_completed_path.unlink(missing_ok=True)
+
+        resumed = af.LBFGS(name=name, maxiter=10)
+        assert not resumed.paths.is_complete, (
+            "the second run must take the resume path, not be short-circuited "
+            "as already-complete -- otherwise this asserts nothing"
+        )
+
+        # The regression: before the fix this raised JSONDecodeError out of an
+        # optional sanity check, and did so on every rerun of the same name.
+        result = resumed.fit(model=model(), analysis=analysis())
+
+        assert result is not None
+
+    def test__json_decode_error_is_a_value_error(self):
+        """
+        The crux of why this was missed. ``JSONDecodeError`` is neither a
+        ``FileNotFoundError``, a ``TypeError`` nor a ``KeyError``, so it fell
+        through every guard on the resume path.
+        """
+        assert issubclass(json.JSONDecodeError, ValueError)
+        assert not issubclass(json.JSONDecodeError, (TypeError, KeyError))


### PR DESCRIPTION
A run interrupted while writing its output left a half-written JSON file on disk, and every subsequent run of that search name then died on it — from inside an **optional** sanity check — until the output directory was deleted by hand.

## Reproduced against `main`

Using the real trigger, a `float32` killing `save_json` at the end of a *successful* fit:

```
run 1:  TypeError: Object of type float32 is not JSON serializable
run 2:  JSONDecodeError: Expecting value: line 1 column 13 (char 12)
```

The message names no file and suggests no remedy. And run 2 is not a one-off: nothing rewrites the corrupt file until a run gets far enough to finish, so the search stays wedged.

**Note on the original report.** This was filed as producing "a 4-second no-op run that reads as a clean result". That is not what reproduces here — what reproduces is the hard crash above. The silent-no-op variant presumably needs a surviving `search_internal` (whose `total_steps` short-circuits the loop). Both are the same root cause, and the fix covers both paths, but I could only reproduce the crash and would rather say so than claim otherwise.

## Three causes, three legs

**1. Writes were not atomic.** `open(path, "w+")` truncates first and writes second, so a failure partway destroys the file that was there. Adds `open_atomic`, which writes a sibling temp file and `os.replace`s it into place — atomic on POSIX and Windows, and same-directory so it stays a rename within one filesystem. On failure the temp file is removed and the original is untouched. It catches `BaseException`, since a `KeyboardInterrupt` mid-write leaves exactly the same debris.

Used by `save_json` and by `save_search_internal` — the latter matters more, since `search_internal` is what a resumed run restores its step count and counters from.

**2. `Fitness.check_log_likelihood` aborted the run on an unreadable summary.** It already returns early on `FileNotFoundError` — no previous run, nothing to check — and a *corrupt* summary is the same situation, since there is no trustworthy old likelihood either way. It now returns early there too, with a **warning** naming the cause and the remedy rather than silence: an unreadable file is a real event, unlike a missing one.

**3. The multi-start resume guard had the same narrow shape.** It caught `(FileNotFoundError, TypeError, KeyError)`, so a corrupt `search_internal` raised instead of falling into the fresh-start branch directly below it. Widened to treat truncated or unpicklable state as "no state to resume from", warning when it does.

## The one fact behind all three

`json.JSONDecodeError` **subclasses `ValueError`**. So it is neither a `FileNotFoundError`, a `TypeError` nor a `KeyError`, and it fell through every guard on the resume path. Asserted directly in a test so it cannot silently stop being true.

## After

The same sequence warns and completes a full 30-step run instead of dying:

```
WARNING - Could not read the previous samples summary while resuming
(JSONDecodeError: ...). It is missing or corrupt, most likely because an
earlier run of this search was interrupted while writing its output. The
likelihood-function sanity check is being SKIPPED for this run, and results
are being recomputed. Delete the search's output directory if you want a
guaranteed-clean start.

total_steps: 30    stop_reason: max_steps
```

## Testing

9 new tests: `open_atomic` success/failure/interrupt/temp-file-cleanup/binary, `save_json` preserving the previous file when a write fails, the `JSONDecodeError`-is-a-`ValueError` assertion, and an end-to-end two-run test that asserts the second run takes the resume path (rather than being short-circuited as already-complete, which would make it assert nothing) and does not raise.

Full suite: **1800 passed**, 4 skipped, 1 failed. The failure (`test_nautilus.py::test__single_core_builds_no_pool`) is **pre-existing** and reproduces identically on a clean tree.

## Related

Branched from `main`, independent of #1478 and #1479. #1479 removes the most common *trigger* (the `float32` crash); this PR removes the *consequence*, so a crash from any cause — full disk, killed process, interrupt — can no longer wedge a search. They are worth landing together but neither depends on the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FzF2XmKQaqZRWZfZMxvTNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzF2XmKQaqZRWZfZMxvTNR)_