### PR TITLE
feat: clipper enters the MLE search identifiers

### DIFF
--- a/autofit/non_linear/search/mle/bfgs/search.py
+++ b/autofit/non_linear/search/mle/bfgs/search.py
@@ -17,6 +17,14 @@ import numpy as np
 
 class AbstractBFGS(AbstractMLE):
 
+    # Same contract as ``AbstractMultiStartGradient``: bounds handed to scipy
+    # change where the fit converges, so the clipper forks the identifier here
+    # too, re-keying existing (L)BFGS output directories (PyAutoFit#1493).
+    # ``Drawer`` deliberately does NOT declare this: it inherits the attribute
+    # from ``AbstractMLE`` but never consumes it, and a setting that cannot
+    # affect the result must not re-key stored results.
+    __identifier_fields__ = ("clipper",)
+
     method = None
 
     def __init__(

--- a/autofit/non_linear/search/mle/multi_start_gradient/search.py
+++ b/autofit/non_linear/search/mle/multi_start_gradient/search.py
@@ -22,6 +22,14 @@ from autofit.non_linear.search.mle.multi_start_gradient.convergence import (
 
 class AbstractMultiStartGradient(AbstractMLE):
 
+    # The clipper changes where a lane can sit and therefore the result, so two
+    # runs differing only in clipper must not share an output directory. This
+    # re-keys every existing multi-start identifier (stored results are orphaned
+    # on disk, not deleted). Scoped to the clipper-consuming searches only: the
+    # nested samplers and MCMC searches never touch the clipper and their
+    # identifiers must stay byte-identical (PyAutoFit#1493).
+    __identifier_fields__ = ("clipper",)
+
     # Name of the optax update rule, resolved lazily at fit time from ``optax``
     # then ``optax.contrib`` (so ``optax`` is only imported when a fit is
     # actually run — it is a JAX-only optional dependency). Subclasses set this

--- a/test_autofit/database/identifier/test_identifiers.py
+++ b/test_autofit/database/identifier/test_identifiers.py
@@ -412,3 +412,107 @@ def test_dynesty_static():
 
 def test_integer_keys():
     assert str(Identifier({1: 1}))
+
+
+def test_nested_sampler_identifiers_unchanged_by_clipper():
+    """
+    The clipper entering the MLE search identifiers (PyAutoFit#1493) must not
+    re-key any nested sampler: these hash lists were captured on main before
+    the change and pin the archived nested-sampling results' directories.
+    """
+    assert Identifier(af.Nautilus()).hash_list == [
+        "Nautilus",
+        "n_live",
+        "3000",
+        "n_update",
+        "enlarge_per_dim",
+        "1.1",
+        "n_points_min",
+        "split_threshold",
+        "100",
+        "n_networks",
+        "4",
+        "n_like_new_bound",
+        "seed",
+        "n_shell",
+        "1",
+        "n_eff",
+        "500",
+    ]
+    assert Identifier(af.DynestyDynamic()).hash_list == [
+        "DynestyDynamic",
+        "bound",
+        "multi",
+        "sample",
+        "auto",
+        "enlarge",
+        "bootstrap",
+        "walks",
+        "5",
+        "facc",
+        "0.2",
+        "slices",
+        "5",
+        "fmove",
+        "0.9",
+        "max_move",
+        "100",
+    ]
+
+
+def test_mcmc_identifiers_unchanged_by_clipper():
+    assert Identifier(af.Emcee()).hash_list == [
+        "Emcee",
+        "nwalkers",
+        "50",
+    ]
+    assert Identifier(af.Zeus()).hash_list == [
+        "Zeus",
+        "nwalkers",
+        "50",
+        "tune",
+        "True",
+        "tolerance",
+        "0.05",
+        "patience",
+        "5",
+        "mu",
+        "1.0",
+        "light_mode",
+        "False",
+    ]
+
+
+def test_nested_samplers_have_no_clipper():
+    """
+    Tripwire for the hard constraint of PyAutoFit#1493: the clipper is resolved
+    on AbstractMLE and must stay there. Hoisting it to NonLinearSearch would put
+    it within reach of the nested samplers' identifier machinery and silently
+    re-key the nested-sampling archive; this fails loudly instead.
+    """
+    for search in [af.Nautilus(), af.DynestyStatic(), af.DynestyDynamic()]:
+        assert not hasattr(search, "clipper")
+
+
+@pytest.mark.parametrize("cls", [af.MultiStartAdam, af.LBFGS])
+def test_clipper_forks_mle_identifier(cls):
+    default = Identifier(cls())
+    assert Identifier(cls(clipper=af.ClipperNone())) == default
+    box = Identifier(cls(clipper=af.ClipperPriorBox()))
+    assert box != default
+    assert Identifier(cls(clipper=af.ClipperPriorBox(margin=1.0e-3))) != box
+
+
+def test_drawer_identifier_ignores_clipper():
+    """
+    Drawer inherits the clipper attribute from AbstractMLE but never consumes
+    it, so a setting that cannot affect its result must not re-key it.
+    """
+    assert Identifier(af.Drawer()).hash_list == [
+        "Drawer",
+        "total_draws",
+        "50",
+    ]
+    assert Identifier(af.Drawer(clipper=af.ClipperPriorBox())) == Identifier(
+        af.Drawer()
+    )


### PR DESCRIPTION
## Summary

Closes #1493. The prior-support `Clipper` (#1477) did not enter the search identifier, so two runs differing only in prior-support enforcement — which demonstrably changes the answer — shared one output directory, and with the `.completed` short-circuit the later run silently returned the earlier one's numbers (this bit the phase-2 validation campaign, which worked around it with unique per-arm names). Per the decision recorded in PyAutoMind (2026-08-18): the clipper now forks the identifier on the two search families that consume one, and nothing else re-keys.

`__identifier_fields__ = ("clipper",)` is added to `AbstractMultiStartGradient` and `AbstractBFGS` — the entire source change. `Drawer` (inherits the attribute but never consumes it), the nested samplers, and the MCMC searches are untouched: their identifiers are byte-for-byte identical, pinned by new regression tests whose hash lists were captured on `main` at c302f51 **before** the change.

**Behaviour change to state in release notes:** every existing `MultiStart*` / `BFGS` / `LBFGS` output directory re-keys, including default-`ClipperNone` runs (the hash gains the `clipper` field itself). Stored results are orphaned on disk, not deleted; re-running recomputes into a fresh directory. Nested-sampling and MCMC results are unaffected.

## API Changes

No public API surface changes — no signatures, classes, or modules added or removed. The observable change is output-directory identifiers for the MLE gradient searches:

- `MultiStartAdam` / `MultiStartADABelief` / `MultiStartLion` / `MultiStartProdigy` / `BFGS` / `LBFGS`: identifier now includes the clipper (`ClipperNone` vs `ClipperPriorBox`, including its `margin`), so all existing output directories for these searches re-key.
- `Nautilus`, `DynestyStatic`, `DynestyDynamic`, `Emcee`, `Zeus`, NUTS, `Drawer`: identifiers unchanged (regression-pinned).

See full details below.

## Test Plan

- [x] `test_autofit/database/identifier/test_identifiers.py` — 29 passed (23 existing incl. the untouched `test_dynesty_static` pin + 6 new)
- [x] New pins: `Nautilus` / `DynestyDynamic` / `Emcee` / `Zeus` hash lists captured on `main` @ c302f51 before the change, asserted after
- [x] New tripwire: nested samplers have no `clipper` attribute — fails loudly if a refactor hoists `clipper` from `AbstractMLE` toward `NonLinearSearch`
- [x] New separation tests: default == explicit `ClipperNone`; `ClipperPriorBox` forks; different margins fork; `Drawer` ignores the clipper
- [x] Full suite on Python 3.13: **1864 passed**, 4 skipped, 1 failed — `test_nautilus.py::test__single_core_builds_no_pool`, the environment-specific failure documented in `complete/2026/08/prior-support-clipper.md` (passes in CI, fails in local venvs, reproduced identically on a clean tree here)

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
- None.

### Added
- `AbstractMultiStartGradient.__identifier_fields__ = ("clipper",)` — clipper forks the multi-start identifier.
- `AbstractBFGS.__identifier_fields__ = ("clipper",)` — clipper forks the (L)BFGS identifier.

### Migration
- No code changes required. Existing multi-start / (L)BFGS output directories are orphaned (not deleted): a re-run with the same config recomputes into a new identifier directory. To keep using an old result, load it explicitly by path. Nested-sampling / MCMC output directories resolve exactly as before.

</details>

### Question for the reviewer

Because these searches' `__identifier_fields__` was empty, **only their class name** hashed until now — `n_starts`, `total_steps`, `learning_rate` etc. also collide today. This PR re-keys the MLE directories anyway, so widening the tuple in the same release would pay the orphaning cost once instead of twice. Kept out of this PR per one-prompt-one-task; say the word and it gets filed as its own follow-up (or folded in here).

Generated by the PyAutoLabs agent workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ifYaS7vcVWptamayY9umv

---
_Generated by [Claude Code](https://claude.ai/code/session_012ifYaS7vcVWptamayY9umv)_