### PR TITLE
docs: link the start-here prompt to the assistant guided mode

### DIFF
--- a/docs/overview/natural_language.md
+++ b/docs/overview/natural_language.md
@@ -10,6 +10,9 @@ with [Quick Start](https://pyautofit.readthedocs.io/en/latest/overview/quick_sta
 **Every step on this page can be requested in natural language—you do not
 need to write Python to follow it.** The workflow is:
 **model → priors → likelihood → search → results → scientific workflow**.
+Typing the start-here prompt from [Quick Start](https://pyautofit.readthedocs.io/en/latest/overview/quick_start.html)
+into the assistant walks these six sections as a [guided tour](https://github.com/PyAutoLabs/autofit_assistant/blob/main/modes/start_here.md), one step at
+a time — or you can paste any prompt below into the assistant directly.
 
 ## Contents
 
@@ -54,9 +57,9 @@ Total Free Parameters = 3
 
 model                         Gaussian (N=3)
 
-centre                        UniformPrior [1], lower_limit = 0.0, upper_limit = 100.0
-normalization                 LogUniformPrior [2], lower_limit = 1e-06, upper_limit = 1000000.0
-sigma                         UniformPrior [3], lower_limit = 0.0, upper_limit = 25.0
+centre                        UniformPrior [0], lower_limit = 0.0, upper_limit = 100.0
+normalization                 UniformPrior [1], lower_limit = 0.0, upper_limit = 100.0
+sigma                         UniformPrior [2], lower_limit = 0.1, upper_limit = 30.0
 ```
 
 Models are highly customizable: you can ask to fix a parameter, 
@@ -78,8 +81,6 @@ The assistant sets up the likelihood function: which in this case evaluates the
 Gaussian at each data point and compares the predictions with the measurements, 
 accounting for their uncertainties. As requested, you get an image comparing
 the model and data.
-
-[Find 1D example of a random model to the data, maybe from HowToFit]?
 
 For your own project, you can instead ask:
 

--- a/docs/overview/quick_start.md
+++ b/docs/overview/quick_start.md
@@ -29,6 +29,13 @@ To begin instantly, follow the [assistant setup guide](https://github.com/PyAuto
 >
 > Begin the "start here" guide for a new user.
 
+The assistant answers this prompt with its guided
+[**start here** mode](https://github.com/PyAutoLabs/autofit_assistant/blob/main/modes/start_here.md):
+six steps on the bundled 1D Gaussian which you type yourself, followed by the same
+six steps on your own science. At any step you can ask a question (for example
+"what is a prior?") or say "teacher mode" to get a full explanation of everything
+as you go. The six steps are the sections of [Natural Language Inference](https://pyautofit.readthedocs.io/en/latest/overview/natural_language.html).
+
 ## Bring Your Own Likelihood
 
 Already have a likelihood function for your science problem? **Point the


### PR DESCRIPTION
## Summary
Docs-only. Links the published "start here" prompt on Quick Start and Natural Language Inference to the `autofit_assistant` guided **start here** mode (`modes/start_here.md`, shipped in PyAutoLabs/autofit_assistant#38's PR), which walks the six sections of Natural Language Inference one step at a time and then replays them on the user's own science, taking questions and "teacher mode" at every step.

Also fixes two defects on `natural_language.md` surfaced while wiring this up:
- the printed `model.info` block contradicted the prompt above it (LogUniformPrior 1e-6–1e6 and sigma 0–25, where the prompt asks uniform 0–100 / 0–100 / 0.1–30). Regenerated from a real compose step (priors constructed at model creation, so ids run 0–2; padding trimmed to the page's column width).
- the dangling editorial placeholder `[Find 1D example of a random model to the data, maybe from HowToFit]?` removed. The page still *describes* an image at that point; a real random-draw figure is a follow-up (the existing `toy_model_fit.png` is a best-fit figure, not a random draw, so it was not substituted).

## API Changes
None — `docs/overview/quick_start.md` and `docs/overview/natural_language.md` only. No prompt blockquote text changed (they are mirrored word-for-word in the assistant README).

## Test Plan
- [x] `git diff --stat` touches only the two overview pages
- [x] Sphinx HTML build: 30 warnings before and after (== `docs/sphinx_warning_baseline.txt`), none on the two pages
- [x] `model.info` block reproduced by running the compose step under the installed stack (autofit 2026.8.17.1)

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
- none

### Added
- none (documentation only)

### Migration
- none

</details>

Companion: PyAutoLabs/autofit_assistant#38 (the mode itself; library-first — this PR merges first).

Generated by the PyAutoLabs agent workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrGfrSxV9xoqCa4v1p9hix
