### PR TITLE
fix(messages): keep the full covariance through coupled transforms in from_mode

### DIFF
--- a/autofit/messages/composed_transform.py
+++ b/autofit/messages/composed_transform.py
@@ -436,8 +436,8 @@ class TransformedMessage(MessageInterface):
         way, ``jac.quad`` being the inverse of the ``invquad`` composition
         that ``variance`` applies base -> physical. A ``LinearOperator``
         covariance (the 0-d or n-d ``DiagonalMatrix`` the Laplace optimiser
-        hands over) is reduced to its diagonal first, which is all the base
-        ``from_mode`` reads.
+        hands over) is densified first when there are transforms to apply,
+        and reduced to its diagonal when there are none.
 
         Physical-space ``lower_limit`` / ``upper_limit`` kwargs are dropped:
         the base message lives in base space and keeps its own support
@@ -446,7 +446,16 @@ class TransformedMessage(MessageInterface):
         from autofit.mapper.operator import LinearOperator
 
         if isinstance(covariance, LinearOperator):
-            covariance = covariance.diagonal()
+            # A Jacobian may be coupled (``MultinomialLogitTransform`` returns a
+            # ``ShermanMorrison`` operator), and ``jac.quad`` contracts a 1-D
+            # argument as a vector, ``J(J.T v)``, not as ``diag(v)``. Handing it
+            # the diagonal would therefore lose the off-diagonal ``J S J.T`` mass
+            # that belongs on the diagonal, so keep the dense matrix whenever
+            # there is a transform to push through. With no transform the base
+            # message reads only the marginals, so the diagonal is enough.
+            covariance = (
+                covariance.to_dense() if self.transforms else covariance.diagonal()
+            )
         covariance = np.asanyarray(covariance)
 
         kwargs.pop("lower_limit", None)

--- a/test_autofit/messages/test_transformed_from_mode.py
+++ b/test_autofit/messages/test_transformed_from_mode.py
@@ -7,7 +7,9 @@ import numpy as np
 import pytest
 
 import autofit as af
-from autofit.mapper.operator import DiagonalMatrix
+from autofit.mapper.operator import DiagonalMatrix, MatrixOperator
+from autofit.messages import MultiLogitNormalMessage
+from autofit.messages.transform import multinomial_logit_transform
 from autofit.mapper.variable import Variable
 from autofit.mapper.variable_operator import VariableFullOperator
 
@@ -80,3 +82,56 @@ def test__two_transform_stack_one_d_matches_zero_d():
 
     assert one_d.variance == pytest.approx([0.04])
     assert zero_d.variance == pytest.approx(0.04)
+
+
+@pytest.fixture(name="multi_logit_mode")
+def make_multi_logit_mode():
+    # Two simplex components, comfortably inside 0 < sum(p) < 1.
+    return np.array([0.3, 0.4])
+
+
+def _delta_method_variance(mode, covariance):
+    """``diag(J Sigma J.T)``, with J by central differences of the transform itself."""
+    step = 1e-6
+    jacobian = np.zeros((mode.size, mode.size))
+    for i in range(mode.size):
+        offset = np.zeros(mode.size)
+        offset[i] = step
+        jacobian[:, i] = (
+            multinomial_logit_transform.transform(mode + offset)
+            - multinomial_logit_transform.transform(mode - offset)
+        ) / (2 * step)
+
+    return np.diag(jacobian @ covariance @ jacobian.T)
+
+
+@pytest.mark.parametrize(
+    "covariance, diagonal",
+    [
+        (np.diag([0.02, 0.03]), np.array([0.02, 0.03])),
+        (np.array([[0.02, 0.008], [0.008, 0.03]]), None),
+    ],
+    ids=["diagonal_covariance", "coupled_covariance"],
+)
+def test__coupled_jacobian_keeps_the_full_covariance(
+    multi_logit_mode, covariance, diagonal
+):
+    # MultinomialLogitTransform's Jacobian is a coupled ShermanMorrison operator,
+    # and ``jac.quad`` contracts a 1-D argument as ``J(J.T v)``. Diagonalising an
+    # operator covariance first (PyAutoFit#1569) therefore returned [2.3611, 2.1875]
+    # for every operator input, against [1.2222, 1.2431] for the equivalent array.
+    forms = [covariance, MatrixOperator(covariance)]
+    if diagonal is not None:
+        forms.append(DiagonalMatrix(diagonal))
+
+    variances = [
+        MultiLogitNormalMessage.from_mode(multi_logit_mode, form).base_message.variance
+        for form in forms
+    ]
+
+    for variance in variances[1:]:
+        assert variance == pytest.approx(variances[0], rel=1.0e-6)
+
+    assert variances[0] == pytest.approx(
+        _delta_method_variance(multi_logit_mode, covariance), rel=1.0e-4
+    )


### PR DESCRIPTION
Closes #1569. Finding 3 of the Codex review of the phase-2 EP fixes (#1560 introduced the path; umbrella #1405).

## Problem

`TransformedMessage.from_mode` reduced a `LinearOperator` covariance to its diagonal before pushing it through the transform Jacobians. `jac.quad` contracts a 1-D argument as a vector, `J(Jᵀv)`, not as `diag(v)`, so a coupled Jacobian (`MultinomialLogitTransform`'s `ShermanMorrison`, used by `MultiLogitNormalMessage`) lost the off-diagonal `J Σ Jᵀ` mass that belongs on the diagonal. Pre-#1560 this path raised; #1560 made it silently wrong. Scalar transforms have diagonal Jacobians where both contractions coincide, which is why every campaign test passed.

| Σ | input form | before | after | delta method |
|---|---|---|---|---|
| diag(0.02, 0.03) | ndarray | [1.2222, 1.2431] | [1.2222, 1.2431] | [1.2222, 1.2431] |
| diag(0.02, 0.03) | MatrixOperator / DiagonalMatrix | [2.3611, 2.1875] | [1.2222, 1.2431] | |
| non-diagonal | MatrixOperator | [2.3611, 2.1875] | [1.5778, 1.5542] | [1.5778, 1.5542] |

## Fix

Keep the dense matrix (`to_dense()`, the existing accessor) through the Jacobian loop when transforms are present; take the diagonal only in the no-transform case. No new methods, no guards.

## Impact

Defensive path only: the sole in-library caller, `MeanField.from_mode_covariance`, passes dense ndarrays. `MultiLogitNormalMessage` has no workspace usage.

## API Changes

None.

## Tests

- New `test__coupled_jacobian_keeps_the_full_covariance` in `test_autofit/messages/test_transformed_from_mode.py`: operator forms match the ndarray form (rel 1e-6) and the ndarray form matches an independent delta-method `diag(J Σ Jᵀ)` (rel 1e-4), over a diagonal and a non-diagonal Σ.
- `test_autofit/messages`: 95 passed. `test_autofit/graphical`: 265 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gu4YysuvpQ4k6zkQjiwabd
