### PR TITLE
fix: quick update tolerates an out-of-disk max-likelihood instance

### DIFF
--- a/autofit/non_linear/fitness.py
+++ b/autofit/non_linear/fitness.py
@@ -580,6 +580,12 @@ class Fitness:
           `self.iterations_per_quick_update`.
         - If the `analysis` class does not implement
           `perform_quick_update`, the update is silently skipped.
+        - If the current maximum log likelihood parameters cannot be turned
+          into a model instance (e.g. they are outside a model component's
+          physical domain), the visual is skipped with a logged warning and
+          the search continues -- a quick update never terminates a fit. The
+          `model.results` text, which is formatted from the parameter vector
+          alone, is still written.
         - This mechanism is intended for fast, coarse visualization only,
           not detailed science-quality outputs.
         """
@@ -616,25 +622,49 @@ class Fitness:
 
             logger.info("Performing quick update of maximum log likelihood fit image and model.results")
 
-            instance = self.model.instance_from_vector(vector=self.quick_update_max_lh_parameters, xp=self._xp)
-
-            if self._background_quick_update is not None:
-                self._background_quick_update.submit(
-                    self.analysis, self.paths, instance,
+            # A quick update is a convenience render, so nothing inside it may end
+            # the search. The max-likelihood vector a sampler is carrying is not
+            # guaranteed to map to a physical instance: PyAutoGalaxy raises
+            # `ModelParameterException` (a `ValueError` / `af.exc.FitException`)
+            # straight out of a profile constructor, and an out-of-disk `ell_comps`
+            # unwound through this call and killed a 36 h Nautilus run at its very
+            # first quick update (PyAutoFit#1567). `Exception` is caught rather than
+            # `FitException` alone so the synchronous path is as protected as the
+            # background worker (`BackgroundQuickUpdate._process_pending`).
+            try:
+                instance = self.model.instance_from_vector(
+                    vector=self.quick_update_max_lh_parameters, xp=self._xp
                 )
-            else:
-                try:
-                    self.analysis.perform_quick_update(self.paths, instance)
-                except NotImplementedError:
-                    pass
+            except Exception:
+                logger.exception(
+                    "Quick update skipped: the current maximum log likelihood "
+                    "parameters do not map to a valid model instance. The search "
+                    "continues; the model.results text is still written."
+                )
+                instance = None
+
+            if instance is not None:
+                if self._background_quick_update is not None:
+                    self._background_quick_update.submit(
+                        self.analysis, self.paths, instance,
+                    )
                 else:
-                    if self._live_display is not None:
-                        try:
-                            self._live_display.update(self.paths)
-                        except Exception:
-                            logger.exception(
-                                "Live display update raised an exception (ignored)."
-                            )
+                    try:
+                        self.analysis.perform_quick_update(self.paths, instance)
+                    except NotImplementedError:
+                        pass
+                    except Exception:
+                        logger.exception(
+                            "Quick update visual raised an exception (ignored)."
+                        )
+                    else:
+                        if self._live_display is not None:
+                            try:
+                                self._live_display.update(self.paths)
+                            except Exception:
+                                logger.exception(
+                                    "Live display update raised an exception (ignored)."
+                                )
 
             # Searches hand their parameters over in whatever type they hold them:
             # ndarray (Nautilus), JAX array, or a plain Python list (Dynesty's

--- a/test_autofit/non_linear/test_quick_update_invalid_instance.py
+++ b/test_autofit/non_linear/test_quick_update_invalid_instance.py
@@ -1,0 +1,153 @@
+import pytest
+
+import autofit as af
+from autofit.non_linear.fitness import Fitness
+
+# A quick update is a convenience render: it draws the current best fit and
+# rewrites `model.results`. It must never be able to end a search.
+#
+# `manage_quick_update` used to call `model.instance_from_vector` unguarded. The
+# max-likelihood vector a sampler is carrying is not guaranteed to map to a
+# physical instance -- PyAutoGalaxy's `ModelParameterException` (which subclasses
+# both `ValueError` and `af.exc.FitException`) is raised straight out of a profile
+# constructor for e.g. an out-of-disk `ell_comps`. That exception unwound through
+# the likelihood call the sampler was driving and killed a 36 h Nautilus run at
+# its first quick update (PyAutoFit#1567).
+#
+# The model class below reproduces exactly that shape: a constructor that raises
+# a ValueError/FitException subclass for a parameter outside its domain.
+
+
+class _OutOfDomain(ValueError, af.exc.FitException):
+    """Mirrors PyAutoGalaxy's `ModelParameterException` inheritance."""
+
+
+class _BoundedGaussian:
+    def __init__(
+        self,
+        centre: float = 0.0,
+        normalization: float = 1.0,
+        sigma: float = 1.0,
+    ):
+        if sigma <= 0.0:
+            raise _OutOfDomain(
+                f"sigma must be positive, got {sigma}."
+            )
+
+        self.centre = centre
+        self.normalization = normalization
+        self.sigma = sigma
+
+
+class RecordingPaths:
+    """Captures the rendered result info instead of writing it to disk."""
+
+    def __init__(self):
+        self.results = []
+
+    def output_model_results(self, result_info):
+        self.results.append(result_info)
+
+
+class RecordingAnalysis(af.Analysis):
+    """Records every quick-update render instead of drawing one."""
+
+    def __init__(self, raises=None):
+        super().__init__()
+        self.instances = []
+        self.raises = raises
+
+    def perform_quick_update(self, paths, instance):
+        self.instances.append(instance)
+
+        if self.raises is not None:
+            raise self.raises
+
+
+def _model():
+    # Priors are given explicitly so the throwaway test class needs no entry in
+    # the prior config. Their ranges are irrelevant here: `instance_from_vector`
+    # takes physical values, so the vector alone decides whether the constructor
+    # raises.
+    return af.Model(
+        _BoundedGaussian,
+        centre=af.UniformPrior(lower_limit=0.0, upper_limit=100.0),
+        normalization=af.UniformPrior(lower_limit=0.0, upper_limit=100.0),
+        sigma=af.UniformPrior(lower_limit=-10.0, upper_limit=10.0),
+    )
+
+
+def _fitness(analysis, iterations_per_quick_update=1):
+    fitness = Fitness(
+        model=_model(),
+        analysis=analysis,
+        iterations_per_quick_update=iterations_per_quick_update,
+    )
+    fitness.paths = RecordingPaths()
+    return fitness
+
+
+def test__an_invalid_max_lh_instance_skips_the_visual_instead_of_killing_the_search(
+    caplog,
+):
+    analysis = RecordingAnalysis()
+    fitness = _fitness(analysis)
+
+    with caplog.at_level("INFO", logger="autofit.non_linear.fitness"):
+        # sigma = -1.0 is outside the model's domain, so `instance_from_vector`
+        # raises inside the update body. Before the guard this propagated out of
+        # `manage_quick_update` and ended the search.
+        fitness.manage_quick_update(
+            parameters=[50.0, 25.0, -1.0], log_likelihood=-10.0
+        )
+
+    # No render happened...
+    assert analysis.instances == []
+
+    # ...but the counter still reset, or every later evaluation would re-fire
+    # the update and re-log the skip.
+    assert fitness.quick_update_count == 0
+
+    assert "Quick update skipped" in caplog.text
+
+    # The results text is formatted from the parameter vector alone, so it is
+    # still written even when no instance could be built.
+    assert len(fitness.paths.results) == 1
+    assert "centre" in fitness.paths.results[0]
+
+
+def test__a_valid_max_lh_instance_still_renders_the_visual(caplog):
+    analysis = RecordingAnalysis()
+    fitness = _fitness(analysis)
+
+    with caplog.at_level("INFO", logger="autofit.non_linear.fitness"):
+        fitness.manage_quick_update(
+            parameters=[50.0, 25.0, 10.0], log_likelihood=-10.0
+        )
+
+    assert len(analysis.instances) == 1
+    assert analysis.instances[0].sigma == 10.0
+
+    assert "Quick update skipped" not in caplog.text
+
+    assert fitness.quick_update_count == 0
+    assert len(fitness.paths.results) == 1
+
+
+def test__a_visual_that_raises_is_swallowed_like_the_background_worker_does(caplog):
+    # The background quick-update worker already swallows `Exception` around the
+    # render (`BackgroundQuickUpdate._process_pending`). The synchronous path
+    # must not be the more fragile of the two.
+    analysis = RecordingAnalysis(raises=RuntimeError("plotting blew up"))
+    fitness = _fitness(analysis)
+
+    with caplog.at_level("INFO", logger="autofit.non_linear.fitness"):
+        fitness.manage_quick_update(
+            parameters=[50.0, 25.0, 10.0], log_likelihood=-10.0
+        )
+
+    assert len(analysis.instances) == 1
+    assert "ignored" in caplog.text
+
+    assert fitness.quick_update_count == 0
+    assert len(fitness.paths.results) == 1


### PR DESCRIPTION
## Summary
A quick update is a convenience render inside the likelihood call the sampler is driving; nothing in it may terminate a search. `Fitness.manage_quick_update` called `model.instance_from_vector` on the running max-likelihood vector unguarded, so when that vector mapped to an unphysical instance (an out-of-disk `ell_comps`, magnitude 1.009, raising PyAutoGalaxy's `ModelParameterException` from the profile constructor) the exception unwound through `nautilus.sampler.evaluate_likelihood` and killed a 36 h Euclid DR1 run 3m52s in, before any partial result existed (RAL array 342301 task 3). Closes #1567.

The guard now wraps instance construction: on failure the skip is logged with the traceback, the visual (both the background-worker submit and the synchronous render) is skipped, the `model.results` text is still written from the parameter vector, and the cadence counter still resets so the update does not re-fire on every later evaluation. The synchronous render also gains the `except Exception` protection the background worker (`BackgroundQuickUpdate._process_pending`) already had.

`Exception` is caught rather than `af.exc.FitException` alone: the contract is "a render never kills a search", and this makes the synchronous path match the background one.

Channel map: #1487 closed the results-write channel (`Result.instance` falls back to `Samples.max_log_likelihood()`); #1538 / PyAutoGalaxy#589 shipped the opt-in joint disk projection, which only gradient searches consume (Nautilus has no clipper hook); this PR closes the quick-update channel. The pipeline leg (euclid_strong_lens_modeling_pipeline, same issue) bounds the source MGE `ell_comps` box inside the unit disk so the unphysical region is not sampled in the first place.

## API Changes
None — internal. Behaviour change only: a quick update whose max-likelihood vector cannot be turned into a model instance, or whose synchronous visual raises, now logs and skips instead of propagating out of the likelihood call.

## Test Plan
- [x] New `test_autofit/non_linear/test_quick_update_invalid_instance.py`: the regression case fails on unfixed code (the `ValueError`/`FitException` propagates) and passes with the guard; positive control (valid vector still renders); synchronous visual that raises is swallowed and logged.
- [x] `pytest test_autofit/non_linear`: 803 passed, 1 skipped.
- [ ] CI green.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
- None

### Added
- None

### Changed
- `autofit.non_linear.fitness.Fitness.manage_quick_update` — model-instance construction and the synchronous `perform_quick_update` call are guarded; failures log (`logger.exception`) and skip the visual; the search continues and `model.results` is still written.

### Migration
- None.

</details>

Generated by the PyAutoLabs agent workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P5K4AXFBYMCPhbNFYA24YX
