### PR TITLE
docs: agentic-only access note in Quick Start

### DIFF
--- a/docs/overview/quick_start.md
+++ b/docs/overview/quick_start.md
@@ -2,9 +2,11 @@
 
 > **Access requirements**
 >
-> The assistant runs through a coding agent such as Claude Code or OpenAI
-> Codex. Sustained use normally needs a paid subscription or API billing;
-> limited free access may be available. See the [assistant setup guide](https://github.com/PyAutoLabs/autofit_assistant#getting-started)
+> The assistant runs inside an AI coding agent: Claude Code or OpenAI Codex are
+> recommended. Sustained scientific use normally needs paid access to one of them
+> (a personal subscription, institutional access or API billing); OpenCode is an
+> experimental alternative whose model access and capability depend on the
+> provider. See the [assistant setup guide](https://github.com/PyAutoLabs/autofit_assistant#getting-started)
 > for current options. PyAutoFit itself is open source.
 
 **PyAutoFit is a Python package for scientific model fitting and Bayesian


### PR DESCRIPTION
## Summary

Docs only. The Quick Start "Access requirements" note no longer suggests a paid subscription is the only route or that limited free access may exist. It names Claude Code / Codex as recommended, frames paid access as subscription / institutional / API billing, and points at OpenCode as an experimental alternative — matching the policy adopted in PyAutoLabs/autofit_assistant.

## Test plan

- [ ] CI docs build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsLuCV9nbPPUWBK9rewCZe

---
_Generated by [Claude Code](https://claude.ai/code/session_01UsLuCV9nbPPUWBK9rewCZe)_