### PR TITLE
Dump the compile traceback before the runner kills the process

### DIFF
--- a/autofit/non_linear/jax_compile.py
+++ b/autofit/non_linear/jax_compile.py
@@ -9,10 +9,15 @@ logger = logging.getLogger(__name__)
 # How often a compile that is still running reports that it is still alive.
 DEFAULT_HEARTBEAT_SECONDS = 30.0
 
-# How long a first compile may run under CI before it dumps its own traceback.
-# Off by default off-CI: an interactive user watching a slow compile does not
-# want a traceback on stderr, they want the heartbeat above.
-DEFAULT_CI_DUMP_SECONDS = 300.0
+# How long a first compile may run under CI before it dumps its own traceback,
+# when the runner has not told us its own cap. Off by default off-CI: an
+# interactive user watching a slow compile does not want a traceback on stderr,
+# they want the heartbeat above.
+DEFAULT_CI_DUMP_SECONDS = 240.0
+
+# Fraction of the runner's per-script cap at which to dump. The dump is only
+# ever useful STRICTLY BEFORE the kill -- see `dump_traceback_seconds`.
+DUMP_FRACTION_OF_CAP = 0.8
 
 
 def _env_seconds(name, default):
@@ -60,8 +65,22 @@ def dump_traceback_seconds():
     runner -- the alternative, threading an environment variable through each
     workspace's `config/build/env_vars_*.yaml`, is more repos touched for the
     same effect, and the workspace scripts are user-facing documentation.
+
+    Under CI the default is derived from `BUILD_SCRIPT_TIMEOUT`, the per-script
+    cap the workspace runners and PyAutoHands both enforce. **A dump scheduled
+    at or after that cap never happens**: the runner SIGKILLs the process group
+    on expiry, and a killed process writes no traceback. The first CI use of
+    this watchdog hit exactly that -- a flat 300s default against a 300s smoke
+    cap produced heartbeats from 20 stalled runs and not one stack
+    (autolens_workspace_test#271). Dumping at a fraction of the cap leaves the
+    traceback time to reach stderr before the kill lands.
     """
-    default = DEFAULT_CI_DUMP_SECONDS if os.environ.get("CI") else 0.0
+    if not os.environ.get("CI"):
+        default = 0.0
+    else:
+        cap = _env_seconds("BUILD_SCRIPT_TIMEOUT", 0.0)
+        default = cap * DUMP_FRACTION_OF_CAP if cap > 0 else DEFAULT_CI_DUMP_SECONDS
+
     return _env_seconds("PYAUTOFIT_JAX_COMPILE_DUMP_SECS", default)
 
 

--- a/test_autofit/non_linear/test_jax_compile.py
+++ b/test_autofit/non_linear/test_jax_compile.py
@@ -256,6 +256,7 @@ def test_the_heartbeat_interval_comes_from_the_environment(monkeypatch):
 
 def test_the_traceback_dump_defaults_on_under_ci_and_off_elsewhere(monkeypatch):
     monkeypatch.delenv("PYAUTOFIT_JAX_COMPILE_DUMP_SECS", raising=False)
+    monkeypatch.delenv("BUILD_SCRIPT_TIMEOUT", raising=False)
 
     monkeypatch.delenv("CI", raising=False)
     assert jax_compile.dump_traceback_seconds() == 0.0
@@ -270,6 +271,45 @@ def test_the_traceback_dump_defaults_on_under_ci_and_off_elsewhere(monkeypatch):
 
     monkeypatch.setenv("PYAUTOFIT_JAX_COMPILE_DUMP_SECS", "0")
     assert jax_compile.dump_traceback_seconds() == 0.0
+
+
+def test_the_dump_lands_strictly_before_the_runner_kills_the_process(monkeypatch):
+    monkeypatch.delenv("PYAUTOFIT_JAX_COMPILE_DUMP_SECS", raising=False)
+    monkeypatch.setenv("CI", "true")
+
+    # The defect this pins (autolens_workspace_test#271): a flat 300s default
+    # against a 300s smoke cap meant the runner's SIGKILL always beat the dump,
+    # so 20 stalled CI runs produced heartbeats and not one traceback. A killed
+    # process writes no stack, so the threshold MUST be under the cap.
+    for cap in ("300", "1800", "60"):
+        monkeypatch.setenv("BUILD_SCRIPT_TIMEOUT", cap)
+        assert jax_compile.dump_traceback_seconds() < float(cap)
+
+    monkeypatch.setenv("BUILD_SCRIPT_TIMEOUT", "300")
+    assert jax_compile.dump_traceback_seconds() == 240.0
+
+    monkeypatch.setenv("BUILD_SCRIPT_TIMEOUT", "1800")
+    assert jax_compile.dump_traceback_seconds() == 1440.0
+
+
+def test_an_unusable_runner_cap_falls_back_to_the_flat_ci_default(monkeypatch):
+    monkeypatch.delenv("PYAUTOFIT_JAX_COMPILE_DUMP_SECS", raising=False)
+    monkeypatch.setenv("CI", "true")
+
+    # No cap advertised, or a meaningless one: there is nothing to derive from,
+    # so use the flat default rather than computing a fraction of zero (which
+    # would silently disable the dump).
+    for cap in ("", "0", "not-a-number"):
+        monkeypatch.setenv("BUILD_SCRIPT_TIMEOUT", cap)
+        assert jax_compile.dump_traceback_seconds() == jax_compile.DEFAULT_CI_DUMP_SECONDS
+
+
+def test_an_explicit_dump_threshold_still_wins_over_the_derived_one(monkeypatch):
+    monkeypatch.setenv("CI", "true")
+    monkeypatch.setenv("BUILD_SCRIPT_TIMEOUT", "1800")
+    monkeypatch.setenv("PYAUTOFIT_JAX_COMPILE_DUMP_SECS", "90")
+
+    assert jax_compile.dump_traceback_seconds() == 90.0
 
 
 def test_a_malformed_interval_falls_back_rather_than_raising(monkeypatch):


### PR DESCRIPTION
Fixes a defect in #1517, found by the measurement #1517 existed to enable. Part of the `jax-compile-stall` epic; evidence in autolens_workspace_test#271.

## The bug

The `faulthandler` watchdog shipped in #1517 **never fired**. Its CI default was a flat `300.0` seconds — and the workspace smoke cap is *also* 300s. The dump timer and the runner's kill timer therefore raced, and the kill won every time. A SIGKILLed process writes no traceback.

This is not theoretical. The first CI use of the watchdog was a re-timing sweep over four quarantined JAX scripts, 5 repeats × 2 Python versions across two repos. **20 of those runs stalled to the cap. All 20 produced heartbeats. None produced a stack:**

```
21:13:50 ... JAX jit compiling vectorized (vmap) likelihood function...
21:14:20 ... JAX jit still compiling ... 30s elapsed...
   ⋮
21:18:20 ... JAX jit still compiling ... 270s elapsed...
##[error]TIMEOUT after 300s — killed the process group.
```

So #1517 delivered the half that proves a stalled run is *alive*, and silently dropped the half that says *where it is stuck* — which is the half phase 3 of the epic actually needs.

## The fix

Derive the CI default from `BUILD_SCRIPT_TIMEOUT`, the per-script cap that the workspace runners and PyAutoHands both enforce, at 80% of it:

| `BUILD_SCRIPT_TIMEOUT` | Dump at |
|---|---|
| `300` (smoke) | 240s |
| `1800` (release) | 1440s |
| unset / `0` / malformed | 240s flat fallback |

The fallback matters: computing a fraction of an absent cap would yield `0`, which *disables* the dump — the same silent no-op in a new disguise. An explicit `PYAUTOFIT_JAX_COMPILE_DUMP_SECS` still overrides everything.

## Verification

Full suite **2011 passed, 34 skipped**. `test_jax_compile.py` 19 passed, 4 new — including one that pins the invariant directly rather than testing today's numbers:

```python
for cap in ("300", "1800", "60"):
    monkeypatch.setenv("BUILD_SCRIPT_TIMEOUT", cap)
    assert jax_compile.dump_traceback_seconds() < float(cap)
```

End-to-end, a simulated stall with a 10s cap — the dump now lands at 8s, before the kill at 12s:

```
21:31:37 ... JAX jit still compiling ... 3s elapsed...
21:31:40 ... JAX jit still compiling ... 6s elapsed...
Timeout (0:00:08)!
  File ".../autofit/non_linear/jax_compile.py", line 254 in wrapper
[exit 137 — SIGKILL]
```

Same scenario before this change wrote no traceback at all.

## Note on the original review

Nothing in #1517's tests could have caught this. They monkeypatched `faulthandler` and asserted the timer was armed and cancelled — which it was, correctly. The failure lives in the relationship between two independently-correct timeouts owned by different repos, and only a real run under a real cap exposes it. Hence the new test asserting the *relationship* rather than the value.

---
_Generated by [Claude Code](https://claude.ai/code/session_015qk7hoavMnFyPtW4toYn8K)_