### PR TITLE
maint: close search.log handler + four CLI-noise warning fixes

### DIFF
--- a/autofit/database/model/fit.py
+++ b/autofit/database/model/fit.py
@@ -327,15 +327,22 @@ class Fit(Base, fit_interface.Fit):
         lazy="joined",
         foreign_keys=[JSON.fit_id],
     )
+    # ``overlaps=``: ``HDU`` extends ``Array`` by joined-table inheritance, so
+    # ``Fit.arrays``/``Array.fit`` and ``Fit.hdus``/``HDU.fit`` all write the
+    # same ``array.fit_id`` column. The overlap is intentional (an HDU is an
+    # Array); the annotations carry exactly the names SQLAlchemy's SAWarning
+    # from ``configure_mappers()`` suggests.
     arrays: Mapped[List[Array]] = sa.orm.relationship(
         "Array",
         lazy="joined",
         foreign_keys=[Array.fit_id],
+        overlaps="fit",
     )
     hdus: Mapped[List[HDU]] = sa.orm.relationship(
         "HDU",
         lazy="joined",
         foreign_keys=[HDU.fit_id],
+        overlaps="arrays,fit",
     )
     fits: Mapped[List[Fits]] = sa.orm.relationship(
         "Fits",

--- a/autofit/non_linear/search/abstract_search.py
+++ b/autofit/non_linear/search/abstract_search.py
@@ -134,6 +134,7 @@ def configure_handler(func):
             return func(self, *args, **kwargs)
         finally:
             root_logger.removeHandler(handler)
+            handler.close()
 
     return decorated
 

--- a/autofit/non_linear/search/mle/bfgs/search.py
+++ b/autofit/non_linear/search/mle/bfgs/search.py
@@ -405,3 +405,15 @@ class LBFGS(AbstractBFGS):
     """
 
     method = "L-BFGS-B"
+
+    # SciPy 1.15 deprecated the L-BFGS-B ``disp`` / ``iprint`` options (removal
+    # slated for 1.18) — the solver no longer emits its Fortran-side verbose
+    # output, so passing them buys nothing but a DeprecationWarning per
+    # ``minimize`` call. The constructor still accepts both for API stability;
+    # they simply never reach scipy for this method.
+    @property
+    def options(self):
+        options = dict(super().options)
+        del options["disp"]
+        del options["iprint"]
+        return options

--- a/autofit/non_linear/search/nest/nautilus/search.py
+++ b/autofit/non_linear/search/nest/nautilus/search.py
@@ -532,7 +532,7 @@ class Nautilus(abstract_nest.AbstractNest):
 
     def samples_info_from(self, search_internal=None):
         return {
-            "log_evidence": search_internal.evidence(),
+            "log_evidence": search_internal.log_z,
             "total_samples": int(search_internal.n_like),
             "total_accepted_samples": int(search_internal.n_like),
             "time": self.timer.time if self.timer else None,

--- a/test_autofit/non_linear/search/optimize/test_lbfgs.py
+++ b/test_autofit/non_linear/search/optimize/test_lbfgs.py
@@ -28,9 +28,14 @@ def test__explicit_params():
     assert search.options["eps"] == 4.
     assert search.options["maxfun"] == 25000
     assert search.options["maxiter"] == 26000
-    assert search.options["iprint"] == -2
     assert search.options["maxls"] == 21
-    assert search.options["disp"] is True
+
+    # Accepted for API stability but never forwarded: scipy deprecated the
+    # L-BFGS-B ``disp`` / ``iprint`` options in 1.15.
+    assert search.iprint == -2
+    assert search.disp is True
+    assert "iprint" not in search.options
+    assert "disp" not in search.options
     assert isinstance(search.initializer, af.InitializerBall)
     assert search.initializer.lower_limit == 0.2
     assert search.initializer.upper_limit == 0.8
@@ -46,7 +51,9 @@ def test__explicit_params():
     assert search.options["eps"] == 1e-08
     assert search.options["maxfun"] == 15000
     assert search.options["maxiter"] == 15000
-    assert search.options["iprint"] == -1
     assert search.options["maxls"] == 20
-    assert search.options["disp"] is False
+    assert search.iprint == -1
+    assert search.disp is False
+    assert "iprint" not in search.options
+    assert "disp" not in search.options
     assert isinstance(search.initializer, af.InitializerBall)

--- a/test_autofit/non_linear/test_fork_context.py
+++ b/test_autofit/non_linear/test_fork_context.py
@@ -13,6 +13,16 @@ from autofit.non_linear.search.nest.dynesty.search.abstract import (
     prior_transform,
 )
 
+# pytest's own machinery keeps a background thread alive, so CPython 3.12+
+# flags every os.fork() here as fork-in-a-multi-threaded-process, and JAX
+# (itself multithreaded once imported) registers an equivalent RuntimeWarning
+# hook. The tests exercise the fork-pinned pool deliberately; the deadlock
+# caveat does not apply to these short-lived, likelihood-only workers.
+pytestmark = [
+    pytest.mark.filterwarnings("ignore:This process:DeprecationWarning"),
+    pytest.mark.filterwarnings(r"ignore:os\.fork\(\) was called:RuntimeWarning"),
+]
+
 pins_fork = (
     sys.platform != "darwin"
     and "fork" in multiprocessing.get_all_start_methods()


### PR DESCRIPTION
## Summary
Five mechanical fixes from the 2026-08-06 full-suite `-W all` CLI-noise audit, all noise-only with no behaviour change to fits: close the `search.log` `FileHandler` that `configure_handler` removed but never closed (44 `ResourceWarning`s + a file-descriptor leak per suite run); annotate the intentional `Fit.arrays`/`Fit.hdus`/`HDU.fit` relationship overlap with the exact `overlaps=` strings SQLAlchemy's `SAWarning` suggests; swap nautilus's deprecated `evidence()` call for the `.log_z` property it wraps; stop forwarding the `disp`/`iprint` options scipy 1.15 deprecated for L-BFGS-B; and filter the unavoidable fork-in-a-multi-threaded-process warnings module-locally in `test_fork_context.py`.

Closes #1495.

## API Changes
None — internal changes only. (One observable nuance: `LBFGS.options` no longer contains the `disp`/`iprint` keys; the constructor still accepts both and `disp` stays live for plain `BFGS`. See details below.)

## Test Plan
- [x] Full suite on Python 3.13 / scipy 1.17.1 / SQLAlchemy 2.0.52 / nautilus 1.0.5: **1884 passed, 3 skipped**
- [x] Handler leak: 50 `configure_handler`-decorated calls under `-W error::ResourceWarning` run clean, no handlers left on the root logger
- [x] `sa.orm.configure_mappers()` emits zero warnings after the `overlaps=` annotations (two `SAWarning`s before, reproduced to copy the exact suggested strings)
- [x] scipy deprecation reproduced on 1.17.1: any L-BFGS-B `minimize` call passing `disp`/`iprint` warns; none after the fix
- [x] nautilus 1.0.5 `evidence()` verified to be a warn-then-`return self.log_z` wrapper — the swap is exactly equivalent
- [x] `test_fork_context.py` runs warning-free; `test_lbfgs.py` updated to pin the new options contract

<details>
<summary>Full API Changes (for automation &amp; release notes)</summary>

### Changed Behaviour
- `LBFGS.options` — no longer includes the `disp` / `iprint` keys (scipy 1.15 deprecated both for the L-BFGS-B solver; removal slated for scipy 1.18). The `LBFGS.__init__` parameters `disp` and `iprint` are still accepted and stored as attributes; they simply never reach `scipy.optimize.minimize` for this method. Plain `BFGS` behaviour is unchanged (`disp` still forwarded).

### Migration
- No action needed. Users who set `disp=True`/`iprint` on `af.LBFGS` lose scipy's Fortran-side verbose output, which scipy itself is removing.

</details>

Generated by the PyAutoLabs agent workflow.

---
_Generated by [Claude Code](https://claude.ai/code/session_018WXzGhe8dt8ANs4xaXHcuD)_