### PR TITLE
fix(samples): errors_at_sigma(as_instance=True) on a prior-valued model

### DIFF
--- a/autofit/mapper/prior_model/prior_model.py
+++ b/autofit/mapper/prior_model/prior_model.py
@@ -8,7 +8,7 @@ from typing import *
 
 from autonerves.class_path import get_class_path
 from autonerves.exc import ConfigException
-from autofit.mapper.model import assert_not_frozen
+from autofit.mapper.model import ModelInstance, assert_not_frozen
 from autofit.mapper.model_object import ModelObject
 from autofit.mapper.prior.abstract import Prior
 from autofit.mapper.prior.constant import Constant
@@ -532,6 +532,20 @@ class Model(AbstractPriorModel):
 
         if self.is_deferred_arguments:
             return DeferredInstance(self.cls, constructor_arguments)
+
+        if (
+            inspect.isclass(self.cls)
+            and issubclass(self.cls, Prior)
+            and any(
+                isinstance(value, tuple) for value in constructor_arguments.values()
+            )
+        ):
+            # A Prior's constructor only takes scalars, so a tuple here can only be an
+            # (lower, upper) bounds pair from errors_at_sigma / values_at_sigma. Every
+            # other model class simply stores such a pair as an attribute, so store it
+            # as an attribute here too instead of building a message from it. Scalar
+            # arguments (median_pdf, max_log_likelihood) still construct the real prior.
+            return ModelInstance(constructor_arguments)
 
         if not inspect.isclass(self.cls):
             result = object.__new__(inspect._findclass(self.cls))

--- a/test_autofit/graphical/global/test_errors_at_sigma_instance.py
+++ b/test_autofit/graphical/global/test_errors_at_sigma_instance.py
@@ -1,0 +1,125 @@
+import pytest
+
+import autofit as af
+import autofit.graphical as g
+
+
+class Analysis(af.Analysis):
+    def __init__(self, value):
+        super().__init__()
+        self.value = value
+
+    def log_likelihood_function(self, instance):
+        return -((instance.one - self.value) ** 2)
+
+
+@pytest.fixture(name="model")
+def make_model():
+    """
+    A global model containing a `Model(af.GaussianPrior)` (contributed by the
+    hierarchical factor's distribution model) alongside an ordinary class component.
+    """
+    hierarchical_factor = g.HierarchicalFactor(
+        af.GaussianPrior,
+        mean=af.GaussianPrior(mean=0.5, sigma=0.1),
+        sigma=af.GaussianPrior(mean=1.0, sigma=0.01),
+    )
+
+    model_factor = g.AnalysisFactor(
+        af.Collection(one=af.UniformPrior()),
+        Analysis(0.5),
+    )
+    ordinary_factor = g.AnalysisFactor(
+        af.Model(af.m.MockClassx2),
+        Analysis(0.0),
+    )
+
+    hierarchical_factor.add_drawn_variable(model_factor.one)
+
+    return g.FactorGraphModel(
+        hierarchical_factor,
+        model_factor,
+        ordinary_factor,
+    ).global_prior_model
+
+
+@pytest.fixture(name="samples")
+def make_samples(model):
+    parameters = [
+        [(j + 1) * (0.1 + 0.02 * i) for j in range(model.prior_count)]
+        for i in range(10)
+    ]
+
+    return af.m.MockSamples(
+        model=model,
+        sample_list=af.Sample.from_lists(
+            model=model,
+            parameter_lists=parameters,
+            log_likelihood_list=list(range(10)),
+            log_prior_list=10 * [0.0],
+            weight_list=10 * [0.1],
+        ),
+    )
+
+
+def _index_of(model, prior):
+    return [
+        prior_tuple.prior.id for prior_tuple in model.prior_tuples_ordered_by_id
+    ].index(prior.id)
+
+
+def _distribution_model(model):
+    for component in model:
+        if hasattr(component, "distribution_model"):
+            return component.distribution_model
+    raise AssertionError("no hierarchical distribution model in the global model")
+
+
+def _prior_valued_instance(instance):
+    for component in instance:
+        if hasattr(component, "distribution_model"):
+            return component.distribution_model
+    raise AssertionError("no hierarchical distribution model in the instance")
+
+
+def _ordinary_instance(instance):
+    for component in instance:
+        if hasattr(component, "two"):
+            return component
+    raise AssertionError("no ordinary class component in the instance")
+
+
+@pytest.mark.parametrize("method", ["errors_at_sigma", "values_at_sigma"])
+def test__tuple_valued_instance_for_prior_valued_component(model, samples, method):
+    """
+    `errors_at_sigma` / `values_at_sigma` are tuple valued. A `Model(af.GaussianPrior)`
+    component cannot be constructed from those tuples, so the instance stores them as
+    attributes instead of raising a `broadcast_arrays` `TypeError`.
+    """
+    values = getattr(samples, method)(sigma=1.0, as_instance=False)
+    instance = getattr(samples, method)(sigma=1.0)
+
+    distribution_model = _distribution_model(model)
+
+    assert _prior_valued_instance(instance).mean == values[
+        _index_of(model, distribution_model.mean)
+    ]
+    assert _prior_valued_instance(instance).sigma == values[
+        _index_of(model, distribution_model.sigma)
+    ]
+
+    ordinary = _ordinary_instance(instance)
+
+    assert ordinary.one in values
+    assert ordinary.two in values
+
+
+def test__median_pdf_instance_still_builds_a_real_prior(model, samples):
+    """
+    The scalar path is untouched: a `Model(af.GaussianPrior)` still constructs a prior.
+    """
+    distribution_model = _prior_valued_instance(samples.median_pdf())
+
+    assert isinstance(distribution_model, af.GaussianPrior)
+    assert isinstance(distribution_model.mean, float)
+    assert isinstance(distribution_model.sigma, float)


### PR DESCRIPTION
## Summary
`Samples.errors_at_sigma(1.0)` and `values_at_sigma(1.0)` (default `as_instance=True`) raised `TypeError: broadcast_arrays requires ndarray or scalar arguments, got <class 'tuple'>` on any global model containing a `Model(af.GaussianPrior)` component — i.e. every `FactorGraphModel.global_prior_model` with a `HierarchicalFactor`. `Model.instance_for_arguments` handed the `(lower, upper)` bounds pairs to the Prior's constructor, which builds a `NormalMessage` from them.

Fix (`autofit/mapper/prior_model/prior_model.py`): when the model class is a `Prior` subclass and any constructor argument is a tuple, return a `ModelInstance` holding the arguments (`.mean == (lo, hi)`, `.sigma == (lo, hi)`) instead of constructing the prior. Scalar vectors (`median_pdf`, `max_log_likelihood`) are unchanged and still build the real prior. An explicit typed branch, not an exception guard.

The alternative of returning a pair of instances was rejected: it would break the public tuple-attribute instance contract used by `autofit_workspace_test/scripts/graphical/ep_parity.py`, `simultaneous.py` and the workspace result tutorials.

Finding D6 of the analytic Gaussian benchmark (autofit_workspace_test#91); umbrella PyAutoFit#1405; closes #1577. Workspace follow-up: remove the `as_instance=False` workaround from `autofit_workspace_test/scripts/graphical/analytic_autofit.py` (ships after this PR merges).

## API Changes
Bug fix only — no signatures changed. `Samples.errors_at_sigma` / `values_at_sigma` with `as_instance=True` now return an instance on models with Prior-class components where they previously raised; the Prior-class component becomes a `ModelInstance` of bounds pairs.
See full details below.

## Test Plan
- [x] `test_autofit/graphical/global/test_errors_at_sigma_instance.py`: `errors_at_sigma` and `values_at_sigma` instances match the `as_instance=False` tuples through `prior_tuples_ordered_by_id` (both fail without the fix); `median_pdf` still yields a real `af.GaussianPrior`
- [x] `pytest test_autofit -q`: 2472 passed, 2 skipped (baseline 2469 + 3 new); graphical 278, messages 95
- [ ] CI: Tests [pull_request] 3.12 / 3.13 / nojax, Docs
- [ ] Workspace follow-up PR on autofit_workspace_test: `analytic_gaussian.py` info lines byte-identical through the instance path

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- `Model.instance_for_arguments` — for a `Prior`-subclass model whose constructor arguments contain a tuple (a bounds pair from `Samples.errors_at_sigma` / `values_at_sigma`), returns `ModelInstance(constructor_arguments)` instead of constructing the prior (which raised). Scalar arguments unchanged.

</details>

Generated by the PyAutoLabs agent workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E2HKd5ZocDmTyZ544eVEh4