### PR TITLE
docs: the search prompt asks about JAX gradient-based inference

### DIFF
--- a/docs/overview/natural_language.md
+++ b/docs/overview/natural_language.md
@@ -136,8 +136,10 @@ use domain-specific natural language while keeping it separate from the inferenc
 
 ## Choose a search
 
-> Show me the available searches. For this first fit, use Dynesty nested
-> sampling with 100 live points to estimate the posterior and evidence.
+> Show me the available non-linear searches, including those which support
+> gradient based inference using JAX. For this example fit, our likelihood
+> function is not implemented using JAX, so lets use Dynesty nested sampling
+> with 100 live points to estimate the posterior and evidence.
 
 PyAutoFit supports several types of inference algorithm:
 
@@ -146,6 +148,10 @@ PyAutoFit supports several types of inference algorithm:
 - **MCMC:** Emcee and Zeus, for posterior sampling.
 - **Optimisation:** algorithms such as L-BFGS, for finding a best-fitting
   solution.
+- **Gradient-based (JAX):** `BlackJAXNUTS` for Hamiltonian / NUTS sampling, and
+  `MultiStartAdam` / `MultiStartProdigy` for optimisation. These take gradients
+  of your likelihood automatically, so they require it to be written in JAX —
+  which is why this example, whose likelihood is plain NumPy, uses Dynesty.
 
 The assistant configures the requested search. You can ask it to explain
 the settings or help choose an algorithm for your likelihood and scientific


### PR DESCRIPTION
## Summary

The "Choose a search" prompt on the Natural Language Inference page now reads:

> Show me the available non-linear searches, including those which support gradient based inference using JAX. For this example fit, our likelihood function is not implemented using JAX, so lets use Dynesty nested sampling with 100 live points to estimate the posterior and evidence.

## The list had to change with it

The prompt now asks about gradient-based/JAX searches, but the list underneath named only nested sampling, MCMC and optimisation — the page would have asked a question it never answers. Added a fourth bullet:

> **Gradient-based (JAX):** `BlackJAXNUTS` for Hamiltonian / NUTS sampling, and `MultiStartAdam` / `MultiStartProdigy` for optimisation. These take gradients of your likelihood automatically, so they require it to be written in JAX — which is why this example, whose likelihood is plain NumPy, uses Dynesty.

Those three names were **verified against the installed `autofit` public API**, not written from memory — the whole point of the prompt is that a reader can ask for them by name.

Typo in the supplied text fixed: "likelihood funciton" → "function". The rest is verbatim, including "lets".

## Test Plan

- [x] `python -m sphinx -b html docs …` → 30 warnings, unchanged against the baseline.
- [x] The old prompt wording appears nowhere in `docs/`.
- [x] `BlackJAXNUTS`, `MultiStartAdam`, `MultiStartProdigy` all present in `dir(autofit)`.

**Companion PR:** PyAutoLabs/autofit_assistant#35 makes the same change to the README, which carries the same walkthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015LXave3uvSeLEq7S68NjXk