### PR TITLE
test: skip-if-missing guards for the [optional] sampler/astropy tests (#1511)

### DIFF
--- a/test_autofit/aggregator/summary_files/test_aggregate_fits.py
+++ b/test_autofit/aggregator/summary_files/test_aggregate_fits.py
@@ -1,8 +1,20 @@
+import importlib.util
 from enum import Enum
 import pytest
 
 import autofit as af
 from pathlib import Path
+
+
+# `astropy` ships via the `[optional]` extras. Envs installed without them
+# must skip rather than fail with `No module named 'astropy'`.
+requires_astropy = pytest.mark.skipif(
+    importlib.util.find_spec("astropy") is None,
+    reason="requires astropy (installed via the [optional] extras)",
+)
+
+
+pytestmark = requires_astropy
 
 
 class FITSFit(Enum):

--- a/test_autofit/aggregator/test_child_analysis.py
+++ b/test_autofit/aggregator/test_child_analysis.py
@@ -1,3 +1,4 @@
+import importlib.util
 from pathlib import Path
 
 import pytest
@@ -5,6 +6,14 @@ import pytest
 from autofit import SearchOutput
 from autofit.aggregator import Aggregator
 import autofit as af
+
+
+# `astropy` ships via the `[optional]` extras. Envs installed without them
+# must skip rather than fail with `No module named 'astropy'`.
+requires_astropy = pytest.mark.skipif(
+    importlib.util.find_spec("astropy") is None,
+    reason="requires astropy (installed via the [optional] extras)",
+)
 
 
 @pytest.fixture(name="directory")
@@ -50,12 +59,14 @@ def make_aggregator(session, directory):
     return aggregator
 
 
+@requires_astropy
 def test_database_aggregator(aggregator):
     assert list(aggregator.child_values("example")) == [
         ["hello world", "hello world"],
     ]
 
 
+@requires_astropy
 def test_child_values(aggregator):
     fit, *_ = list(aggregator)
     assert fit.child_values("example") == ["hello world", "hello world"]

--- a/test_autofit/aggregator/test_reference.py
+++ b/test_autofit/aggregator/test_reference.py
@@ -1,3 +1,4 @@
+import importlib.util
 import os
 
 import pytest
@@ -7,6 +8,14 @@ from autofit.aggregator import Aggregator
 from pathlib import Path
 import autofit as af
 from autofit.database.aggregator.info import Info
+
+
+# `astropy` ships via the `[optional]` extras. Envs installed without them
+# must skip rather than fail with `No module named 'astropy'`.
+requires_astropy = pytest.mark.skipif(
+    importlib.util.find_spec("astropy") is None,
+    reason="requires astropy (installed via the [optional] extras)",
+)
 
 
 @pytest.fixture(name="directory")
@@ -56,6 +65,7 @@ def database_aggregator(
     return aggregator
 
 
+@requires_astropy
 def test_database(database_aggregator):
     fit = list(database_aggregator)[0]
     model = fit.model
@@ -67,20 +77,24 @@ def make_info(database_aggregator):
     return Info(database_aggregator.session)
 
 
+@requires_astropy
 def test_query_fits(info):
     fits = info.fits
     assert len(info.fits) == 3
     assert fits[0].total_parameters == 4
 
 
+@requires_astropy
 def test_headers_and_rows(info):
     assert len(info.headers) == len(info.rows[0])
 
 
+@requires_astropy
 def test_info_path(info, output_directory):
     assert info.path == output_directory / "database.info"
 
 
+@requires_astropy
 def test_database_info(
     database_aggregator,
     output_directory,

--- a/test_autofit/aggregator/test_scrape.py
+++ b/test_autofit/aggregator/test_scrape.py
@@ -1,7 +1,17 @@
+import importlib.util
+
 import pytest
 
 from autofit import SearchOutput
 from autofit.database.aggregator.scrape import _add_files
+
+
+# `astropy` ships via the `[optional]` extras. Envs installed without them
+# must skip rather than fail with `No module named 'astropy'`.
+requires_astropy = pytest.mark.skipif(
+    importlib.util.find_spec("astropy") is None,
+    reason="requires astropy (installed via the [optional] extras)",
+)
 
 
 class MockFit:
@@ -36,6 +46,7 @@ def make_fit(directory):
     return fit
 
 
+@requires_astropy
 def test_add_files(fit):
     assert fit.jsons["model"] == {
         "class_path": "autofit.example.model.Gaussian",
@@ -63,6 +74,7 @@ def test_add_files(fit):
     }
 
 
+@requires_astropy
 def test_add_recursive(fit):
     assert fit.jsons["directory.example"] == {
         "hello": "world",

--- a/test_autofit/database/test_file_types.py
+++ b/test_autofit/database/test_file_types.py
@@ -3,6 +3,14 @@ import pytest
 
 from autofit.database import JSON
 from autofit import database as db
+
+# `astropy` ships via the `[optional]` extras; skip the module there
+# rather than fail collection with `No module named 'astropy'`.
+pytest.importorskip(
+    "astropy",
+    reason="requires astropy (installed via the [optional] extras)",
+)
+
 from astropy.io import fits
 
 

--- a/test_autofit/non_linear/paths/test_save_and_load.py
+++ b/test_autofit/non_linear/paths/test_save_and_load.py
@@ -1,8 +1,16 @@
 import numpy as np
 import pytest
-from astropy.io import fits
 
 import autofit as af
+
+# `astropy` ships via the `[optional]` extras; skip the module there
+# rather than fail collection with `No module named 'astropy'`.
+pytest.importorskip(
+    "astropy",
+    reason="requires astropy (installed via the [optional] extras)",
+)
+
+from astropy.io import fits
 
 
 @pytest.fixture(name="dictionary")

--- a/test_autofit/non_linear/search/nest/test_nautilus.py
+++ b/test_autofit/non_linear/search/nest/test_nautilus.py
@@ -1,9 +1,20 @@
+import importlib.util
+
 import numpy as np
 import pytest
 
 import autofit as af
 
 pytestmark = pytest.mark.filterwarnings("ignore::FutureWarning")
+
+# The regression test below runs a real `search.fit`, which imports the
+# `nautilus` sampler; it ships via the `[optional]` extras. Envs installed
+# without those extras must skip rather than fail with
+# `No module named 'nautilus'` — the other tests here only read config.
+requires_nautilus = pytest.mark.skipif(
+    importlib.util.find_spec("nautilus") is None,
+    reason="requires nautilus-sampler (installed via the [optional] extras)",
+)
 
 
 def test__explicit_params():
@@ -54,6 +65,7 @@ def test__test_mode():
     assert search.n_like_max == 1
 
 
+@requires_nautilus
 def test__single_core_builds_no_pool(monkeypatch):
     """
     number_of_cores=1 must not construct a multiprocessing pool: nautilus


### PR DESCRIPTION
Closes #1511.

## What

Adds skip-if-missing guards to the tests that need `[optional]`-extra packages
(`nautilus-sampler`, `astropy`), following the pattern already used by
`test_blackjax_nuts.py:14`, `nest/nss/test_search.py:20` and `test_fork_context.py:31`.

| file | guard |
|---|---|
| `non_linear/search/nest/test_nautilus.py` | `requires_nautilus` on `test__single_core_builds_no_pool` (the only test there that runs a real `fit`) |
| `database/test_file_types.py` | `pytest.importorskip("astropy")` — module-level import |
| `non_linear/paths/test_save_and_load.py` | `pytest.importorskip("astropy")` — module-level import |
| `aggregator/summary_files/test_aggregate_fits.py` | `pytestmark = requires_astropy` — every test is FITS |
| `aggregator/test_reference.py` | `requires_astropy` on the 5 database/info tests |
| `aggregator/test_scrape.py` | `requires_astropy` on the 2 `_add_files` tests |
| `aggregator/test_child_analysis.py` | `requires_astropy` on the 2 aggregator tests |

Tests only — no `autofit/` source is touched, so no behaviour or API change.

## Why

`test__single_core_builds_no_pool` runs a real `search.fit`, which reaches
`from nautilus import Sampler` (`nautilus/search.py:238`). `nautilus-sampler` ships only
in the `[optional]` extra, and the test had no guard — so it hard-failed with
`ModuleNotFoundError` in any env without those extras, while passing in CI (which does
install `[optional]`).

The cost was not the failure itself but the misreading: that one test has been reported
as "pre-existing on clean `main`" in at least six task records since 2026-08-16, each
one spending a control run to re-disprove it. `astropy` was the same story — two
collection errors and nine aggregator errors, all missing-dependency.

## Verification

Three envs, all on this branch:

| env | result |
|---|---|
| no extras at all | nautilus test **skips** with its reason — `3 passed, 1 skipped` |
| no `astropy` | `1985 passed, 33 skipped, 0 failed, 0 errors` (before: 2 collection errors, then 4 failed / 9 errors) |
| full `[optional]` extras — the CI env | `2024 passed, 3 skipped` |

That last line is **identical** to CI on main
([run 32546158666](https://github.com/PyAutoLabs/PyAutoFit/actions/runs/32546158666):
2024 passed, 3 skipped), which is the point — the guards are inert wherever the extras
are installed, so nothing that runs today stops running and no coverage is lost.

Baseline for the first two rows was measured on untouched `main` @ `a639226` in the same
venv, before any edit.

## Note on formatting

`black` reports pre-existing reformat candidates in several of these files (e.g. a long
`raise AssertionError(...)` in `test_nautilus.py` that predates this branch). Left alone
— formatting is advisory and not gated per `AGENTS.md`, and reformatting would bury a
79-line diff in unrelated churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F1uQdHt11NPBc5cXA5cvme

---
_Generated by [Claude Code](https://claude.ai/code/session_01F1uQdHt11NPBc5cXA5cvme)_