### PR TITLE
docs: Bring Your Own Likelihood (BYOL) headings and link to the assistant BYOL mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Begin the "start here" guide for a new user.
 [natural-language inference page](https://pyautofit.readthedocs.io/en/latest/overview/natural_language.html)
 walks through this, including its **AI First Design**.
 
-## Bring Your Own Likelihood
+## Bring Your Own Likelihood (BYOL)
 
 Already have a likelihood function for your science problem? **Point the assistant at your existing code and it can
 set it up with PyAutoFit** — defining the model, choosing priors with you, configuring a search and organising the
@@ -55,6 +55,12 @@ Do not begin inference until we have discussed the setup and I give you the go-a
 Once inference is running, explain how the results are written to disk and show me how to inspect and interpret
 them with PyAutoFit.
 ```
+
+The assistant answers this prompt with its
+[**BYOL** mode](https://github.com/PyAutoLabs/autofit_assistant/blob/main/modes/byol.md) — bring your own likelihood,
+the assistant brings the inference. It reads your code and restates what your likelihood scores, composes a model with
+priors chosen with you, wraps and validates your function unchanged, recommends a search, and runs nothing until you
+say go.
 
 Your existing science code remains the source of the likelihood. With PyAutoFit built around it, you can perform
 inference through natural language while gaining access to features such as flexible priors and model composition,

--- a/docs/overview/natural_language.md
+++ b/docs/overview/natural_language.md
@@ -92,6 +92,9 @@ For your own project, you can instead ask:
 > the same parameter values.
 :::
 
+This is the job of the assistant's [**BYOL** mode](https://github.com/PyAutoLabs/autofit_assistant/blob/main/modes/byol.md),
+which wraps your existing likelihood unchanged and validates it.
+
 :::{container} ai-first-design
 **AI First Design:** PyAutoFit gives the agent a small, testable integration task: connect named model parameters to your existing likelihood and check that its numerical outputs are unchanged. Your validated science code then becomes available to PyAutoFit's searches and result-analysis tools, without the agent having to reimplement it.
 :::

--- a/docs/overview/quick_start.md
+++ b/docs/overview/quick_start.md
@@ -38,7 +38,7 @@ six steps on your own science. At any step you can ask a question (for example
 "what is a prior?") or say "teacher mode" to get a full explanation of everything
 as you go. The six steps are the sections of [Natural Language Inference](https://pyautofit.readthedocs.io/en/latest/overview/natural_language.html).
 
-## Bring Your Own Likelihood
+## Bring Your Own Likelihood (BYOL)
 
 Already have a likelihood function for your science problem? **Point the
 assistant at your existing code and it can set it up with PyAutoFit** —
@@ -59,6 +59,13 @@ organising the results:
 > Once inference is running, explain how the results are written to disk and
 > show me how to inspect and interpret them with PyAutoFit.
 :::
+
+The assistant answers this prompt with its
+[**BYOL** mode](https://github.com/PyAutoLabs/autofit_assistant/blob/main/modes/byol.md) — bring your
+own likelihood, the assistant brings the inference. It reads your code and
+restates what your likelihood scores, composes a model with priors chosen
+with you, wraps and validates your function unchanged, recommends a search,
+and runs nothing until you say go.
 
 Your existing science code remains the source of the likelihood. With
 PyAutoFit built around it, you can perform inference through natural


### PR DESCRIPTION
## Summary
Docs-only companion to PyAutoLabs/autofit_assistant#40 (BYOL mode). The sections carrying the published Bring Your Own Likelihood prompt are retitled **Bring Your Own Likelihood (BYOL)** on `README.md` and `docs/overview/quick_start.md`, each gaining one paragraph saying the assistant answers the prompt with its BYOL mode (`modes/byol.md`) — you bring the likelihood, the assistant brings the inference — and the Natural Language page's "use my existing likelihood code" pointer names the mode. No prompt text changed (the blocks are mirrored word-for-word in the assistant README).

## API Changes
None — documentation only.

## Test Plan
- [x] `git diff --stat` touches only `README.md` and `docs/overview/*.md`
- [x] Sphinx HTML build warning count equals `docs/sphinx_warning_baseline.txt`
- [x] BYOL prompt blocks byte-identical before/after

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
- none

### Added
- none (documentation only)

### Migration
- none

</details>

Companion: PyAutoLabs/autofit_assistant#40 — library-first, this PR merges first.

Generated by the PyAutoLabs agent workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrGfrSxV9xoqCa4v1p9hix
