### PR TITLE
fix: per-method recovery when stored samples fail model reconstruction (#1486)

### DIFF
--- a/autofit/non_linear/samples/interface.py
+++ b/autofit/non_linear/samples/interface.py
@@ -2,44 +2,73 @@ from abc import ABC, abstractmethod
 from functools import wraps
 from typing import Union, List, Tuple, Dict
 
+from autofit import exc
 from autofit.mapper.model import ModelInstance
 from autofit.mapper.prior_model.abstract import AbstractPriorModel
 from autofit.mapper.prior_model.abstract import Path
 
 
-def to_instance(func):
+def to_instance(recover: str = "raise"):
     """
     Decorator for methods that return a vector of parameters, which can be converted to a model instance.
 
+    Constructor validation can become stricter after a result was written, so a stored
+    vector may be rejected via the narrow `FitException` contract when materialized.
+    The `recover` policy decides what happens then:
+
+    - "raise": raise a typed `SamplesException` (chained to the rejection). This is the
+      only honest option for vectors with no stored sample to substitute — e.g. the
+      marginalized methods, which synthesize each parameter independently — and for
+      `from_sample_index`, where the caller asked for one specific sample.
+    - "next_valid": call the object's `_next_valid_instance`, which substitutes the
+      best valid stored sample (see `Samples._next_valid_instance`).
+
     Parameters
     ----------
-    func
-        A method that returns a vector of parameters
+    recover
+        The recovery policy applied when the model rejects the vector with
+        `FitException` while building an instance.
 
     Returns
     -------
-    A wrapper that converts the vector to a model instance
+    A decorator whose wrapper converts the vector to a model instance
     """
 
-    @wraps(func)
-    def wrapper(
-        self,
-        *args,
-        as_instance: bool = True,
-        as_dict: bool = False,
-        **kwargs,
-    ) -> Union[List, Dict, ModelInstance]:
-        vector = func(self, *args, **kwargs)
+    def decorator(func):
+        @wraps(func)
+        def wrapper(
+            self,
+            *args,
+            as_instance: bool = True,
+            as_dict: bool = False,
+            **kwargs,
+        ) -> Union[List, Dict, ModelInstance]:
+            vector = func(self, *args, **kwargs)
 
-        if as_dict:
-            return {".".join(path[0]): value for path, value in zip(self.paths, vector)}
+            if as_dict:
+                return {
+                    ".".join(path[0]): value
+                    for path, value in zip(self.paths, vector)
+                }
 
-        if as_instance:
-            return self._instance_from_vector(vector)
+            if as_instance:
+                try:
+                    return self._instance_from_vector(vector)
+                except exc.FitException as error:
+                    if recover == "next_valid":
+                        return self._next_valid_instance(error)
+                    raise exc.SamplesException(
+                        f"The stored parameters returned by {func.__name__} cannot "
+                        f"be reconstructed as a model instance because the current "
+                        f"model rejected them (see the chained exception). Pass "
+                        f"as_instance=False to retrieve the raw values instead."
+                    ) from error
 
-        return vector
+            return vector
 
-    return wrapper
+        return wrapper
+
+    return decorator
 
 
 class SamplesInterface(ABC):
@@ -90,7 +119,7 @@ class SamplesInterface(ABC):
             self._names = self.model.all_names
         return self._names
 
-    @to_instance
+    @to_instance()
     def max_log_likelihood(self, as_instance: bool = True) -> List[float]:
         """
         The parameters of the maximum log likelihood sample of the `NonLinearSearch` returned as a model instance or

--- a/autofit/non_linear/samples/mcmc.py
+++ b/autofit/non_linear/samples/mcmc.py
@@ -133,7 +133,7 @@ class SamplesMCMC(SamplesPDF):
             total_samples=self.total_samples
         )
 
-    @to_instance
+    @to_instance()
     def median_pdf(self, as_instance: bool = True) -> [float]:
         """
         The median of the probability density function (PDF) of every parameter marginalized in 1D, returned
@@ -150,7 +150,7 @@ class SamplesMCMC(SamplesPDF):
 
         return self.max_log_likelihood(as_instance=False)
 
-    @to_instance
+    @to_instance()
     def values_at_sigma(self, sigma: float) -> [float]:
         """
         The value of every parameter marginalized in 1D at an input sigma value of its probability density function

--- a/autofit/non_linear/samples/pdf.py
+++ b/autofit/non_linear/samples/pdf.py
@@ -136,7 +136,7 @@ class SamplesPDF(Samples):
             return False
         return True
 
-    @to_instance
+    @to_instance()
     def median_pdf(self) -> List[float]:
         """
         The median of the probability density function (PDF) of every parameter marginalized in 1D, returned
@@ -149,7 +149,7 @@ class SamplesPDF(Samples):
             ]
         return self.max_log_likelihood(as_instance=False)
 
-    @to_instance
+    @to_instance()
     def values_at_sigma(self, sigma: float) -> [Tuple, ModelInstance]:
         """
         The value of every parameter marginalized in 1D at an input sigma value of its probability density function
@@ -198,7 +198,7 @@ class SamplesPDF(Samples):
             for index in range(len(parameters_min))
         ]
 
-    @to_instance
+    @to_instance()
     def values_at_upper_sigma(self, sigma: float) -> Union[List, ModelInstance]:
         """
         The upper value of every parameter marginalized in 1D at an input sigma value of its probability density
@@ -215,7 +215,7 @@ class SamplesPDF(Samples):
             map(lambda param: param[1], self.values_at_sigma(sigma, as_instance=False))
         )
 
-    @to_instance
+    @to_instance()
     def values_at_lower_sigma(self, sigma: float) -> Union[List, ModelInstance]:
         """
         The lower value of every parameter marginalized in 1D at an input sigma value of its probability density
@@ -232,7 +232,7 @@ class SamplesPDF(Samples):
             map(lambda param: param[0], self.values_at_sigma(sigma, as_instance=False))
         )
 
-    @to_instance
+    @to_instance()
     def errors_at_sigma(
         self, sigma: float, as_instance: bool = True
     ) -> [Tuple, ModelInstance]:
@@ -254,7 +254,7 @@ class SamplesPDF(Samples):
             for lower, upper in zip(error_vector_lower, error_vector_upper)
         ]
 
-    @to_instance
+    @to_instance()
     def errors_at_upper_sigma(
         self, sigma: float, as_instance: bool = True
     ) -> Union[List, ModelInstance]:
@@ -278,7 +278,7 @@ class SamplesPDF(Samples):
             )
         )
 
-    @to_instance
+    @to_instance()
     def errors_at_lower_sigma(self, sigma: float) -> Union[List, ModelInstance]:
         """
         The lower error of every parameter marginalized in 1D at an input sigma value of its probability density
@@ -300,7 +300,7 @@ class SamplesPDF(Samples):
             )
         )
 
-    @to_instance
+    @to_instance()
     def error_magnitudes_at_sigma(self, sigma: float) -> Union[List, ModelInstance]:
         """
         The magnitude of every error after marginalization in 1D at an input sigma value of the probability density
@@ -397,7 +397,7 @@ class SamplesPDF(Samples):
             samples_info=self.samples_info,
         )
 
-    @to_instance
+    @to_instance()
     def offset_values_via_input_values(
         self, input_vector: List
     ) -> Union[List, ModelInstance]:

--- a/autofit/non_linear/samples/samples.py
+++ b/autofit/non_linear/samples/samples.py
@@ -70,15 +70,15 @@ class Samples(SamplesInterface, ABC):
     @property
     def instances(self):
         """
-        One model instance for each sample
+        One model instance for each stored sample the current model can still build.
+
+        Stored samples rejected via the narrow :class:`FitException` contract are
+        skipped (a warning is logged), so the list can be shorter than
+        ``sample_list``. Use ``valid_sample_instance_pairs`` when instances must
+        stay paired with their samples (e.g. weights).
         """
         return [
-            self.model.instance_from_vector(
-                sample.parameter_lists_for_paths(
-                    self.paths if sample.is_path_kwargs else self.names
-                ),
-            )
-            for sample in self.sample_list
+            instance for _, instance in self.valid_sample_instance_pairs()
         ]
 
     def valid_sample_instance_pairs(
@@ -405,19 +405,38 @@ class Samples(SamplesInterface, ABC):
         try:
             return self._instance_from_vector(vector)
         except exc.FitException as error:
-            last_error = error
+            return self._instance_from_next_valid_sample(
+                exclude_sample=sample,
+                sample_value=lambda candidate: candidate.log_likelihood,
+                quantity_name="likelihood",
+                last_error=error,
+            )
 
-        valid_sample_candidates = sorted(
-            (candidate for candidate in self.sample_list if candidate is not sample),
+    def _instance_from_next_valid_sample(
+        self,
+        exclude_sample: Sample,
+        sample_value,
+        quantity_name: str,
+        last_error: Exception,
+    ) -> ModelInstance:
+        """
+        The highest-``quantity_name`` stored sample, excluding ``exclude_sample``
+        (already rejected), that the current model can still reconstruct.
+
+        Raises ``SamplesException`` chained to the final rejection when no stored
+        sample survives.
+        """
+        candidates = sorted(
+            (candidate for candidate in self.sample_list if candidate is not exclude_sample),
             key=lambda candidate: (
                 float("-inf")
-                if np.isnan(candidate.log_likelihood)
-                else candidate.log_likelihood
+                if np.isnan(sample_value(candidate))
+                else sample_value(candidate)
             ),
             reverse=True,
         )
 
-        for candidate in valid_sample_candidates:
+        for candidate in candidates:
             candidate_vector = candidate.parameter_lists_for_paths(
                 self.paths if candidate.is_path_kwargs else self.names
             )
@@ -428,10 +447,11 @@ class Samples(SamplesInterface, ABC):
                 continue
 
             logger.warning(
-                "The maximum-likelihood stored sample can no longer be "
-                "reconstructed because the model rejected it with "
-                "FitException; using the highest-likelihood valid stored "
-                "sample instead."
+                "The maximum-%s stored sample can no longer be reconstructed "
+                "because the model rejected it with FitException; using the "
+                "highest-%s valid stored sample instead.",
+                quantity_name,
+                quantity_name,
             )
             return instance
 
@@ -439,6 +459,19 @@ class Samples(SamplesInterface, ABC):
             "None of the stored samples can be reconstructed as a valid model "
             "instance."
         ) from last_error
+
+    def _next_valid_instance(self, last_error: Exception) -> ModelInstance:
+        """
+        Recovery hook for the ``to_instance(recover="next_valid")`` policy,
+        currently used only by ``max_log_posterior``: substitute the
+        highest-posterior stored sample the current model can still build.
+        """
+        return self._instance_from_next_valid_sample(
+            exclude_sample=self.max_log_posterior_sample,
+            sample_value=lambda candidate: candidate.log_posterior,
+            quantity_name="posterior",
+            last_error=last_error,
+        )
 
     @property
     def max_log_posterior_sample(self) -> Sample:
@@ -459,14 +492,14 @@ class Samples(SamplesInterface, ABC):
             return 0
         return int(np.nanargmax(log_posterior_list))
 
-    @to_instance
+    @to_instance(recover="next_valid")
     def max_log_posterior(self) -> ModelInstance:
         """
         The parameters of the maximum log posterior sample of the `NonLinearSearch` returned as a model instance.
         """
         return self.parameter_lists[self.max_log_posterior_index]
 
-    @to_instance
+    @to_instance()
     def from_sample_index(self, sample_index: int) -> ModelInstance:
         """
         The parameters of an individual sample of the non-linear search, returned as a model instance.

--- a/autofit/non_linear/samples/summary.py
+++ b/autofit/non_linear/samples/summary.py
@@ -55,7 +55,7 @@ class SamplesSummary(SamplesInterface):
     def median_pdf_sample(self):
         return self._median_pdf_sample
 
-    @to_instance
+    @to_instance()
     def median_pdf(self, as_instance: bool = True) -> List[float]:
         """
         The parameters of the maximum log likelihood sample of the `NonLinearSearch` returned as a model instance or

--- a/autofit/non_linear/search/abstract_search.py
+++ b/autofit/non_linear/search/abstract_search.py
@@ -758,7 +758,7 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
         if mode == 1:
             try:
                 samples_summary.max_log_likelihood()
-            except exc.FitException as error:
+            except (exc.FitException, exc.SamplesException) as error:
                 samples = self._test_mode_samples_after_rejected_fit(
                     samples=samples,
                     error=error,
@@ -786,7 +786,7 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
     def _test_mode_samples_after_rejected_fit(
         self,
         samples: Samples,
-        error: exc.FitException,
+        error: Exception,
     ) -> Samples:
         """Build valid representative samples after a mode-1 rejected result.
 

--- a/autofit/non_linear/search/updater.py
+++ b/autofit/non_linear/search/updater.py
@@ -210,7 +210,7 @@ class SearchUpdater:
 
         try:
             instance = samples_summary.instance
-        except exc.FitException:
+        except (exc.FitException, exc.SamplesException):
             return samples, samples_summary, None, samples
 
         self._paths.save_samples_summary(samples_summary=samples_summary)

--- a/test_autofit/non_linear/samples/test_samples.py
+++ b/test_autofit/non_linear/samples/test_samples.py
@@ -205,6 +205,95 @@ def test__valid_sample_instance_pairs__does_not_hide_programming_errors():
         samples.valid_sample_instance_pairs()
 
 
+def test__instances__skips_historical_invalid_points():
+    samples = _guarded_samples(
+        parameter_lists=[[0.1], [0.9]],
+        log_likelihood_list=[2.0, 1.0],
+        weight_list=[0.5, 0.5],
+    )
+
+    instances = samples.instances
+
+    assert len(instances) == 1
+    assert instances[0].value == 0.9
+
+
+def test__max_log_posterior__historical_invalid_best_uses_next_valid_instance():
+    samples = _guarded_samples(
+        parameter_lists=[[0.1], [0.9]],
+        log_likelihood_list=[2.0, 1.0],
+        weight_list=[0.5, 0.5],
+    )
+
+    assert samples.max_log_posterior(as_instance=False) == [0.1]
+    assert samples.max_log_posterior().value == 0.9
+
+
+def test__max_log_posterior__all_invalid_fails_clearly():
+    samples = _guarded_samples(
+        parameter_lists=[[0.1], [0.2]],
+        log_likelihood_list=[2.0, 1.0],
+        weight_list=[0.5, 0.5],
+    )
+
+    with pytest.raises(
+        af.exc.SamplesException,
+        match="None of the stored samples can be reconstructed",
+    ):
+        samples.max_log_posterior()
+
+
+def test__from_sample_index__historical_invalid_raises_samples_exception():
+    samples = _guarded_samples(
+        parameter_lists=[[0.1], [0.9]],
+        log_likelihood_list=[2.0, 1.0],
+        weight_list=[0.5, 0.5],
+    )
+
+    assert samples.from_sample_index(sample_index=0, as_instance=False) == [0.1]
+    assert samples.from_sample_index(sample_index=1).value == 0.9
+
+    with pytest.raises(
+        af.exc.SamplesException,
+        match="from_sample_index",
+    ):
+        samples.from_sample_index(sample_index=0)
+
+
+def test__median_pdf__historical_invalid_raises_samples_exception():
+    samples = _guarded_samples(
+        parameter_lists=[[0.1], [0.2]],
+        log_likelihood_list=[2.0, 1.0],
+        weight_list=[0.5, 0.5],
+    )
+
+    assert samples.median_pdf(as_instance=False)[0] < 0.5
+
+    with pytest.raises(af.exc.SamplesException, match="median_pdf"):
+        samples.median_pdf()
+
+
+def test__to_instance__does_not_hide_programming_errors():
+    class _RaisesUnexpectedly:
+        def __init__(self, value):
+            raise ValueError("real bug")
+
+    model = af.Model(_RaisesUnexpectedly)
+    samples = af.SamplesPDF(
+        model=model,
+        sample_list=af.Sample.from_lists(
+            model=model,
+            parameter_lists=[[1.0]],
+            log_likelihood_list=[1.0],
+            log_prior_list=[0.0],
+            weight_list=[1.0],
+        ),
+    )
+
+    with pytest.raises(ValueError, match="real bug"):
+        samples.from_sample_index(sample_index=0)
+
+
 def test__draw_randomly_via_pdf__historical_invalid_draw_is_retried(monkeypatch):
     from autofit.non_linear.samples import pdf
 

--- a/test_autofit/non_linear/search/test_abstract_search.py
+++ b/test_autofit/non_linear/search/test_abstract_search.py
@@ -640,7 +640,9 @@ class TestReducedModeRejectedFinalSample:
             child.instance.galaxies.value == pytest.approx(0.9) for child in result
         )
 
-    def test__normal_mode__fitexception_still_propagates(self, monkeypatch):
+    def test__normal_mode__reconstruction_failure_raises_samples_exception(
+        self, monkeypatch
+    ):
         monkeypatch.delenv("PYAUTO_TEST_MODE", raising=False)
         model, rejected_samples = _model_and_rejected_samples(_RejectsLowValue)
 
@@ -649,8 +651,10 @@ class TestReducedModeRejectedFinalSample:
             analysis=af.m.MockAnalysis(),
         )
 
-        with pytest.raises(af.exc.FitException):
+        with pytest.raises(af.exc.SamplesException) as error:
             result.samples_summary.instance
+
+        assert isinstance(error.value.__cause__, af.exc.FitException)
 
     def test__test_mode_1__non_fitexception_still_propagates(self, monkeypatch):
         monkeypatch.setenv("PYAUTO_TEST_MODE", "1")


### PR DESCRIPTION
## Summary
Stored results written before a model's constructor validation tightened can hold samples the current model rejects via the narrow `FitException` contract. `Samples.instances` and the 15 methods sharing the `to_instance` decorator materialized those samples with no recovery, raising from deep inside instance construction (#1486; the workspace half shipped as PyAutoLabs/autogalaxy_workspace#210).

`to_instance` now takes a per-method recovery policy: `max_log_posterior` substitutes the highest-posterior valid stored sample (mirroring the #1466 `max_log_likelihood` guard, via a shared `_instance_from_next_valid_sample` helper); `from_sample_index` and the marginalized methods raise a typed `SamplesException` chained to the rejection, since a marginalized vector has no stored sample to substitute. `Samples.instances` skips rejected samples with a warning, reusing `valid_sample_instance_pairs` (#1470).

## API Changes
Reconstruction failures from `to_instance`-decorated methods (e.g. `from_sample_index`, `median_pdf`, `values_at_sigma`) now raise `autofit.exc.SamplesException` instead of letting `ModelParameterException` (a `ValueError`) escape; the original rejection is chained as `__cause__`. `max_log_posterior` recovers to the next valid stored sample instead of raising. `Samples.instances` skips unreconstructable stored samples instead of raising, so it can be shorter than `sample_list`.
See full details below.

## Test Plan
- [x] `pytest test_autofit` — 2011 passed, 16 skipped (full suite, in the task worktree)
- [x] New unit tests: `instances` skips invalid samples; `max_log_posterior` next-valid recovery and all-invalid failure; `from_sample_index` and `median_pdf` raise `SamplesException`; non-`FitException` constructor errors still propagate unwrapped

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- `Samples.instances` — skips stored samples the current model rejects via `FitException` (warning logged) instead of raising; the list can be shorter than `sample_list`. Use `valid_sample_instance_pairs` when instances must stay paired with their samples/weights.
- `Samples.max_log_posterior(as_instance=True)` — when the stored best sample is rejected, recovers to the highest-posterior valid stored sample (warning logged) instead of raising; raises `SamplesException` only when no stored sample is valid.
- All other `to_instance`-decorated methods (`from_sample_index`, `median_pdf`, `values_at_sigma`, `values_at_upper_sigma`, `values_at_lower_sigma`, `errors_at_sigma`, `errors_at_upper_sigma`, `errors_at_lower_sigma`, `error_magnitudes_at_sigma`, `offset_values_via_input_values`, `SamplesSummary.median_pdf`, `SamplesInterface.max_log_likelihood`) — a `FitException` during instance materialization now surfaces as `autofit.exc.SamplesException` (plain `Exception`) chained to the rejection, instead of `ModelParameterException` (a `ValueError`). The `as_instance=False` and `as_dict=True` paths are unchanged.
- `to_instance` — now a decorator factory taking a `recover` policy: use `@to_instance()` or `@to_instance(recover="next_valid")`; bare `@to_instance` no longer works (internal decorator; no downstream PyAuto repo imports it).

### Migration
- Before: `try: samples.from_sample_index(i) except ValueError: ...`
- After: `try: samples.from_sample_index(i) except af.exc.SamplesException: ...`

</details>

Generated by the PyAutoLabs agent workflow.
