### PR TITLE
fix: Model.from_instance carries only constructor parameters (#1607)

### DIFF
--- a/autofit/mapper/prior_model/abstract.py
+++ b/autofit/mapper/prior_model/abstract.py
@@ -1646,6 +1646,33 @@ class AbstractPriorModel(AbstractModel):
             from .prior_model import Model
 
             try:
+                instance_dict = instance.__dict__
+            except AttributeError:
+                return instance
+
+            # Only attributes that are constructor arguments may become model
+            # arguments. Attributes an `__init__` derives from its arguments
+            # (e.g. `self.centre = (0.0, 0.0)` in a class with no `centre`
+            # parameter) are recomputed when the instance is rebuilt; passing
+            # them back to the constructor raises a TypeError, which breaks
+            # `Model.from_dict` and therefore aggregator loading of a
+            # `model.json` written from such a model (issue #1607).
+            try:
+                spec = inspect.getfullargspec(instance.__class__)
+            except TypeError:
+                # Uninspectable constructor: keep every attribute.
+                allowed_keys = None
+            else:
+                if spec.varkw is not None:
+                    # The constructor accepts **kwargs, so any attribute may
+                    # legitimately be passed back to it.
+                    allowed_keys = None
+                else:
+                    allowed_keys = {
+                        arg for arg in spec.args if arg != "self"
+                    } | set(spec.kwonlyargs)
+
+            try:
                 result = Model(
                     instance.__class__,
                     **{
@@ -1654,8 +1681,9 @@ class AbstractPriorModel(AbstractModel):
                             model_classes=model_classes,
                             exclude_classes=exclude_classes,
                         )
-                        for key, value in instance.__dict__.items()
+                        for key, value in instance_dict.items()
                         if key != "cls"
+                        and (allowed_keys is None or key in allowed_keys)
                     },
                 )
             except AttributeError:

--- a/test_autofit/aggregator/test_from_directory.py
+++ b/test_autofit/aggregator/test_from_directory.py
@@ -370,3 +370,45 @@ def test_non_linear_search_from_search_json(directory):
         output.directory.name
         for output in aggregator.query(aggregator.non_linear_search == "emcee")
     ] == ["search_output_derived"]
+
+
+class DerivedAttributeModel:
+    """
+    A class whose ``__init__`` sets an attribute that is not one of its own
+    arguments. Defined at module level so ``class_path`` resolves when the
+    aggregator reads ``model.json`` back (issue #1607).
+    """
+
+    def __init__(self, gamma_1=0.0, gamma_2=0.0):
+        self.gamma_1 = gamma_1
+        self.gamma_2 = gamma_2
+        self.centre = (0.0, 0.0)
+
+
+def test_model_written_from_instance_is_loaded(scan_directory):
+    """
+    ``model.json`` written from ``Model.from_instance`` of an object with a
+    derived attribute must load: before #1607 the derived attribute was written
+    into the arguments and the constructor rejected it on read.
+    """
+    import autofit as af
+
+    model_json = scan_directory / "search_output" / "files" / "model.json"
+    model_json.write_text(
+        json.dumps(
+            af.Model.from_instance(
+                DerivedAttributeModel(gamma_1=0.02, gamma_2=0.03)
+            ).dict()
+        )
+    )
+
+    aggregator = Aggregator.from_directory(scan_directory)
+
+    assert len(aggregator) == 1
+
+    model = list(aggregator)[0].model
+
+    assert isinstance(model, DerivedAttributeModel)
+    assert model.gamma_1 == 0.02
+    assert model.gamma_2 == 0.03
+    assert model.centre == (0.0, 0.0)

--- a/test_autofit/mapper/model/test_from_instance_roundtrip.py
+++ b/test_autofit/mapper/model/test_from_instance_roundtrip.py
@@ -1,0 +1,131 @@
+"""
+Regression tests for issue #1607.
+
+``AbstractPriorModel.from_instance`` used to copy every entry of an instance's
+``__dict__`` onto the model, including attributes an ``__init__`` derives from
+its arguments. Those attributes were then passed back to the constructor by
+``ModelObject.from_dict``, raising ``TypeError`` and breaking aggregator loading
+of any ``model.json`` written from such a model.
+
+The classes below are defined at module level so that the ``class_path`` written
+into the dictionary resolves when it is read back.
+"""
+
+import autofit as af
+
+
+class Shear:
+    """
+    A class with a derived attribute (``centre``) and a property, neither of
+    which is a constructor argument.
+    """
+
+    def __init__(self, gamma_1=0.0, gamma_2=0.0):
+        self.gamma_1 = gamma_1
+        self.gamma_2 = gamma_2
+        # Derived: recomputed by __init__, never passed to it.
+        self.centre = (0.0, 0.0)
+
+    @property
+    def magnitude(self):
+        return (self.gamma_1**2 + self.gamma_2**2) ** 0.5
+
+
+class Isothermal:
+    """
+    A tuple-valued constructor argument alongside a derived scalar.
+    """
+
+    def __init__(self, centre=(0.0, 0.0), einstein_radius=1.0):
+        self.centre = centre
+        self.einstein_radius = einstein_radius
+        self.slope = 2.0
+
+
+class WithKwargs:
+    """
+    A constructor taking ``**kwargs`` and storing them as attributes. Every
+    attribute may legitimately be passed back, so none are filtered.
+    """
+
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+class Outer:
+    """
+    An outer class holding a derived-attribute instance as an argument.
+    """
+
+    def __init__(self, shear=None, scale=1.0):
+        self.shear = shear or Shear()
+        self.scale = scale
+        self.total = scale * 2.0
+
+
+def test_derived_attributes_are_not_model_arguments():
+    model = af.Model.from_instance(Shear(gamma_1=0.02, gamma_2=0.03))
+
+    assert {name for name, _ in model.items()} == {"gamma_1", "gamma_2"}
+    assert set(model.dict()["arguments"]) == {"gamma_1", "gamma_2"}
+    assert not hasattr(model, "centre")
+    assert not hasattr(model, "magnitude")
+
+
+def test_derived_attribute_round_trip():
+    instance = af.Model.from_dict(
+        af.Model.from_instance(Shear(gamma_1=0.02, gamma_2=0.03)).dict()
+    )
+
+    assert isinstance(instance, Shear)
+    assert instance.gamma_1 == 0.02
+    assert instance.gamma_2 == 0.03
+    # Recomputed by __init__ rather than carried through the dictionary.
+    assert instance.centre == (0.0, 0.0)
+    assert instance.magnitude == (0.02**2 + 0.03**2) ** 0.5
+
+
+def test_tuple_argument_round_trip():
+    model = af.Model.from_instance(
+        Isothermal(centre=(1.0, 2.0), einstein_radius=1.5)
+    )
+
+    assert set(model.dict()["arguments"]) == {"centre", "einstein_radius"}
+
+    instance = af.Model.from_dict(model.dict())
+
+    assert isinstance(instance, Isothermal)
+    assert instance.centre == (1.0, 2.0)
+    assert instance.einstein_radius == 1.5
+    assert instance.slope == 2.0
+
+
+def test_kwargs_constructor_keeps_every_attribute():
+    model = af.Model.from_instance(WithKwargs(one=1.0, two=2.0))
+
+    assert set(model.dict()["arguments"]) == {"one", "two"}
+
+    instance = af.Model.from_dict(model.dict())
+
+    assert isinstance(instance, WithKwargs)
+    assert instance.one == 1.0
+    assert instance.two == 2.0
+
+
+def test_nested_derived_attribute_round_trip():
+    model = af.Model.from_instance(
+        Outer(shear=Shear(gamma_1=0.04, gamma_2=0.05), scale=3.0)
+    )
+
+    assert set(model.dict()["arguments"]) == {"shear", "scale"}
+
+    instance = af.Model.from_dict(model.dict())
+
+    assert isinstance(instance, Outer)
+    assert isinstance(instance.shear, Shear)
+    assert instance.shear.gamma_1 == 0.04
+    assert instance.shear.gamma_2 == 0.05
+    assert instance.shear.centre == (0.0, 0.0)
+    assert instance.scale == 3.0
+    assert instance.total == 6.0


### PR DESCRIPTION
## Summary
`AbstractPriorModel.from_instance` copied every entry of `instance.__dict__` onto the model, including attributes an `__init__` derives from its arguments (ExternalShear's `centre`, Isothermal's `slope`). `ModelObject.dict()` types a prior-free model as `instance`, and `from_dict` passed those keys back to the constructor, which raised `TypeError`, so any `model.json` written from such a model could not be loaded by `Aggregator.from_directory`.

The generic-object branch of `from_instance` now keeps only the constructor's parameters (`inspect.getfullargspec` args + kwonlyargs), the same inspection `Model.constructor_argument_names` already uses. Every attribute is still kept when the constructor takes `**kwargs` or cannot be inspected. Derived attributes are recomputed by `__init__` on rebuild, so nothing is lost.

Closes #1607.

## API Changes
None — internal changes only. `from_instance` no longer attaches non-constructor attributes to the returned `Model`; instances built from that model are unchanged because `__init__` recomputes them.

## Test Plan
- [x] `test_autofit/mapper/model/test_from_instance_roundtrip.py`: derived-attribute, tuple-argument, `**kwargs` and nested round-trips through `dict()` / `from_dict` (5 tests; 4 fail without the fix, the `**kwargs` one pins preserved behaviour)
- [x] `test_autofit/aggregator/test_from_directory.py::test_model_written_from_instance_is_loaded`: `Aggregator.from_directory` loads a `model.json` written from `from_instance` (fails without the fix)
- [x] Full suite: 2575 passed, 43 skipped, 0 failed

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- `autofit.AbstractPriorModel.from_instance(instance, ...)` — for a plain object, only attributes named in `type(instance).__init__`'s signature become model arguments; attributes derived inside `__init__` are dropped from the model (and recomputed on instantiation). Unchanged when the constructor accepts `**kwargs` or is not inspectable.

</details>

Generated by the PyAutoLabs agent workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWGZiKQo2PhvsymabkUJJm

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWGZiKQo2PhvsymabkUJJm)_