### PR TITLE
fix: TEST_MODE bypass must evaluate a point the model's assertions accept

### DIFF
--- a/autofit/non_linear/search/abstract_search.py
+++ b/autofit/non_linear/search/abstract_search.py
@@ -11,7 +11,7 @@ from abc import ABC, abstractmethod
 from collections import Counter
 from functools import wraps
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional, Union, Tuple, List, Dict
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union, Tuple, List, Dict
 
 import psutil
 
@@ -783,6 +783,96 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
 
         return result
 
+    def _test_mode_valid_parameter_vector(
+        self,
+        model: AbstractPriorModel,
+        failure_prefix: str,
+        validate: Optional[Callable[[List[float]], Any]] = None,
+    ) -> Tuple[List[float], Any]:
+        """The first deterministically-drawn parameter vector the model accepts.
+
+        Test mode has no sampler, so it evaluates the model at a point it picks
+        itself — the prior medians.  A model whose components share priors and
+        carry an ordering assertion (``trap_0.release_timescale <
+        trap_1.release_timescale``, the standard idiom for breaking exchange
+        degeneracy) ties *exactly* there, so ``check_assertions`` rejects the
+        medians with :class:`FitException`.  A production search absorbs that by
+        resampling, and test mode must do the same rather than hard-fail on an
+        artifact of its own choice of point.
+
+        Try the prior medians first, then a deterministic sequence of prior
+        draws, returning the first candidate ``validate`` accepts.  The fixed
+        seed keeps smoke runs reproducible without touching the application's
+        global random state.
+
+        Parameters
+        ----------
+        model
+            The model the vector must be valid for.
+        failure_prefix
+            Opening of the :class:`FitException` message raised once the attempt
+            budget is spent; the attempt count is appended to it.
+        validate
+            Called with each candidate vector.  Raising `FitException` rejects
+            that candidate and moves on to the next draw; the return value is
+            handed back alongside the accepted vector, so a caller that must
+            build something in order to validate it does not build it twice.
+            Defaults to instantiating the vector.
+
+        Returns
+        -------
+        The accepted parameter vector, and whatever ``validate`` returned for it.
+
+        Raises
+        ------
+        FitException
+            If no candidate is accepted within
+            ``TEST_MODE_REPRESENTATIVE_MAX_ATTEMPTS`` attempts, chained to the
+            final rejection.
+        """
+        if validate is None:
+
+            def validate(candidate: List[float]):
+                return model.instance_from_vector(vector=candidate)
+
+        rng = np.random.default_rng(seed=0)
+        last_error = None
+
+        for attempt in range(TEST_MODE_REPRESENTATIVE_MAX_ATTEMPTS):
+            unit_vector = (
+                [0.5] * model.prior_count
+                if attempt == 0
+                else rng.random(model.prior_count).tolist()
+            )
+
+            try:
+                parameter_vector = [
+                    float(value)
+                    for value in model.vector_from_unit_vector(
+                        unit_vector=unit_vector,
+                    )
+                ]
+                validated = validate(parameter_vector)
+            except exc.FitException as candidate_error:
+                last_error = candidate_error
+                continue
+
+            if attempt > 0:
+                logger.warning(
+                    "TEST MODE: the prior medians are not a valid model "
+                    f"instance ({last_error.__cause__ or last_error!r}); using "
+                    f"deterministic prior draw {attempt} instead. A model whose "
+                    "components share priors and carry an ordering assertion "
+                    "ties at its medians, which a real search resamples past."
+                )
+
+            return parameter_vector, validated
+
+        raise exc.FitException(
+            f"{failure_prefix} after "
+            f"{TEST_MODE_REPRESENTATIVE_MAX_ATTEMPTS} attempts."
+        ) from last_error
+
     def _test_mode_samples_after_rejected_fit(
         self,
         samples: Samples,
@@ -808,56 +898,44 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
             "a valid representative sample for result construction."
         )
 
-        rng = np.random.default_rng(seed=0)
-        last_error = error
         model = samples.model
 
-        for attempt in range(TEST_MODE_REPRESENTATIVE_MAX_ATTEMPTS):
-            unit_vector = (
-                [0.5] * model.prior_count
-                if attempt == 0
-                else rng.random(model.prior_count).tolist()
+        def validate(parameter_vector: List[float]):
+            """Every synthetic sample, not just the first, must reconstruct."""
+            sample_list = self._build_fake_samples(
+                model=model,
+                parameter_vector=parameter_vector,
+                log_likelihood=-1.0e99,
             )
 
-            try:
-                parameter_vector = [
-                    float(value)
-                    for value in model.vector_from_unit_vector(
-                        unit_vector=unit_vector,
-                    )
-                ]
-                sample_list = self._build_fake_samples(
-                    model=model,
-                    parameter_vector=parameter_vector,
-                    log_likelihood=-1.0e99,
+            for sample in sample_list:
+                model.instance_from_vector(
+                    vector=sample.parameter_lists_for_model(model)
                 )
 
-                for sample in sample_list:
-                    model.instance_from_vector(
-                        vector=sample.parameter_lists_for_model(model)
-                    )
-            except exc.FitException as candidate_error:
-                last_error = candidate_error
-                continue
+            return sample_list
 
-            samples_info = {
-                **(samples.samples_info or {}),
-                "total_iterations": 1,
-                "time": 0.0,
-                "log_evidence": -1.0e99,
-            }
-            samples_info.update(self._test_mode_samples_info())
+        _, sample_list = self._test_mode_valid_parameter_vector(
+            model=model,
+            failure_prefix=(
+                "TEST MODE 1 could not construct a valid representative result"
+            ),
+            validate=validate,
+        )
 
-            return samples.from_list_info_and_model(
-                model=model,
-                sample_list=sample_list,
-                samples_info=samples_info,
-            )
+        samples_info = {
+            **(samples.samples_info or {}),
+            "total_iterations": 1,
+            "time": 0.0,
+            "log_evidence": -1.0e99,
+        }
+        samples_info.update(self._test_mode_samples_info())
 
-        raise exc.FitException(
-            "TEST MODE 1 could not construct a valid representative result "
-            f"after {TEST_MODE_REPRESENTATIVE_MAX_ATTEMPTS} attempts."
-        ) from last_error
+        return samples.from_list_info_and_model(
+            model=model,
+            sample_list=sample_list,
+            samples_info=samples_info,
+        )
 
     def result_via_completed_fit(
         self,
@@ -996,16 +1074,25 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
 
         model.freeze()
 
-        unit_vector = [0.5] * model.prior_count
-        parameter_vector = [
-            float(v) for v in model.vector_from_unit_vector(
-                unit_vector=unit_vector,
-            )
-        ]
+        # The bypass has no sampler, so it chooses its own evaluation point and
+        # must choose one the model accepts. A model whose components share
+        # priors and carry an ordering assertion ties exactly at the prior
+        # medians, and `check_assertions` rejects that tie with `FitException`.
+        # The vector chosen here is also the one written into the fake samples
+        # below, so picking a valid one is what keeps
+        # `result.max_log_likelihood_instance` reconstructible — which is why
+        # mode 3 needs this too, not just mode 2's likelihood call
+        # (PyAutoFit #1519).
+        parameter_vector, instance = self._test_mode_valid_parameter_vector(
+            model=model,
+            failure_prefix=(
+                "TEST MODE could not find a parameter vector satisfying the "
+                "model's assertions"
+            ),
+        )
 
         log_likelihood = -1.0e99
         if call_likelihood:
-            instance = model.instance_from_vector(vector=parameter_vector)
             try:
                 log_likelihood = float(
                     analysis.log_likelihood_function(instance)

--- a/test_autofit/non_linear/search/test_abstract_search.py
+++ b/test_autofit/non_linear/search/test_abstract_search.py
@@ -476,6 +476,125 @@ class TestBypassToleratesFitException:
             search.fit(model=af.Model(af.m.MockClassx2), analysis=_BrokenAnalysis())
 
 
+class _ConstantLikelihoodAnalysis(af.m.MockAnalysis):
+    """`MockAnalysis` maps its likelihood over the model, which returns a list
+    for the collections below; the bypass wants a single float."""
+
+    def log_likelihood_function(self, instance):
+        return 1.0
+
+
+class _Ordered:
+    """A one-parameter component; two of them plus an ordering assertion is the
+    standard idiom for breaking an exchange degeneracy."""
+
+    def __init__(self, value=1.0):
+        self.value = value
+
+
+def _tied_assertion_model():
+    """Identical priors either side of an ordering assertion — so the two
+    parameters tie *exactly* at the prior medians the bypass evaluates at."""
+    model = af.Collection(
+        first=af.Model(_Ordered, value=af.UniformPrior(0.1, 10.0)),
+        second=af.Model(_Ordered, value=af.UniformPrior(0.1, 10.0)),
+    )
+    model.add_assertion(model.first.value < model.second.value)
+    return model
+
+
+def _impossible_assertion_model():
+    """Disjoint priors ordered the wrong way round: no draw can satisfy it."""
+    model = af.Collection(
+        first=af.Model(_Ordered, value=af.UniformPrior(5.0, 10.0)),
+        second=af.Model(_Ordered, value=af.UniformPrior(0.1, 1.0)),
+    )
+    model.add_assertion(model.first.value < model.second.value)
+    return model
+
+
+class TestBypassToleratesAssertionTies:
+    """
+    The bypass has no sampler, so it evaluates the model at a point it picks
+    itself — the prior medians. A model whose components share priors and carry
+    an ordering assertion (e.g. PyAutoCTI trap models with
+    `trap_0.release_timescale < trap_1.release_timescale`) ties exactly there,
+    so `check_assertions` rejects it and the run hard-fails on an artifact of
+    the bypass's own choice of point. A real search resamples past this
+    (PyAutoFit #1519).
+
+    Mode 3 is affected as well as mode 2. It never calls the likelihood, but the
+    vector the bypass *stores* is the one `result.max_log_likelihood_instance`
+    reconstructs, and `SamplesSummary.max_log_likelihood` raises rather than
+    falling back to another stored sample — every fake sample is the same point
+    scaled uniformly, which preserves the tie anyway.
+    """
+
+    @pytest.mark.parametrize("mode", ["2", "3"])
+    def test__tied_assertion__fit_completes_and_result_instance_reconstructs(
+        self, monkeypatch, mode
+    ):
+        monkeypatch.setenv("PYAUTO_TEST_MODE", mode)
+
+        result = af.DynestyStatic(
+            name=f"bypass_assertion_tie_{mode}",
+            unique_tag=f"bypass_assertion_tie_{mode}_test",
+        ).fit(model=_tied_assertion_model(), analysis=_ConstantLikelihoodAnalysis())
+
+        # The result must be constructible, not just the fit survivable: the
+        # stored vector is re-instantiated here, assertions and all.
+        instance = result.max_log_likelihood_instance
+
+        assert instance.first.value < instance.second.value
+
+    def test__tied_assertion__chosen_point_is_deterministic_across_modes(
+        self, monkeypatch
+    ):
+        values = []
+
+        for mode in ("2", "3"):
+            monkeypatch.setenv("PYAUTO_TEST_MODE", mode)
+            result = af.DynestyStatic(
+                name=f"bypass_assertion_seed_{mode}",
+                unique_tag=f"bypass_assertion_seed_{mode}_test",
+            ).fit(model=_tied_assertion_model(), analysis=_ConstantLikelihoodAnalysis())
+            instance = result.max_log_likelihood_instance
+            values.append([instance.first.value, instance.second.value])
+
+        # A fixed seed, so smoke runs stay reproducible and the two modes agree.
+        assert values[0] == pytest.approx(values[1])
+
+    @pytest.mark.parametrize("mode", ["2", "3"])
+    def test__unsatisfiable_assertion__bounded_failure_is_clear(
+        self, monkeypatch, mode
+    ):
+        from autofit.non_linear.search import abstract_search
+
+        monkeypatch.setenv("PYAUTO_TEST_MODE", mode)
+        monkeypatch.setattr(
+            abstract_search,
+            "TEST_MODE_REPRESENTATIVE_MAX_ATTEMPTS",
+            2,
+        )
+
+        with pytest.raises(
+            af.exc.FitException,
+            match=(
+                "could not find a parameter vector satisfying the model's "
+                "assertions after 2 attempts"
+            ),
+        ) as error:
+            af.DynestyStatic(
+                name=f"bypass_assertion_impossible_{mode}",
+                unique_tag=f"bypass_assertion_impossible_{mode}_test",
+            ).fit(
+                model=_impossible_assertion_model(),
+                analysis=_ConstantLikelihoodAnalysis(),
+            )
+
+        assert isinstance(error.value.__cause__, af.exc.FitException)
+
+
 class _RejectsLowValue:
     def __init__(self, value):
         if value < 0.75:


### PR DESCRIPTION
## Summary

The `PYAUTO_TEST_MODE=2/3` bypass has no sampler, so it picks its own evaluation point: the prior medians. A model whose components share priors and carry an ordering assertion — the standard idiom for breaking exchange degeneracy, e.g. PyAutoCTI trap models with `trap_0.release_timescale < trap_1.release_timescale` — ties *exactly* there, so `check_assertions` rejects it with `FitException` and the run hard-fails on an artifact of the bypass's own choice of point. A real search absorbs this by resampling.

The failure had **three** sites, not the one reported:

1. `_fit_bypass_test_mode` instantiated the model *outside* the `try` that catches `FitException`, so the assertion rejection escaped that guard.
2. Every fake sample is the median vector scaled uniformly (1.001 / 0.999 / 1.002), and a uniform scale preserves an ordering tie — so no stored sample was reconstructible either.
3. `SamplesSummary.max_log_likelihood` is `@to_instance()` with `recover="raise"` (it extends `SamplesInterface` directly, so it does not inherit `Samples`' next-valid recovery), so `result.max_log_likelihood_instance` raised `SamplesException`; `Result.instance` catches only `AttributeError`.

Consequence: **`PYAUTO_TEST_MODE=3` was broken too**, even though it never calls the likelihood — it survived the fit and died at the first `result.max_log_likelihood_instance`.

This fixes all three at the source by making the bypass evaluate *and store* a vector the model accepts. `_test_mode_valid_parameter_vector` factors out the deterministic search the `TEST_MODE=1` recovery path already used — prior medians first, then `np.random.default_rng(seed=0)` prior draws, each candidate validated — and both call sites now share it. The fixed seed keeps smoke runs reproducible without touching global random state.

Mode 1's stricter per-sample validation is preserved via the helper's `validate` hook, so its behaviour and its exact failure message are unchanged. The likelihood-call guard is untouched: a pathological *likelihood* is a different contract from an invalid *instance*, and both are now covered.

Unblocks `autocti_workspace` smoke coverage of `modeling/start_here.py`-class scripts (CTI resurrection epic, Phase 5), which currently documents this artifact in its `AGENTS.md` as a workaround.

## API Changes

None — internal changes only. No public symbol is added, removed, renamed, or re-signatured; `_test_mode_valid_parameter_vector` is private.

There is one **observable behaviour change** worth a reviewer's eye: the bypass now instantiates the model once under `PYAUTO_TEST_MODE=3` as well as `=2` (previously mode 3 did no instantiation at all). That is what makes the stored vector valid. It means a model whose constructor raises a *non*-`FitException` at the medians now fails at fit time rather than at result-access time — the same failure, surfaced earlier. Cost is one instantiation, not one per sample: the 50,000-sample bypass test is unaffected.

See full details below.

## Test Plan

- [x] Reproduced on clean `main` first — mode 2: `FitException: 1 assertions failed!` during the fit; mode 3: fit completes, then `SamplesException` at `result.max_log_likelihood_instance`.
- [x] After the fix both modes complete and reconstruct the instance, at the **same** parameter vector (`8.1513753680827, 9.13628021504944`) — confirming determinism across modes.
- [x] `pytest test_autofit/non_linear/search/test_abstract_search.py` — **36 passed** (31 before, 5 new).
- [x] All 5 new tests **fail against the un-patched source** and pass with it, at both modes — verified by reverting only the source file.
- [x] Full suite `pytest test_autofit` — **2016 passed, 34 skipped, 0 failed**.

New regression coverage in `TestBypassToleratesAssertionTies`: a tied ordering assertion completing the fit *and* reconstructing `result.max_log_likelihood_instance` at modes 2 and 3; cross-mode determinism of the chosen point; and an unsatisfiable assertion still failing cleanly within the attempt budget, chained to the final rejection.

<details>
<summary>Full API Changes (for automation &amp; release notes)</summary>

### Removed

None.

### Added

None public. Internal: `NonLinearSearch._test_mode_valid_parameter_vector(model, failure_prefix, validate=None)` — returns `(parameter_vector, validated)` for the first deterministically-drawn vector the model accepts; raises `FitException` chained to the final rejection once `TEST_MODE_REPRESENTATIVE_MAX_ATTEMPTS` is spent.

### Renamed

None. `TEST_MODE_REPRESENTATIVE_MAX_ATTEMPTS` keeps its name — it is monkeypatched by an existing test.

### Changed Signature

None.

### Changed Behaviour

- `PYAUTO_TEST_MODE=2` — a model whose assertions reject the prior medians no longer raises during the fit; the bypass evaluates the first accepted deterministic draw instead and logs a WARNING naming the rejection and the draw index.
- `PYAUTO_TEST_MODE=3` — same point selection, so the stored samples are reconstructible and `result.max_log_likelihood_instance` no longer raises `SamplesException`. This mode now instantiates the model once (see above).
- `PYAUTO_TEST_MODE=1` — unchanged, including the exact `"TEST MODE 1 could not construct a valid representative result after N attempts"` message and the per-sample validation.

### Migration

None required.

</details>

## Gate

`pyauto-heart` is not reachable from this environment (`pyauto-brain vitals` → `'pyauto-heart' not found on PATH`), so the readiness gate ran in the documented fallback form (`PyAutoBrain/skills/WORKFLOW.md`): the full library suite as the gate, any failure treated as RED. It came back **2016 passed / 34 skipped / 0 failed**. This is *not* a Heart GREEN verdict — a Heart-reachable environment should confirm before merge.

Closes #1519

Generated by the PyAutoLabs agent workflow.

---
_Generated by [Claude Code](https://claude.ai/code/session_013A798vGNqBR4Av4ENVGgf7)_