### PR TITLE
docs: Natural Language Inference — retitle, orange AI First Design asides, BYO likelihood

### DIFF
--- a/docs/_static/pyautofit.css
+++ b/docs/_static/pyautofit.css
@@ -1,0 +1,27 @@
+/* PyAutoFit-only docs layer. The shared brand file `pyauto.css` is byte-identical
+   across PyAutoFit / PyAutoGalaxy / PyAutoLens, so repo-specific rules live here
+   instead of diverging it. */
+
+/* "AI First Design" asides on the Natural Language Inference overview: the note
+   is rendered in the project accent so it reads as commentary on the design
+   rather than part of the walkthrough. Colour comes from Furo's brand variable,
+   so it follows the light/dark accent set in conf.py automatically. */
+.ai-first-design {
+  color: var(--color-brand-content);
+  border-left: 3px solid var(--color-brand-content);
+  padding-left: 1rem;
+  margin: 1.2rem 0;
+}
+
+.ai-first-design p {
+  color: inherit;
+  margin-bottom: 0;
+}
+
+/* Inline literals inside the aside inherit the accent too, so the block reads as
+   one colour rather than orange prose broken up by default-coloured code spans. */
+.ai-first-design code,
+.ai-first-design .literal {
+  color: inherit;
+  background: transparent;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -121,7 +121,7 @@ add_function_parentheses = False
 language = "en"
 
 html_static_path = ["_static"]
-html_css_files = ["pyauto.css"]
+html_css_files = ["pyauto.css", "pyautofit.css"]
 
 html_theme_options = {
     "light_css_variables": {

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ and organising the results. It is domain agnostic: inference can sit around your
 We recommend getting started with [autofit_assistant](https://github.com/PyAutoLabs/autofit_assistant), which lets
 you **perform scientific inference using natural language**. Describe the model you want to fit, ask the assistant
 to run the analysis, and explore the results through follow-up requests —
-see [Inference with Natural Language](https://pyautofit.readthedocs.io/en/latest/overview/natural_language.html).
+see [Natural Language Inference](https://pyautofit.readthedocs.io/en/latest/overview/natural_language.html).
 
 Users can then set up a **PyAutoFit** scientific workflow, which enables streamlined modeling of small
 datasets with tools to scale up to large datasets.
@@ -53,7 +53,7 @@ the `data` (black) and the model (red) we'll fit:
 
 There are two ways to read the rest of these docs:
 
-- [Inference with Natural Language](https://pyautofit.readthedocs.io/en/latest/overview/natural_language.html)
+- [Natural Language Inference](https://pyautofit.readthedocs.io/en/latest/overview/natural_language.html)
   walks through this fit as a conversation with an assistant — composing the model, defining the likelihood,
   choosing a search, running the fit and inspecting the results, all described in words rather than written by
   hand. **This is the recommended starting point.**

--- a/docs/overview/natural_language.md
+++ b/docs/overview/natural_language.md
@@ -1,4 +1,4 @@
-# Inference with Natural Language
+# Natural Language Inference
 
 > **Access requirements**
 >
@@ -20,11 +20,6 @@ results through follow-up requests. PyAutoFit's named models, separate
 likelihood, interchangeable searches and structured results make this
 workflow well suited to AI agents. The examples below show why.
 
-An LLM can help write a fitting script. An agent with access to your project
-can also run it, inspect the outputs and extend the analysis. You guide the
-science; the assistant leaves the work as Python scripts you can inspect,
-rerun and share.
-
 To begin instantly, follow the [assistant setup guide](https://github.com/PyAutoLabs/autofit_assistant#getting-started) and ask:
 
 > Fit the bundled dataset in dataset/gaussian_x1/ with a 1D Gaussian.
@@ -37,6 +32,25 @@ need to write Python to follow it.** The workflow is:
 If you do want to see how **PyAutoFit** works under the hood, [The Python API](https://pyautofit.readthedocs.io/en/latest/overview/python_api.html) explains PyAutoFit's 
 inner workings and Python API, including the model, Analysis, search and Result objects that the assistant
 uses behind the scenes.
+
+## Bring Your Own Likelihood
+
+You do not need to start from a bundled example, or write the integration
+yourself. **Point the assistant at your existing likelihood function and it
+takes care of the rest** — wiring your code to a named model, choosing priors
+with you, setting up a search and organising the results:
+
+> Setup PyAutoFit with my existing science project, an example likelihood
+> function can be found at [point to GitHub link or computer directory].
+> Give me an overview of my project, compose a model and tell me about it and
+> give me your assessment of what non-linear search (MCMC, nested sampler,
+> maximum likelihood estimator) you think would be a good choice. Do not
+> begin inference until we have had a discussion and I give you the go ahead,
+> and once inference is running give me a overview of how results are output
+> to hard-disk and how I can inspect and interpret them with PyAutoFit.
+
+Your validated science code keeps working exactly as it did; PyAutoFit's
+searches and result tools are what get wrapped around it.
 
 ## Contents
 
@@ -88,11 +102,9 @@ Models are highly customizable: you can ask to fix a parameter,
 link parameters between components, or assert a constraint. For your own 
 science, simply ask the assistant to compose your model for you.
 
-**AI First Design: Internally, **PyAutoFit** composes the model with a name
-(`Gaussian`), named parameters (`centre`, `normalization`, `sigma`) and 
-an expressive naming convention (e.g. `model.gaussian.sigma`) which ensure
-the AI can easily map natural language descriptions of the model to changes in its
-internal representation.**
+:::{container} ai-first-design
+**AI First Design:** Internally, PyAutoFit composes the model with a name (`Gaussian`), named parameters (`centre`, `normalization`, `sigma`) and an expressive naming convention (e.g. `model.gaussian.sigma`) which ensure the AI can easily map natural language descriptions of the model to changes in its internal representation.
+:::
 
 ## Define the likelihood
 
@@ -114,10 +126,9 @@ For your own project, you can instead ask:
 > it to PyAutoFit and check that it returns the same likelihood values at 
 > the same parameter values.
 
-**AI First Design: PyAutoFit gives the agent a small, testable integration task: connect 
-named model parameters to your existing likelihood and check that its numerical outputs are unchanged. 
-Your validated science code then becomes available to PyAutoFit's searches and result-analysis tools, 
-without the agent having to reimplement it.**
+:::{container} ai-first-design
+**AI First Design:** PyAutoFit gives the agent a small, testable integration task: connect named model parameters to your existing likelihood and check that its numerical outputs are unchanged. Your validated science code then becomes available to PyAutoFit's searches and result-analysis tools, without the agent having to reimplement it.
+:::
 
 You can also give the assistant papers and descriptions of your data,
 parameters and assumptions. This supplies the scientific context so you can
@@ -140,9 +151,9 @@ The assistant configures the requested search. You can ask it to explain
 the settings or help choose an algorithm for your likelihood and scientific
 goal.
 
-**AI First Design: All **PyAutoFit** searches share a common interface,
-so the agent can switch between them while retaining the model and likelihood,
-making it easy to compare inference across different searches.**
+:::{container} ai-first-design
+**AI First Design:** All PyAutoFit searches share a common interface, so the agent can switch between them while retaining the model and likelihood, making it easy to compare inference across different searches.
+:::
 
 ## Fit and inspect the result
 
@@ -156,9 +167,9 @@ a plot of the fitted profile. You can then explore the result:
 > Plot the posterior distributions. How well is sigma constrained, and
 > is it correlated with normalization?
 
-**AI First Design: Results preserve the model's named
-parameters (e.g. `result.instance.gaussian.sigma`), so the agent can connect 
-the scientific quantities you specify via language to the numerical results.**
+:::{container} ai-first-design
+**AI First Design:** Results preserve the model's named parameters (e.g. `result.instance.gaussian.sigma`), so the agent can connect the scientific quantities you specify via language to the numerical results.
+:::
 
 ## Save and revisit the analysis
 
@@ -176,9 +187,9 @@ search, model or result properties. For example:
 > Find the completed Gaussian fits and make a table of the inferred widths
 > and their uncertainties, labelled by dataset and search algorithm.
 
-**AI First Design: Structured, persistent outputs give
-the agent a history of experiments it can reload, query and compare as
-your analysis grows.**
+:::{container} ai-first-design
+**AI First Design:** Structured, persistent outputs give the agent a history of experiments it can reload, query and compare as your analysis grows.
+:::
 
 ## Extend the workflow
 
@@ -250,7 +261,7 @@ not mentioned here. This includes hierarchical models to large dataset, building
 chaining them together, and Bayesian model comparison. You can ask the assistant to describe each feature and then perform inference using the 
 same natural-language approach.
 
-## HowToFit
+## HowToFit / Teacher Mode
 
 For users less familiar with Bayesian inference and scientific analysis you may wish to read through
 the **HowToFits** lectures. These teach you the basic principles of Bayesian inference, with the
@@ -262,17 +273,15 @@ If you're new to statistical inference and are not totally sure what concepts li
 sampling are, you can use **teacher mode** to have the assistant explain concepts in more detail. Simply
 start a prompt with "Teacher mode." and ask questions:
 
-```
-Teacher mode.
-
-I'm new to PyAutoFit and want to learn the basic workflow end-to-end. Fit the
-bundled 1D Gaussian dataset in dataset/gaussian_x1/ and recover its input
-parameters.
-
-Explain what each step is doing and why as we go: composing the model, choosing
-the priors, picking the non-linear search, and how to read the posterior. So I
-come away understanding the workflow, not just the commands.
-```
+> Teacher mode.
+>
+> I'm new to PyAutoFit and want to learn the basic workflow end-to-end. Fit the
+> bundled 1D Gaussian dataset in dataset/gaussian_x1/ and recover its input
+> parameters.
+>
+> Explain what each step is doing and why as we go: composing the model, choosing
+> the priors, picking the non-linear search, and how to read the posterior. So I
+> come away understanding the workflow, not just the commands.
 
 ## The Python API
 

--- a/docs/overview/python_api.md
+++ b/docs/overview/python_api.md
@@ -2,7 +2,7 @@
 
 # The Python API
 
-This page is the under-the-hood companion to [Inference with Natural Language](https://pyautofit.readthedocs.io/en/latest/overview/natural_language.html):
+This page is the under-the-hood companion to [Natural Language Inference](https://pyautofit.readthedocs.io/en/latest/overview/natural_language.html):
 it walks through the **PyAutoFit** Python API that an assistant writes for you, so you can read, run and
 extend that code yourself.
 


### PR DESCRIPTION
## Summary

Follow-up polish on the overview page from #1588.

- **"Inference with Natural Language" → "Natural Language Inference"**, at the page title and all three references (`index.md` ×2, `python_api.md`).
- **Removed** the "An LLM can help write a fitting script…" paragraph.
- **New "Bring Your Own Likelihood" section** before Contents: you can point the assistant at an existing likelihood function and it takes care of the integration, with the natural-language prompt to do it.
- **The five "AI First Design" asides now render in the project accent (orange).**
- **"HowToFit" → "HowToFit / Teacher Mode"**, and its prompt moves from a fenced code block to a blockquote.

## Two defects fixed along the way

**The asides were malformed markdown.** Each read `**AI First Design: … **PyAutoFit** …**` — bold opened inside bold, which terminates the emphasis early rather than nesting. They have never rendered as intended. Each is now a `container` directive with a fixed `**AI First Design:**` label.

**The teacher-mode prompt was in a fenced code block**, so a natural-language prompt was rendering as source code. Every other prompt on the page is a `>` blockquote; this one now matches.

## Styling

The orange lands in a **new `docs/_static/pyautofit.css`**, not in `pyauto.css` — that file states in its own header that it is identical across PyAutoFit / PyAutoGalaxy / PyAutoLens, so a PyAutoFit-only rule there would silently diverge the three. Colour comes from Furo's `--color-brand-content`, so it follows the light/dark accent already configured in `conf.py` (`#c2410c` / `#f28c38`) instead of hard-coding a second orange.

## Test Plan

- [x] `python -m sphinx -b html docs …` → **30 warnings, baseline 30**, and the warning set is **byte-identical** to the pre-change build (diffed, not just counted).
- [x] All five asides render as `<div class="ai-first-design docutils container">`, and `pyautofit.css` is linked from the built page.
- [x] Page `<title>` is `Natural Language Inference - PyAutoFit`; no reference to the old title remains in `docs/`.
- [ ] Eyeball the orange in light and dark mode on the built page.

**Companion PR:** PyAutoLabs/autofit_assistant#34 mirrors the same changes in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015LXave3uvSeLEq7S68NjXk