### PR TITLE
docs: point The Python API at the workspace script that carries its code

### DIFF
--- a/docs/overview/python_api.md
+++ b/docs/overview/python_api.md
@@ -6,6 +6,14 @@ This page is the under-the-hood companion to [Natural Language Inference](https:
 it walks through the **PyAutoFit** Python API that an assistant writes for you, so you can read, run and
 extend that code yourself.
 
+**Every code snippet on this page is available as a runnable script and notebook** in the
+[autofit_workspace](https://github.com/PyAutoLabs/autofit_workspace):
+[`scripts/overview/overview_1_the_basics.py`](https://github.com/PyAutoLabs/autofit_workspace/blob/main/scripts/overview/overview_1_the_basics.py)
+and [`notebooks/overview/overview_1_the_basics.ipynb`](https://github.com/PyAutoLabs/autofit_workspace/blob/main/notebooks/overview/overview_1_the_basics.ipynb),
+which you can also
+[run in your browser on Colab](https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.9.8.1/notebooks/overview/overview_1_the_basics.ipynb)
+without installing anything.
+
 **PyAutoFit** is a Python based probabilistic programming language for model fitting and Bayesian inference
 of large datasets. The API lets a user quickly compose a probabilistic model and fit it to data via a
 log likelihood function, using a range of non-linear search algorithms (e.g. MCMC, nested sampling).


### PR DESCRIPTION
## Summary

Every code snippet on **The Python API** page exists as a runnable script and notebook in `autofit_workspace`, but the page never said so — its only pointer at the workspace was a generic repo link in the Resources section at the very bottom.

The intro now links:

- [`scripts/overview/overview_1_the_basics.py`](https://github.com/PyAutoLabs/autofit_workspace/blob/main/scripts/overview/overview_1_the_basics.py)
- [`notebooks/overview/overview_1_the_basics.ipynb`](https://github.com/PyAutoLabs/autofit_workspace/blob/main/notebooks/overview/overview_1_the_basics.ipynb)
- the Colab route for running it without installing anything

## Note on the two URL forms

The GitHub source links track `main` (you want to read the current code), while the **Colab link is pinned to `2026.9.8.1`** — matching the convention already used in `docs/index.md` and `README.md`. Pinning matters there: Colab installs the released library, so an unpinned notebook can use API that is on `main` but not yet published. I matched the existing convention rather than introducing a second, main-tracking form.

The workspace files keep their `the_basics` name. Renaming them is separate work in a separate repo, flagged when this page was renamed in #1588.

## Test Plan

- [x] Both GitHub URLs return 200; the pinned Colab tag `2026.9.8.1` returns 200.
- [x] `python -m sphinx -b html docs …` → 30 warnings, unchanged against the baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015LXave3uvSeLEq7S68NjXk